### PR TITLE
Remove macOS ARM build probe

### DIFF
--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  APPLE_CONTAINER_VERSION: 1.0.0
   CROSS_VERSION: 0.2.5
   DOCKER_DEFAULT_PLATFORM: linux/amd64
   MISTER_CROSS_IMAGE: cross-custom-rust:armv7-unknown-linux-gnueabihf-b52a5
@@ -138,101 +137,4 @@ jobs:
         with:
           name: binary-size-${{ matrix.name }}
           path: build/binary-size.tsv
-          if-no-files-found: error
-
-  macos-arm64-native-container:
-    name: macos-arm64-native-container
-    runs-on: macos-26
-    continue-on-error: true
-    timeout-minutes: 90
-    env:
-      DOCKER_DEFAULT_PLATFORM: ""
-      MISTER_APPLE_CONTAINER_TARGET_DIR: /private/tmp/mister-magik-apple-container-target
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Verify native macOS ARM runner
-        run: |
-          echo "host arch: $(uname -m)"
-          test "$(uname -m)" = "arm64"
-          if command -v cross >/dev/null 2>&1; then
-            echo "cross is present on PATH but this job will not call it"
-          fi
-          if command -v docker >/dev/null 2>&1; then
-            echo "Docker is present on PATH but this job will not call it"
-          fi
-
-      - name: Install Rust toolchain
-        working-directory: magik-gui
-        run: |
-          rustup toolchain add stable-aarch64-unknown-linux-gnu --profile minimal --force-non-host
-          rustup target add armv7-unknown-linux-gnueabihf --toolchain stable-aarch64-unknown-linux-gnu
-
-      - name: Cache cargo registry
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-apple-container-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock') }}
-          restore-keys: |
-            cargo-apple-container-${{ runner.os }}-
-
-      - name: Cache Apple-container target
-        uses: actions/cache@v4
-        with:
-          path: /private/tmp/mister-magik-apple-container-target
-          key: apple-container-target-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock', 'magik-gui/Dockerfile.cross-armv7') }}
-          restore-keys: |
-            apple-container-target-${{ runner.os }}-
-
-      - name: Install Apple container
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if command -v container >/dev/null 2>&1; then
-            container --version
-            exit 0
-          fi
-          mkdir -p /tmp/apple-container
-          gh release download "$APPLE_CONTAINER_VERSION" \
-            --repo apple/container \
-            --pattern '*.pkg' \
-            --dir /tmp/apple-container
-          ls -la /tmp/apple-container
-          pkg="$(find /tmp/apple-container -maxdepth 1 -name '*.pkg' | head -n 1)"
-          test -n "$pkg"
-          sudo installer -pkg "$pkg" -target /
-          container --version
-
-      - name: Start Apple container services
-        id: apple-container-start
-        continue-on-error: true
-        run: |
-          container system start --enable-kernel-install
-          container builder start --cpus 3 --memory 5g
-
-      - name: Report unavailable hosted virtualization
-        if: steps.apple-container-start.outcome != 'success'
-        run: |
-          {
-            echo "### Apple container native ARM probe"
-            echo
-            echo "The macos-26 arm64 runner was reached and Apple container was installed."
-            echo "The hosted runner did not expose the virtualization backend needed to start Apple container."
-            echo
-            echo 'This is an accepted non-blocking diagnostic result; the native container build will run when the runtime starts successfully, or on a self-hosted Apple Silicon runner.'
-          } >> "$GITHUB_STEP_SUMMARY"
-
-      - name: Build ARM binary with native Apple container
-        if: steps.apple-container-start.outcome == 'success'
-        run: magik-gui/build-arm64-apple-container.sh --fast
-
-      - name: Upload macOS ARM-native binary
-        if: steps.apple-container-start.outcome == 'success'
-        uses: actions/upload-artifact@v4
-        with:
-          name: mister-magik-fb-macos-arm64-native
-          path: /private/tmp/mister-magik-apple-container-target/armv7-unknown-linux-gnueabihf/release/mister-magik-fb
           if-no-files-found: error

--- a/magik-gui/BUILD.md
+++ b/magik-gui/BUILD.md
@@ -246,18 +246,6 @@ The shared-library check intentionally fails if any `libav*`, `libswscale`, or
 `libswresample` dependency appears. FFmpeg must stay statically linked from the
 project-local minimal build.
 
-CI also has a non-blocking `macos-26` Apple Silicon probe for the native ARM64
-container path:
-
-```bash
-magik-gui/build-arm64-apple-container.sh --fast
-```
-
-That job uses Apple's `container` tool with a `linux/arm64` image, a
-`stable-aarch64-unknown-linux-gnu` Rust toolchain, and no `cross` or
-`DOCKER_DEFAULT_PLATFORM=linux/amd64` path. It is deliberately non-blocking
-while hosted-runner virtualization support is proven.
-
 ## Config files
 
 - **`Cargo.toml`** — `[profile.release]` vs `[profile.release-device]` (inherits release, overrides LTO/CGU).


### PR DESCRIPTION
## Summary

- remove the non-blocking macos-26 ARM container probe from the Rust ARM workflow
- remove the BUILD.md CI note that described that macOS probe
- keep the Ubuntu ARM matrix, including the full device video release build, as the CI path that actually produces MiSTer MagiK binaries

## Validation

- bash -n magik-gui/build-arm64-apple-container.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust-arm.yml"); puts "yaml ok"'
- git diff --check
