### PR TITLE
Try Apple container ARM builds in CI

### DIFF
--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -105,6 +105,98 @@ jobs:
 
   arm-build:
     name: ${{ matrix.name }}
+    runs-on: macos-26
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: release
+            args: --device
+            profile: release-device
+            features: none
+          - name: release-video-full
+            args: --device --all-scenes --video
+            profile: release-device
+            features: video
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust host toolchain
+        working-directory: magik-gui
+        run: rustup show
+
+      - name: Install Rust Linux ARM64 toolchain
+        run: |
+          rustup toolchain add stable-aarch64-unknown-linux-gnu --profile minimal --force-non-host
+          rustup target add armv7-unknown-linux-gnueabihf --toolchain stable-aarch64-unknown-linux-gnu
+
+      - name: Install Apple container
+        run: |
+          curl -L \
+            https://github.com/apple/container/releases/download/1.0.0/container-1.0.0-installer-signed.pkg \
+            -o /tmp/container-installer-signed.pkg
+          sudo installer -pkg /tmp/container-installer-signed.pkg -target /
+          yes | container system start
+          container --version
+          sysctl kern.hv_support || true
+
+      - name: Cache cargo registry
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Cache minimal FFmpeg
+        if: matrix.features == 'video'
+        uses: actions/cache@v5
+        with:
+          path: magik-gui/target/ffmpeg-minimal/armv7
+          key: ffmpeg-minimal-${{ runner.os }}-8.1.1-${{ hashFiles('magik-gui/scripts/build-minimal-ffmpeg.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+
+      - name: Cache Apple-container ARM build outputs
+        uses: actions/cache@v5
+        with:
+          path: |
+            /private/tmp/mister-magik-apple-container-target
+            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
+          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          restore-keys: |
+            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.name }}-
+
+      - name: Build ARM binary
+        env:
+          MISTER_ARM_BUILD_BACKEND: apple-container
+        run: magik-gui/build-arm.sh ${{ matrix.args }}
+
+      - name: Check ARM shared libraries
+        run: magik-gui/scripts/check-arm-shared-libs.sh magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/mister-magik-fb
+
+      - name: Upload ARM binary
+        uses: actions/upload-artifact@v7
+        with:
+          name: mister-magik-fb-${{ matrix.name }}
+          path: magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/mister-magik-fb
+          if-no-files-found: error
+
+      - name: Upload size history
+        uses: actions/upload-artifact@v7
+        with:
+          name: binary-size-${{ matrix.name }}
+          path: build/binary-size.tsv
+          if-no-files-found: error
+
+  arm-build-cross:
+    # Disabled while the PR focuses on getting hosted Apple-container builds green.
+    if: false
+    name: cross-${{ matrix.name }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
@@ -134,8 +226,9 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: cargo-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock') }}
+          key: cargo-cross-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock') }}
           restore-keys: |
+            cargo-cross-${{ runner.os }}-
             cargo-${{ runner.os }}-
 
       - name: Cache cross binary
@@ -154,7 +247,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: magik-gui/target/ffmpeg-minimal/armv7
-          key: ffmpeg-minimal-${{ runner.os }}-8.1.1-${{ hashFiles('magik-gui/scripts/build-minimal-ffmpeg.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: ffmpeg-minimal-cross-${{ runner.os }}-8.1.1-${{ hashFiles('magik-gui/scripts/build-minimal-ffmpeg.sh', 'magik-gui/Dockerfile.cross-armv7') }}
 
       - name: Cache ARM build outputs
         uses: actions/cache@v5
@@ -162,12 +255,14 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-cross-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
-            target-arm-${{ runner.os }}-${{ matrix.name }}-
+            target-arm-cross-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-cross-${{ runner.os }}-${{ matrix.name }}-
 
       - name: Build ARM binary
+        env:
+          MISTER_ARM_BUILD_BACKEND: cross
         run: magik-gui/build-arm.sh ${{ matrix.args }}
 
       - name: Check ARM shared libraries
@@ -176,13 +271,13 @@ jobs:
       - name: Upload ARM binary
         uses: actions/upload-artifact@v7
         with:
-          name: mister-magik-fb-${{ matrix.name }}
+          name: mister-magik-fb-cross-${{ matrix.name }}
           path: magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/mister-magik-fb
           if-no-files-found: error
 
       - name: Upload size history
         uses: actions/upload-artifact@v7
         with:
-          name: binary-size-${{ matrix.name }}
+          name: binary-size-cross-${{ matrix.name }}
           path: build/binary-size.tsv
           if-no-files-found: error

--- a/magik-gui/scripts/check-arm-shared-libs.sh
+++ b/magik-gui/scripts/check-arm-shared-libs.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 BIN="${1:-$HERE/target/armv7-unknown-linux-gnueabihf/release-device/mister-magik-fb}"
 IMAGE="${MISTER_CROSS_IMAGE:-cross-custom-rust:armv7-unknown-linux-gnueabihf-b52a5}"
+APPLE_IMAGE="${MISTER_APPLE_CONTAINER_IMAGE:-mister-magik-cross-armv7:ubuntu20-arm64}"
 
 if [ ! -f "$BIN" ]; then
   echo "ERROR: binary missing: $BIN" >&2
@@ -23,31 +24,44 @@ if command -v arm-linux-gnueabihf-readelf >/dev/null 2>&1; then
       | sort -Vu
   )"
 else
-  if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
-    echo "==> building cross helper image $IMAGE"
-    docker build -t "$IMAGE" -f "$HERE/Dockerfile.cross-armv7" "$HERE"
-  fi
-
   if [[ "$BIN" != "$HERE/"* ]]; then
-    echo "ERROR: binary must be under $HERE so the Docker helper can read it" >&2
+    echo "ERROR: binary must be under $HERE so the container helper can read it" >&2
     exit 1
   fi
   REL_BIN="/project/${BIN#"$HERE/"}"
 
+  if [ "$(uname -s)" = Darwin ] && [ "$(uname -m)" = arm64 ] && command -v container >/dev/null 2>&1; then
+    if ! container image inspect "$APPLE_IMAGE" >/dev/null 2>&1; then
+      echo "==> building Apple-container helper image $APPLE_IMAGE"
+      container build --arch arm64 --file "$HERE/Dockerfile.cross-armv7" --tag "$APPLE_IMAGE" "$HERE"
+    fi
+    RUNNER=(
+      container run --arch arm64 --rm
+      --volume "$HERE:/project:ro"
+      --workdir /project
+      "$APPLE_IMAGE"
+    )
+  else
+    export DOCKER_DEFAULT_PLATFORM="${DOCKER_DEFAULT_PLATFORM:-linux/amd64}"
+    if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+      echo "==> building cross helper image $IMAGE"
+      docker build -t "$IMAGE" -f "$HERE/Dockerfile.cross-armv7" "$HERE"
+    fi
+    RUNNER=(
+      docker run --rm
+      --platform linux/amd64
+      -v "$HERE:/project:ro"
+      -w /project
+      "$IMAGE"
+    )
+  fi
+
   NEEDED="$(
-    docker run --rm \
-      --platform linux/amd64 \
-      -v "$HERE:/project:ro" \
-      -w /project \
-      "$IMAGE" \
+    "${RUNNER[@]}" \
       bash -lc "arm-linux-gnueabihf-readelf -d '$REL_BIN' | awk '/NEEDED/ { gsub(/[][]/, \"\", \$5); print \$5 }'"
   )"
   GLIBC_VERSIONS="$(
-    docker run --rm \
-      --platform linux/amd64 \
-      -v "$HERE:/project:ro" \
-      -w /project \
-      "$IMAGE" \
+    "${RUNNER[@]}" \
       bash -lc "arm-linux-gnueabihf-readelf --version-info '$REL_BIN' | grep -o 'GLIBC_[0-9.]*' | sort -Vu"
   )"
 fi


### PR DESCRIPTION
## Summary
- switch the ARM CI matrix to macos-26 and force the Apple-container backend
- install Apple container from the signed upstream 1.0.0 package in CI
- keep the previous Ubuntu/cross ARM job commented in the workflow for quick rollback
- let the shared-library checker use Apple container when Docker is not available

## Notes
This is intentionally a CI experiment PR. If hosted macOS 26 supports Apple container cleanly, the commented cross job can be removed or restored as a fallback before merge.

## Local checks
- bash -n magik-gui/scripts/check-arm-shared-libs.sh magik-gui/build-arm.sh magik-gui/build-arm64-apple-container.sh magik-gui/scripts/build-minimal-ffmpeg.sh
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust-arm.yml")'
- git diff --check
- magik-gui/scripts/check-arm-shared-libs.sh magik-gui/target/armv7-unknown-linux-gnueabihf/release-device/mister-magik-fb