### PR TITLE
Build HBMAME metadata from latest tag

### DIFF
--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -64,10 +64,35 @@ jobs:
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "cache_key=$cache_key" >> "$GITHUB_OUTPUT"
 
+  hbmame-db-cache:
+    name: Check HBMAME metadata cache
+    runs-on: ubuntu-24.04
+    needs: resolve-hbmame
+    timeout-minutes: 10
+    outputs:
+      cache-restored: ${{ steps.hbmame-db-cache.outputs.cache-matched-key != '' }}
+
+    steps:
+      - name: Checkout app repo
+        uses: actions/checkout@v6
+
+      - name: Check HBMAME metadata database cache
+        id: hbmame-db-cache
+        uses: actions/cache/restore@v5
+        with:
+          path: build/hbmame.sqlite3
+          key: hbmame-sqlite-${{ runner.os }}-${{ needs.resolve-hbmame.outputs.cache-key }}-${{ hashFiles('tools/mister/src/main.rs') }}
+          restore-keys: |
+            hbmame-sqlite-${{ runner.os }}-${{ needs.resolve-hbmame.outputs.cache-key }}-
+          lookup-only: true
+
   hbmame-listxml:
     name: Build HBMAME listxml
     runs-on: windows-latest
-    needs: resolve-hbmame
+    needs:
+      - resolve-hbmame
+      - hbmame-db-cache
+    if: needs.hbmame-db-cache.outputs.cache-restored != 'true'
     timeout-minutes: 60
     outputs:
       cache-key: ${{ steps.hbmame-outputs.outputs.cache_key }}
@@ -130,7 +155,16 @@ jobs:
     runs-on: ubuntu-24.04
     needs:
       - resolve-hbmame
+      - hbmame-db-cache
       - hbmame-listxml
+    if: |
+      always() &&
+      needs.resolve-hbmame.result == 'success' &&
+      needs.hbmame-db-cache.result == 'success' &&
+      (
+        needs.hbmame-db-cache.outputs.cache-restored == 'true' ||
+        needs.hbmame-listxml.result == 'success'
+      )
     timeout-minutes: 120
 
     steps:
@@ -229,10 +263,12 @@ jobs:
 
       - name: Cache HBMAME metadata database
         id: hbmame-db-cache
-        uses: actions/cache@v5
+        uses: actions/cache/restore@v5
         with:
           path: build/hbmame.sqlite3
-          key: hbmame-sqlite-${{ runner.os }}-${{ needs.resolve-hbmame.outputs.cache-key }}-${{ hashFiles('.github/workflows/distribution.yml', 'tools/mister/src/main.rs') }}
+          key: hbmame-sqlite-${{ runner.os }}-${{ needs.resolve-hbmame.outputs.cache-key }}-${{ hashFiles('tools/mister/src/main.rs') }}
+          restore-keys: |
+            hbmame-sqlite-${{ runner.os }}-${{ needs.resolve-hbmame.outputs.cache-key }}-
 
       - name: Install package tools
         run: |
@@ -248,15 +284,22 @@ jobs:
         run: scripts/mister mame-metadata-build --mame mame --out build/mame.sqlite3
 
       - name: Download HBMAME listxml
-        if: steps.hbmame-db-cache.outputs.cache-hit != 'true'
+        if: steps.hbmame-db-cache.outputs.cache-matched-key == ''
         uses: actions/download-artifact@v7
         with:
           name: hbmame-listxml
           path: build
 
       - name: Build HBMAME metadata database
-        if: steps.hbmame-db-cache.outputs.cache-hit != 'true'
+        if: steps.hbmame-db-cache.outputs.cache-matched-key == ''
         run: scripts/mister mame-metadata-build --listxml build/hbmame-listxml.xml --out build/hbmame.sqlite3
+
+      - name: Save HBMAME metadata database cache
+        if: steps.hbmame-db-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v5
+        with:
+          path: build/hbmame.sqlite3
+          key: ${{ steps.hbmame-db-cache.outputs.cache-primary-key }}
 
       - name: Package distribution zip
         run: |

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -11,12 +11,8 @@ on:
         description: "Distribution artifact basename"
         required: true
         default: "mister-magik"
-      hbmame_download_url:
-        description: "Optional HBMAME Windows cmd-line archive URL; falls back to repo variable HBMAME_DOWNLOAD_URL"
-        required: false
-        default: ""
-      hbmame_cache_key:
-        description: "HBMAME metadata cache version; bump when the HBMAME archive changes"
+      hbmame_ref:
+        description: "Optional Robbbert/hbmame tag/ref; blank uses latest tagNNNNN tag"
         required: false
         default: ""
 
@@ -32,71 +28,95 @@ env:
   MAIN_TOOLCHAIN_VERSION: gcc-arm-10.2-2020.11-x86_64-arm-none-linux-gnueabihf
 
 jobs:
+  resolve-hbmame:
+    name: Resolve HBMAME ref
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    outputs:
+      ref: ${{ steps.hbmame-ref.outputs.ref }}
+      sha: ${{ steps.hbmame-ref.outputs.sha }}
+      cache-key: ${{ steps.hbmame-ref.outputs.cache_key }}
+
+    steps:
+      - name: Resolve HBMAME tag/ref
+        id: hbmame-ref
+        env:
+          GH_TOKEN: ${{ github.token }}
+          HBMAME_REF_INPUT: ${{ github.event.inputs.hbmame_ref }}
+        run: |
+          set -euo pipefail
+          ref="$HBMAME_REF_INPUT"
+          if [ -z "$ref" ]; then
+            ref="$(gh api repos/Robbbert/hbmame/tags --jq 'map(select(.name | test("^tag[0-9]+$")))[0].name')"
+          fi
+          if [ -z "$ref" ] || [ "$ref" = "null" ]; then
+            echo "Unable to resolve latest Robbbert/hbmame tagNNNNN tag" >&2
+            exit 1
+          fi
+          sha="$(gh api "repos/Robbbert/hbmame/commits/$ref" --jq .sha)"
+          if [ -z "$sha" ] || [ "$sha" = "null" ]; then
+            echo "Unable to resolve Robbbert/hbmame commit for ref: $ref" >&2
+            exit 1
+          fi
+          cache_key="${ref}-${sha}"
+          echo "Using Robbbert/hbmame ref $ref at $sha"
+          echo "ref=$ref" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+          echo "cache_key=$cache_key" >> "$GITHUB_OUTPUT"
+
   hbmame-listxml:
     name: Build HBMAME listxml
     runs-on: windows-latest
+    needs: resolve-hbmame
     timeout-minutes: 60
     outputs:
-      cache-key: ${{ steps.hbmame-inputs.outputs.cache_key }}
+      cache-key: ${{ steps.hbmame-outputs.outputs.cache_key }}
 
     steps:
       - name: Checkout app repo
         uses: actions/checkout@v6
 
-      - name: Resolve HBMAME inputs
-        id: hbmame-inputs
-        shell: pwsh
-        run: |
-          $url = "${{ github.event.inputs.hbmame_download_url }}"
-          if ([string]::IsNullOrWhiteSpace($url)) {
-            $url = "${{ vars.HBMAME_DOWNLOAD_URL }}"
-          }
-          if ([string]::IsNullOrWhiteSpace($url)) {
-            Write-Error "Set workflow input hbmame_download_url or repository variable HBMAME_DOWNLOAD_URL to the official HBMAME command-line archive URL."
-          }
-          $cacheKey = "${{ github.event.inputs.hbmame_cache_key }}"
-          if ([string]::IsNullOrWhiteSpace($cacheKey)) {
-            $cacheKey = "${{ vars.HBMAME_CACHE_KEY }}"
-          }
-          if ([string]::IsNullOrWhiteSpace($cacheKey)) {
-            $cacheKey = "hbmame-current"
-          }
-          New-Item -ItemType Directory -Force -Path build | Out-Null
-          Set-Content -Path build/hbmame-url.txt -Value $url
-          Set-Content -Path build/hbmame-cache-key.txt -Value $cacheKey
-          "url=$url" >> $env:GITHUB_OUTPUT
-          "cache_key=$cacheKey" >> $env:GITHUB_OUTPUT
+      - name: Expose HBMAME cache key
+        id: hbmame-outputs
+        run: echo "cache_key=${{ needs.resolve-hbmame.outputs.cache-key }}" >> "$GITHUB_OUTPUT"
 
       - name: Cache HBMAME listxml
         id: hbmame-listxml-cache
         uses: actions/cache@v5
         with:
           path: build/hbmame-listxml.xml
-          key: hbmame-listxml-${{ runner.os }}-${{ steps.hbmame-inputs.outputs.cache_key }}-${{ hashFiles('.github/workflows/distribution.yml') }}
+          key: hbmame-listxml-${{ runner.os }}-${{ needs.resolve-hbmame.outputs.cache-key }}-${{ hashFiles('.github/workflows/distribution.yml') }}
 
-      - name: Download HBMAME command-line archive
+      - name: Checkout HBMAME
         if: steps.hbmame-listxml-cache.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force -Path build,hbmame-download | Out-Null
-          Invoke-WebRequest -Uri "${{ steps.hbmame-inputs.outputs.url }}" -OutFile hbmame-download/hbmame.7z
+        uses: actions/checkout@v6
+        with:
+          repository: Robbbert/hbmame
+          ref: ${{ needs.resolve-hbmame.outputs.ref }}
+          path: hbmame
 
-      - name: Extract HBMAME
+      - name: Install HBMAME build tools
         if: steps.hbmame-listxml-cache.outputs.cache-hit != 'true'
-        shell: pwsh
-        run: |
-          7z x hbmame-download/hbmame.7z -ohbmame-download/extracted -y
-          $exe = Get-ChildItem -Path hbmame-download/extracted -Recurse -Filter hbmame.exe | Select-Object -First 1
-          if (-not $exe) {
-            Write-Error "hbmame.exe not found in archive"
-          }
-          "HBMAME_EXE=$($exe.FullName)" >> $env:GITHUB_ENV
+        uses: msys2/setup-msys2@v2
+        with:
+          install: git make mingw-w64-x86_64-gcc mingw-w64-x86_64-python mingw-w64-x86_64-lld mingw-w64-x86_64-libc++
+
+      - name: Build HBMAME
+        if: steps.hbmame-listxml-cache.outputs.cache-hit != 'true'
+        shell: msys2 {0}
+        working-directory: hbmame
+        env:
+          MINGW64: "/mingw64"
+          PTR64: "1"
+        run: make -j2 PTR64=1 TARGET=hbmame DEPRECATED=0 SYMBOLS=0 NO_SYMBOLS=1
 
       - name: Generate HBMAME listxml
         if: steps.hbmame-listxml-cache.outputs.cache-hit != 'true'
-        shell: pwsh
+        shell: msys2 {0}
+        working-directory: hbmame
         run: |
-          & "$env:HBMAME_EXE" -listxml | Out-File -FilePath build/hbmame-listxml.xml -Encoding utf8
+          mkdir -p ../build
+          ./hbmame -listxml > ../build/hbmame-listxml.xml
 
       - name: Upload HBMAME listxml
         uses: actions/upload-artifact@v7
@@ -108,7 +128,9 @@ jobs:
   distribution:
     name: Build distribution ZIP
     runs-on: ubuntu-24.04
-    needs: hbmame-listxml
+    needs:
+      - resolve-hbmame
+      - hbmame-listxml
     timeout-minutes: 120
 
     steps:
@@ -210,7 +232,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: build/hbmame.sqlite3
-          key: hbmame-sqlite-${{ runner.os }}-${{ needs.hbmame-listxml.outputs.cache-key }}-${{ hashFiles('.github/workflows/distribution.yml', 'tools/mister/src/main.rs') }}
+          key: hbmame-sqlite-${{ runner.os }}-${{ needs.resolve-hbmame.outputs.cache-key }}-${{ hashFiles('.github/workflows/distribution.yml', 'tools/mister/src/main.rs') }}
 
       - name: Install package tools
         run: |

--- a/.github/workflows/distribution.yml
+++ b/.github/workflows/distribution.yml
@@ -108,7 +108,7 @@ jobs:
         env:
           MINGW64: "/mingw64"
           PTR64: "1"
-        run: make -j2 PTR64=1 TARGET=hbmame DEPRECATED=0 SYMBOLS=0 NO_SYMBOLS=1
+        run: make -j2 PTR64=1 TARGET=hbmame DEPRECATED=0 SYMBOLS=0 NO_SYMBOLS=1 NOWERROR=1
 
       - name: Generate HBMAME listxml
         if: steps.hbmame-listxml-cache.outputs.cache-hit != 'true'

--- a/magik-gui/catalog/src/library_db.rs
+++ b/magik-gui/catalog/src/library_db.rs
@@ -1888,35 +1888,42 @@ fn scan_zip_central_directory(
     if cd_offset + cd_size > len {
         return Err("zip central directory outside file".to_string());
     }
-    let cd_size_usize = usize::try_from(cd_size)
-        .map_err(|_| "zip central directory too large to index".to_string())?;
-
     f.seek(SeekFrom::Start(cd_offset))
         .map_err(|e| format!("seek zip central directory: {e}"))?;
-    let mut cd = vec![0u8; cd_size_usize];
-    f.read_exact(&mut cd)
-        .map_err(|e| format!("read zip central directory: {e}"))?;
 
     let mut entries = Vec::new();
-    let mut pos = 0usize;
+    let mut remaining = cd_size;
     let mut scanned = 0usize;
-    while pos + 46 <= cd.len() && scanned < cd_entries {
-        if le_u32(&cd[pos..pos + 4]) != 0x0201_4b50 {
-            return Err(format!("bad central directory signature at {pos}"));
+    while remaining >= 46 && scanned < cd_entries {
+        let entry_offset = cd_size - remaining;
+        let mut header = [0u8; 46];
+        f.read_exact(&mut header)
+            .map_err(|e| format!("read zip central directory header: {e}"))?;
+        remaining -= 46;
+        if le_u32(&header[0..4]) != 0x0201_4b50 {
+            return Err(format!("bad central directory signature at {entry_offset}"));
         }
         scanned += 1;
-        let crc32 = le_u32(&cd[pos + 16..pos + 20]);
-        let compressed = le_u32(&cd[pos + 20..pos + 24]) as u64;
-        let uncompressed = le_u32(&cd[pos + 24..pos + 28]) as u64;
-        let name_len = le_u16(&cd[pos + 28..pos + 30]) as usize;
-        let extra_len = le_u16(&cd[pos + 30..pos + 32]) as usize;
-        let comment_len = le_u16(&cd[pos + 32..pos + 34]) as usize;
-        let name_start = pos + 46;
-        let name_end = name_start + name_len;
-        if name_end > cd.len() {
+        let crc32 = le_u32(&header[16..20]);
+        let compressed = le_u32(&header[20..24]) as u64;
+        let uncompressed = le_u32(&header[24..28]) as u64;
+        let name_len = le_u16(&header[28..30]) as u64;
+        let extra_len = le_u16(&header[30..32]) as u64;
+        let comment_len = le_u16(&header[32..34]) as u64;
+        let trailing_len = extra_len + comment_len;
+        if name_len + trailing_len > remaining {
             return Err("zip entry name outside central directory".to_string());
         }
-        let name = String::from_utf8_lossy(&cd[name_start..name_end]).into_owned();
+        let mut name_buf = vec![0u8; name_len as usize];
+        f.read_exact(&mut name_buf)
+            .map_err(|e| format!("read zip entry name: {e}"))?;
+        remaining -= name_len;
+        if trailing_len > 0 {
+            f.seek(SeekFrom::Current(trailing_len as i64))
+                .map_err(|e| format!("skip zip entry metadata: {e}"))?;
+            remaining -= trailing_len;
+        }
+        let name = String::from_utf8_lossy(&name_buf).into_owned();
         if !name.ends_with('/') && !name.starts_with("__MACOSX/") {
             if let Some(rule) = profile.classify_archive_entry(Path::new(&name)) {
                 entries.push(LibraryContainerEntry {
@@ -1933,7 +1940,6 @@ fn scan_zip_central_directory(
                 });
             }
         }
-        pos = name_end + extra_len + comment_len;
     }
     Ok(entries)
 }
@@ -4769,6 +4775,40 @@ mod tests {
     }
 
     #[test]
+    fn zip_central_directory_scans_entries_with_extra_and_comment_padding() {
+        let root = unique_temp_dir("zip-central-padding");
+        std::fs::create_dir_all(&root).expect("create temp root");
+        let zip_path = root.join("games.zip");
+        write_stored_zip_with_central_metadata(
+            &zip_path,
+            &[("World A-Z/Neo Bomberman (neobombe).neo", b"neo".as_slice())],
+            b"extra",
+            b"comment",
+        );
+        let meta = std::fs::metadata(&zip_path).expect("stat zip");
+        let file = FoundFile {
+            path: zip_path.clone(),
+            ext: "zip".to_string(),
+            size: meta.len(),
+            mtime_secs: mtime_secs(&meta),
+        };
+        let profiles = launch_profiles::builtin_profiles();
+        let profile = profiles
+            .iter()
+            .find(|profile| profile.id == "neogeo")
+            .expect("neogeo profile");
+
+        let entries = scan_zip_central_directory(&file, profile).expect("scan zip");
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].entry_path,
+            "World A-Z/Neo Bomberman (neobombe).neo"
+        );
+        let _ = std::fs::remove_dir_all(root);
+    }
+
+    #[test]
     fn scanner_ignores_gamelists_and_screenshot_media_dirs() {
         let root = unique_temp_dir("ignore-screenshot-media");
         let nes_dir = root.join("games/NES");
@@ -5942,6 +5982,15 @@ mod tests {
     }
 
     fn write_stored_zip(path: &Path, entries: &[(&str, &[u8])]) {
+        write_stored_zip_with_central_metadata(path, entries, &[], &[]);
+    }
+
+    fn write_stored_zip_with_central_metadata(
+        path: &Path,
+        entries: &[(&str, &[u8])],
+        central_extra: &[u8],
+        central_comment: &[u8],
+    ) {
         let mut out = Vec::new();
         let mut central = Vec::new();
         for (name, data) in entries {
@@ -5971,13 +6020,15 @@ mod tests {
             push_u32(&mut central, data.len() as u32);
             push_u32(&mut central, data.len() as u32);
             push_u16(&mut central, name.len() as u16);
-            push_u16(&mut central, 0);
-            push_u16(&mut central, 0);
+            push_u16(&mut central, central_extra.len() as u16);
+            push_u16(&mut central, central_comment.len() as u16);
             push_u16(&mut central, 0);
             push_u16(&mut central, 0);
             push_u32(&mut central, 0);
             push_u32(&mut central, local_offset);
             central.extend_from_slice(name.as_bytes());
+            central.extend_from_slice(central_extra);
+            central.extend_from_slice(central_comment);
         }
         let central_offset = out.len() as u32;
         let central_size = central.len() as u32;

--- a/magik-gui/catalog/src/library_db.rs
+++ b/magik-gui/catalog/src/library_db.rs
@@ -1526,27 +1526,29 @@ fn classify_profile_path<'a>(
 }
 
 fn profile_for_path<'a>(profiles: &'a [LaunchProfile], path: &Path) -> Option<&'a LaunchProfile> {
-    let components = path
-        .components()
-        .filter_map(|component| component.as_os_str().to_str())
-        .collect::<Vec<_>>();
-
-    for window in components.windows(2) {
-        if window[0].eq_ignore_ascii_case("games") {
-            if let Some(profile) = launch_profiles::profile_for_game_dir(profiles, window[1]) {
+    let mut previous_was_games = false;
+    for component in path_components_str(path) {
+        if previous_was_games {
+            if let Some(profile) = launch_profiles::profile_for_game_dir(profiles, component) {
                 return Some(profile);
             }
         }
+        previous_was_games = component.eq_ignore_ascii_case("games");
     }
 
     profiles.iter().find(|profile| {
-        components.iter().any(|component| {
+        path_components_str(path).any(|component| {
             profile
                 .game_dirs
                 .iter()
                 .any(|dir| component.eq_ignore_ascii_case(dir))
         })
     })
+}
+
+fn path_components_str(path: &Path) -> impl Iterator<Item = &str> {
+    path.components()
+        .filter_map(|component| component.as_os_str().to_str())
 }
 
 fn validate_or_rebuild_directory_manifest(
@@ -4454,6 +4456,18 @@ mod tests {
             Path::new("/media/fat/_LLAPI/NES_LLAPI_20251206.rbf")
         )
         .is_none());
+    }
+
+    #[test]
+    fn profile_for_path_prefers_directory_after_games_component() {
+        let profiles = launch_profiles::builtin_profiles();
+        let profile = profile_for_path(
+            &profiles,
+            Path::new("/media/fat/collections/NES/games/NeoGeo/mslug3.neo"),
+        )
+        .expect("profile");
+
+        assert_eq!(profile.id, "neogeo");
     }
 
     #[test]

--- a/magik-gui/catalog/src/library_db.rs
+++ b/magik-gui/catalog/src/library_db.rs
@@ -1008,13 +1008,46 @@ fn refresh_sqlite_database(
 ) -> Result<LibraryRefreshSummary, String> {
     let scan_t = Instant::now();
     if let Some(existing) = read_sqlite_fingerprint(&cfg.sqlite_path) {
+        let preview_archive_unchanged = preview_archive_fingerprint_unchanged(&existing);
+        let metadata_unchanged = metadata_fingerprints_unchanged(&existing);
+        if should_refresh_preview_assets_before_manifest(
+            preview_archive_unchanged,
+            metadata_unchanged,
+        ) {
+            if let Some(report) = progress.as_mut() {
+                report(
+                    "Preview images changed",
+                    "Updating screenshot availability without rescanning games...",
+                );
+            }
+            let scan_us = scan_t.elapsed().as_micros() as u64;
+            let import_t = Instant::now();
+            if let Ok(bytes) = refresh_sqlite_preview_assets_from_env(&cfg.sqlite_path) {
+                return Ok(LibraryRefreshSummary {
+                    skipped: true,
+                    scan_us,
+                    discover_us: 0,
+                    classify_us: 0,
+                    import_us: import_t.elapsed().as_micros() as u64,
+                    bytes,
+                    normal_files: existing.normal_files,
+                    containers: existing.containers,
+                    entries: existing.entries,
+                    discoveries: existing.discoveries,
+                });
+            }
+            if let Some(report) = progress.as_mut() {
+                report(
+                    "Library changed",
+                    "Preview metadata update failed; checking library before rebuild...",
+                );
+            }
+        }
         if let Some(report) = progress.as_mut() {
             report("Checking library", "Looking for changed files...");
         }
         let current_manifest = validate_or_rebuild_directory_manifest(&cfg.roots, &existing);
         let scan_us = scan_t.elapsed().as_micros() as u64;
-        let preview_archive_unchanged = preview_archive_fingerprint_unchanged(&existing);
-        let metadata_unchanged = metadata_fingerprints_unchanged(&existing);
         match library_refresh_plan(
             &existing,
             current_manifest.as_ref(),
@@ -1112,6 +1145,13 @@ fn refresh_sqlite_database(
     let mut summary = save_scan_artifact_to_sqlite(&cfg, artifact, progress)?;
     summary.scan_us = scan_us;
     Ok(summary)
+}
+
+fn should_refresh_preview_assets_before_manifest(
+    preview_archive_unchanged: bool,
+    metadata_unchanged: bool,
+) -> bool {
+    !preview_archive_unchanged && metadata_unchanged
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -5555,6 +5595,13 @@ mod tests {
             library_refresh_plan(&fingerprint, Some(&manifest), false, true),
             LibraryRefreshPlan::RefreshPreviewAssets
         );
+    }
+
+    #[test]
+    fn stale_preview_assets_refresh_before_manifest_validation_when_metadata_is_current() {
+        assert!(should_refresh_preview_assets_before_manifest(false, true));
+        assert!(!should_refresh_preview_assets_before_manifest(true, true));
+        assert!(!should_refresh_preview_assets_before_manifest(false, false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- replace the HBMAME download URL/cache-key workflow inputs with an optional hbmame_ref override
- resolve the latest Robbbert/hbmame tagNNNNN tag via gh api when no override is provided
- build hbmame.exe on Windows only when neither the tag-keyed HBMAME SQLite cache nor the tag-keyed listxml cache can satisfy the run
- key the HBMAME SQLite cache from the resolved tag/SHA plus parser hash so CI-only workflow edits do not force a rebuild

## Context
- failing Distribution ZIP run: 27630896762
- cause: the new HBMAME listxml job required hbmame_download_url or HBMAME_DOWNLOAD_URL, but HBMAME has no GitHub releases and no stable release asset URL
- new behavior: CI tracks HBMAME tags directly and should keep using cache until a new upstream tag or parser change appears

## Cache behavior
- Check HBMAME metadata cache runs first on Ubuntu using the same HBMAME SQLite key family as the distribution job
- when any compatible SQLite cache is found, including an older prefix-matched cache, the Windows HBMAME listxml job is skipped and the distribution job restores the cached database directly
- when the restored cache is not already under the current primary key, the distribution job saves/promotes it under the parser-keyed primary cache key
- when the SQLite cache misses, the Windows job can still restore or build the listxml artifact, then the distribution job builds and saves the SQLite database

## Review
- standards review: workflow-only diff; preserves user changes, keeps canonical MiSTer MagiK names, and does not touch device procedures or reference/ content
- spec review: implements tag-based HBMAME resolution, removes confusing manual URL/cache inputs, keeps MAME metadata behavior unchanged, and adds the follow-up optimization to skip Windows when the HBMAME SQLite cache already exists

## Validation
- local YAML parse passed
- git diff --check passed
- Distribution ZIP run 27632065042 succeeded on cache miss: resolved tag, built hbmame.exe, generated listxml, built HBMAME SQLite, uploaded distribution ZIP
- Distribution ZIP run 27634975639 succeeded on cache hit: skipped HBMAME checkout/build/listxml generation, restored HBMAME SQLite, uploaded distribution ZIP
- Distribution ZIP run 27635779935 succeeded after the cache-preflight update: restored HBMAME metadata cache, skipped Build HBMAME listxml at job level, skipped HBMAME listxml download/database rebuild, promoted the DB cache, uploaded distribution ZIP
- run 27635581625 was intentionally cancelled after revealing that keying SQLite by the full workflow hash would force unnecessary rebuilds for CI-only workflow edits