### PR TITLE
Add screenshot pack index fast lane

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "private/magik-cloud"]
+	path = private/magik-cloud
+	url = git@github.com:NigelBreslaw/magik-cloud.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ Benchmark entrypoints:
 ```bash
 scripts/profile-arcade-scroll.sh LABEL
 scripts/profile-preview-scroll.sh LABEL
+scripts/profile-first-preview.sh LABEL --skip-build
 scripts/gate-preview-60fps.sh LABEL --skip-build --visual-captures 0
 scripts/bench-toolchain.sh LABEL --replace-label
 scripts/profile-first-scan.sh LABEL --deploy-device --replace-label

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ default. Override with `MISTER_MAIN_DIR`.
 - `magik-gui/BUILD.md` - ARM build profiles, FFmpeg, size, CI, toolchain notes.
 - `tools/mister/` - Rust host-side MiSTer SSH/status/cache tooling.
 - `scripts/` - approved build, deploy, profiling, and device wrappers.
+- `private/magik-cloud/` - private submodule for screenshot source data,
+  raw565 cache generation, `.mmlz4b` pack building, and Cloudflare R2 publish
+  tooling. Source is private; the public repo tracks only the gitlink.
 - `docs/architecture.md` - current architecture and handoff model.
 - `docs/catalog.md` - catalog lifecycle, stamp validation, build/publish model,
   and benchmark gates.
@@ -71,6 +74,16 @@ default. Override with `MISTER_MAIN_DIR`.
   `MISTER_ARM_BUILD_BACKEND=cross` is explicitly requested for a comparison.
 - Edit `MiSTer.ini` only through `scripts/mister` mutators or the provided
   install/restore scripts. Do not use ad hoc sed/awk/manual rewrites.
+- Use `scripts/magik-cloud path` or `scripts/magik-cloud run -- ...` for
+  magik-cloud commands. It resolves `MAGIK_CLOUD_DIR`, then the private
+  `private/magik-cloud` submodule, then legacy `../magik-cloud`.
+- Treat `private/magik-cloud` as its own private git repo. If you edit files
+  there, commit and push inside the submodule first, then stage the parent
+  submodule gitlink. Do not leave the parent pointing at an unpublished private
+  commit.
+- Never stage private source screenshots, generated caches, snapshot archives,
+  `.env`, `.wrangler/`, or Cloudflare credentials. The parent repo should see
+  only the submodule gitlink, not private file contents.
 - Treat `reference/` as read-only. Do not commit changes there.
 - Preserve user changes. Do not reset, checkout, or clean unrelated work.
 
@@ -147,8 +160,9 @@ Effect-scene and mega-transition work is experimental only; see
   contract is RGB565-only; do not reintroduce wider-color env overrides, smoke
   commands, or framebuffer color-route A/B paths.
 - Do not rebuild or write preview caches on the MiSTer hot path. Build source
-  screenshots, raw565 caches, and snapshot packs from the sibling
-  `../magik-cloud` repo.
+  screenshots, raw565 caches, and snapshot packs from the private
+  `private/magik-cloud` submodule. Use `scripts/magik-cloud path` to resolve
+  `MAGIK_CLOUD_DIR`, the submodule, or the legacy `../magik-cloud` checkout.
 - The library scanner must not walk screenshot/cache media directories, read
   `gamelist.xml`, or classify helper payloads as games.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,8 +159,10 @@ Current rules:
   them to `mame.sqlite3` with `scripts/mister mame-metadata-build`; the runtime
   scanner consumes the SQLite rows, not those XML files.
 - Runtime preview loading is raw565-oriented. Build source screenshots, raw565
-  caches, and fixed LZ4-block `.mmlz4b` preview packs from the sibling
-  `../magik-cloud` repo. Runtime deploy does not build catalog/media artifacts.
+  caches, and fixed LZ4-block `.mmlz4b` preview packs from the private
+  `private/magik-cloud` submodule. Runtime deploy does not build catalog/media
+  artifacts. Use `scripts/magik-cloud path` when a command needs to resolve the
+  checkout.
 
 Relevant docs:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,10 +159,11 @@ Current rules:
   them to `mame.sqlite3` with `scripts/mister mame-metadata-build`; the runtime
   scanner consumes the SQLite rows, not those XML files.
 - Runtime preview loading is raw565-oriented. Build source screenshots, raw565
-  caches, and fixed LZ4-block `.mmlz4b` preview packs from the private
-  `private/magik-cloud` submodule. Runtime deploy does not build catalog/media
-  artifacts. Use `scripts/magik-cloud path` when a command needs to resolve the
-  checkout.
+  caches, fixed LZ4-block `.mmlz4b` preview packs, and `.mmlz4b.idx` seek
+  sidecars from the private `private/magik-cloud` submodule. The sidecar is a
+  first-preview latency optimization; the whole pack remains the correctness
+  fallback. Runtime deploy does not build catalog/media artifacts. Use
+  `scripts/magik-cloud path` when a command needs to resolve the checkout.
 
 Relevant docs:
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -148,12 +148,12 @@ Generated MagiK screenshot packs live under:
 
 Only generated cache directories should be deleted/recreated. Runtime preview
 loading is raw565-oriented; build caches and publish-ready packs from the Mac in
-the sibling `../magik-cloud` repo with:
+the private `private/magik-cloud` submodule with:
 
 ```bash
-scripts/build-arcade-screenshot-pack.sh
-scripts/build-neogeo-screenshot-pack.sh
-scripts/build-console-screenshot-pack.sh --system saturn --input data/sources/saturn/canonical
+scripts/magik-cloud run -- scripts/build-arcade-screenshot-pack.sh
+scripts/magik-cloud run -- scripts/build-neogeo-screenshot-pack.sh
+scripts/magik-cloud run -- scripts/build-console-screenshot-pack.sh --system saturn --input data/sources/saturn/canonical
 ```
 
 `magik-cloud` writes resized PNGs, `.rgb565` files, and compressed LZ4 block

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -173,6 +173,8 @@ archive. When a matching `.mmlz4b.idx` sidecar is present and the archive is not
 yet in RAM, selected and prefetch preview requests may use `index_pread` to
 seek directly to one compressed entry, then trigger background full-pack loading.
 Once the full pack is loaded, steady-state requests return to `archive_mem`.
+Invalid index data is ignored for correctness and reported as a fast-lane miss
+before falling back to the full archive loader.
 There is no runtime fallback to PNG/JPG sources or individual `.rgb565` files.
 The arcade pack measured on the MiSTer at 34,623,433 bytes takes multiple
 seconds to cold-read from `/media/fat` into RAM, so first-preview claims must

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -42,6 +42,7 @@ Use these entrypoints:
 ```bash
 scripts/profile-arcade-scroll.sh LABEL
 scripts/profile-preview-scroll.sh LABEL
+scripts/profile-first-preview.sh LABEL --skip-build
 ```
 
 For the "perfect 60fps Arcade preview" work, each single-commit PR must record
@@ -60,10 +61,12 @@ window so the profiler can flush, and pulls
 `build/preview-scroll-profiles/LABEL-CPU-FADE-VEL-arcade-cpu.svg`.
 
 Preview-scroll benchmarks synchronously warm the screenshot archive cache before
-the benchmark timing window and first launcher step. Production preview evidence
-uses the built-in 200ms fade; transition selection flags were removed from the
-release benchmark script. `mega` transition coverage is experimental only and is
-not release benchmark evidence.
+the benchmark timing window and first launcher step unless
+`--skip-preview-warm` is passed. Use warm runs for steady 60fps preview evidence
+and cold no-warm runs for screenshot-pack index fast-lane work. Production
+preview evidence uses the built-in 200ms fade; transition selection flags were
+removed from the release benchmark script. `mega` transition coverage is
+experimental only and is not release benchmark evidence.
 `turbo-hold` ping-pongs between the Arcade list edges so long traces keep
 exercising preview selection changes after reaching the bottom.
 
@@ -104,8 +107,9 @@ These scripts write `/media/fat/mister-magik/launcher.env`, send
 ```text
 MISTER_LAUNCHER_START_SCREEN=arcade
 MISTER_LAUNCHER_LOCK_SCREEN=arcade
-MISTER_LAUNCHER_BENCH_SCENARIO=held-scroll|turbo-hold|preview-step-hold|idle
+MISTER_LAUNCHER_BENCH_SCENARIO=held-scroll|turbo-hold|preview-step-hold|preview-idle|idle
 MISTER_PREVIEW_SCROLL_TRACE_SECS=N
+MISTER_PREVIEW_SCROLL_SKIP_ARCHIVE_WARM=1  # only for cold fast-lane benchmarks
 MISTER_CATALOG_REFRESH=default
 ```
 
@@ -124,6 +128,9 @@ Preview transition policy:
 - Add new transition experiments under `scripts/experiments/preview/` and
   experiment builds rather than replacing the production `fade` effect.
 - For visual review, use `MISTER_LAUNCHER_BENCH_SCENARIO=preview-step-hold`.
+- For first selected screenshot latency, use `scripts/profile-first-preview.sh`;
+  it runs `preview-idle` so the initial selected result can apply without being
+  superseded by a scroll step.
 
 Historical evidence:
 
@@ -162,10 +169,14 @@ archive path and asset key projected by the catalog; it must not derive cache
 paths from PNG/JPG screenshot locations.
 
 The preview loader reads each configured archive into memory when it opens the
-archive. There is no runtime fallback to PNG/JPG sources, individual `.rgb565`
-files, or per-entry archive file reads. The arcade pack measured on the MiSTer
-at 34,623,433 bytes takes about 1.75s to cold-read from `/media/fat` into RAM
-and about 0.24s once the filesystem cache is warm.
+archive. When a matching `.mmlz4b.idx` sidecar is present and the archive is not
+yet in RAM, selected and prefetch preview requests may use `index_pread` to
+seek directly to one compressed entry, then trigger background full-pack loading.
+Once the full pack is loaded, steady-state requests return to `archive_mem`.
+There is no runtime fallback to PNG/JPG sources or individual `.rgb565` files.
+The arcade pack measured on the MiSTer at 34,623,433 bytes takes multiple
+seconds to cold-read from `/media/fat` into RAM, so first-preview claims must
+state whether `load_source` was `index_pread` or `archive_mem`.
 
 The library scanner must not walk screenshot/cache media directories, read
 `gamelist.xml`, or probe normal PNG/JPG screenshots for metadata.
@@ -216,6 +227,18 @@ trace while media requests are pending. Use `frame_pacing` p95/p99 work,
 `work_gt_16_7ms`, `preview_latency selected_*_age_us`, and RSS HWM from the log
 or status rows. Do not use "still 60fps" as proof; the app can remain vsync
 paced while losing CPU or SD-card headroom.
+
+For screenshot-pack index work, run both:
+
+```bash
+scripts/profile-first-preview.sh FIRST-IDX-YYYYMMDD --skip-build
+scripts/profile-preview-scroll.sh 30 held-scroll SCROLL-IDX-YYYYMMDD --skip-build --skip-preview-warm --visual-captures 0
+```
+
+Acceptance evidence should show the first selected decode using
+`load_source=index_pread` in the sub-250ms target range, scrolling previews
+visible before the full pack load completes, and later steady-state preview
+decodes returning to `archive_mem`.
 
 Relevant docs:
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -248,7 +248,8 @@ individual AmigaVision titles. The archive itself is not a direct launch ref.
 ## Preview And Metadata Artifacts
 
 Screenshot packs are fixed runtime artifacts, not catalog inputs. The runtime
-loads LZ4-block `.mmlz4b` packs from `/media/fat/mister-magik/assets`; the
+loads LZ4-block `.mmlz4b` packs from `/media/fat/mister-magik/assets`; matching
+`.mmlz4b.idx` sidecars are optional seek indexes for first-preview latency. The
 catalog stores only the pack path and asset key needed to request a preview.
 Raw preview archive formats and ad hoc on-device pack generation are retired.
 Build and publish packs from the private `private/magik-cloud` submodule; this
@@ -267,8 +268,11 @@ Runtime downloads save new packs with the image size in the filename:
 
 ```text
 /media/fat/mister-magik/assets/arcade-screenshots-320x320.mmlz4b
+/media/fat/mister-magik/assets/arcade-screenshots-320x320.mmlz4b.idx
 /media/fat/mister-magik/assets/neogeo-screenshots-320x320.mmlz4b
+/media/fat/mister-magik/assets/neogeo-screenshots-320x320.mmlz4b.idx
 /media/fat/mister-magik/assets/saturn-screenshots-320x320.mmlz4b
+/media/fat/mister-magik/assets/saturn-screenshots-320x320.mmlz4b.idx
 ```
 
 Legacy catalog paths such as `arcade-screenshots.mmlz4b` remain valid lookup
@@ -279,12 +283,16 @@ their size in the local filename.
 
 The downloader streams the raw manifest object directly into a hidden temporary
 file beside the final pack on `/media/fat` while feeding the same bytes to the
-SHA-256 verifier. It compares the streamed byte count and SHA-256 with both the
-selected raw variant and the raw pack manifest entry, then publishes verified
-packs atomically with file sync, rename, and parent-directory sync. The state file
+SHA-256 verifier. When the manifest includes an `index` block, it also downloads
+and verifies the `.mmlz4b.idx` sidecar before marking the pack current. A local
+pack is current only when the raw pack and its advertised sidecar match the
+media state. If the raw pack is current but the sidecar is missing or stale, the
+worker repairs only the sidecar. Verified files are published atomically with
+file sync, rename, and parent-directory sync. The state file
 `/media/fat/mister-magik/assets/.screenshot-media-state.json` records the last
-successful media update, preferred size, and the latest HTTP/cache headers
-observed for each downloaded pack. It is not a catalog stamp input.
+successful media update, preferred size, index metadata, and the latest
+HTTP/cache headers observed for each downloaded pack. It is not a catalog stamp
+input.
 
 During catalog scans, the scanner emits the first discovery of each supported
 screenshot-pack system: `arcade`, `neogeo`, `nes`, `snes`, `n64`, `sms`,
@@ -308,8 +316,11 @@ finalization phases stay at 100%. The row omits byte labels and keeps completed
 packs visible briefly so users can see every requested pack finish.
 
 The production path is the canonical `.mmlz4b` object served with
-`Accept-Encoding: identity`. Runtime v1 uses manifest `compression: "none"`.
-MagiK does not decode or benchmark gzip/Brotli screenshot objects on device.
+`Accept-Encoding: identity`. Runtime v1 uses manifest `compression: "none"` for
+the raw pack plus optional `codec: "mmlz4b-index-v1"` sidecars. The preview
+loader uses the sidecar for `index_pread` only while the full archive is not yet
+loaded; steady state returns to `archive_mem`. MagiK does not decode or
+benchmark gzip/Brotli screenshot objects on device.
 Cloudflare compression behavior can still be inspected separately through
 header probes:
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -319,8 +319,10 @@ The production path is the canonical `.mmlz4b` object served with
 `Accept-Encoding: identity`. Runtime v1 uses manifest `compression: "none"` for
 the raw pack plus optional `codec: "mmlz4b-index-v1"` sidecars. The preview
 loader uses the sidecar for `index_pread` only while the full archive is not yet
-loaded; steady state returns to `archive_mem`. MagiK does not decode or
-benchmark gzip/Brotli screenshot objects on device.
+loaded; steady state returns to `archive_mem`. Malformed sidecars, duplicate
+entries, archive-size mismatches, and out-of-bounds entry ranges are treated as
+fast-lane misses and fall back to the full archive path. MagiK does not decode
+or benchmark gzip/Brotli screenshot objects on device.
 Cloudflare compression behavior can still be inspected separately through
 header probes:
 

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -251,9 +251,11 @@ Screenshot packs are fixed runtime artifacts, not catalog inputs. The runtime
 loads LZ4-block `.mmlz4b` packs from `/media/fat/mister-magik/assets`; the
 catalog stores only the pack path and asset key needed to request a preview.
 Raw preview archive formats and ad hoc on-device pack generation are retired.
-Build and publish packs from the sibling `../magik-cloud` repo; this repo keeps
-only runtime preview loading, catalog projection, and device acceptance checks.
-See `../magik-cloud/docs/media-build.md` for the media-build workflow.
+Build and publish packs from the private `private/magik-cloud` submodule; this
+repo keeps only runtime preview loading, catalog projection, and device
+acceptance checks. Use `scripts/magik-cloud path` to resolve `MAGIK_CLOUD_DIR`,
+the submodule, or the legacy `../magik-cloud` checkout. See
+`private/magik-cloud/docs/media-build.md` for the media-build workflow.
 
 Remote screenshot-pack updates are manifest-driven. On-device MagiK and the
 host commands `scripts/mister media-check` and `scripts/mister media-download`

--- a/docs/console-media-identity.md
+++ b/docs/console-media-identity.md
@@ -105,12 +105,11 @@ Archive entries use filesystem-safe canonical keys:
 mame-software__megadriv__sonic.rgb565
 ```
 
-Build a pack from MagiK-owned source images in the sibling `../magik-cloud`
-repo:
+Build a pack from MagiK-owned source images in the private
+`private/magik-cloud` submodule:
 
 ```bash
-cd ../magik-cloud
-scripts/build-console-screenshot-pack.sh \
+scripts/magik-cloud run -- scripts/build-console-screenshot-pack.sh \
   --system megadrive \
   --input data/sources/megadrive/canonical
 ```
@@ -128,8 +127,7 @@ canonical names before building the pack.
 Stage scraper/title screenshots offline with the `magik-cloud` Rust tool:
 
 ```bash
-cd ../magik-cloud
-cargo run -- \
+scripts/magik-cloud run -- cargo run -- \
   console-screenshot-stage \
   --system saturn \
   --input data/sources/saturn/originals \

--- a/magik-gui/catalog/src/preview_worker.rs
+++ b/magik-gui/catalog/src/preview_worker.rs
@@ -1444,14 +1444,23 @@ fn read_preview_archive_sidecar_index(
                 index_path.display()
             ));
         }
-        entries.insert(
-            name.to_ascii_lowercase(),
-            PreviewArchiveEntry {
-                raw_len,
-                compressed_len,
-                offset,
-            },
-        );
+        let key = name.to_ascii_lowercase();
+        if entries
+            .insert(
+                key.clone(),
+                PreviewArchiveEntry {
+                    raw_len,
+                    compressed_len,
+                    offset,
+                },
+            )
+            .is_some()
+        {
+            return Err(format!(
+                "{}: duplicate preview archive index entry {key}",
+                index_path.display()
+            ));
+        }
     }
     Ok(PreviewArchiveSidecarIndex { entries })
 }
@@ -2060,6 +2069,33 @@ mod tests {
         let _ = std::fs::remove_file(path);
     }
 
+    #[test]
+    fn duplicate_preview_index_entries_fall_back_to_archive_mem() {
+        let path = std::env::temp_dir().join(format!(
+            "mister-magik-preview-index-duplicate-{}.mmlz4b",
+            std::process::id()
+        ));
+        let payload = raw565_fixture(1, 1, &[0xf800]);
+        write_lz4_block_archive(&path, "tiny.rgb565", &payload);
+        write_duplicate_lz4_block_archive_index(&path, "tiny.rgb565", payload.len());
+        let mut scratch = PreviewArchiveScratch::default();
+
+        let loaded = load_preview_pixels(
+            &path.display().to_string(),
+            "tiny",
+            &mut scratch,
+            PreviewResizeSpec {
+                filter: PreviewResizeFilter::Hybrid,
+                max_w: 320,
+                max_h: 320,
+            },
+        )
+        .expect("fall back to full archive for duplicate index entries");
+
+        assert_eq!(loaded.timing.load_source, PreviewLoadSource::ArchiveMem);
+        let _ = std::fs::remove_file(preview_archive_sidecar_path(&path));
+        let _ = std::fs::remove_file(path);
+    }
 
     #[test]
     fn auto_preview_archive_uses_assets_arcade_pack() {
@@ -2499,6 +2535,25 @@ mod tests {
         index.extend_from_slice(name.as_bytes());
         std::fs::write(preview_archive_sidecar_path(path), index)
             .expect("write lz4 block archive index fixture");
+    }
+
+    fn write_duplicate_lz4_block_archive_index(path: &Path, name: &str, payload_len: usize) {
+        let archive_bytes = std::fs::metadata(path).unwrap().len();
+        let archive_payload_offset = 8 + 4 + 2 + 4 + 4 + 8 + name.len();
+        let mut index = Vec::new();
+        index.extend_from_slice(b"MMIDX01\0");
+        index.extend_from_slice(&archive_bytes.to_le_bytes());
+        index.extend_from_slice(b"0000000000000000000000000000000000000000000000000000000000000000");
+        index.extend_from_slice(&2u32.to_le_bytes());
+        for _ in 0..2 {
+            index.extend_from_slice(&(name.len() as u16).to_le_bytes());
+            index.extend_from_slice(&(payload_len as u32).to_le_bytes());
+            index.extend_from_slice(&((payload_len + 1) as u32).to_le_bytes());
+            index.extend_from_slice(&(archive_payload_offset as u64).to_le_bytes());
+            index.extend_from_slice(name.as_bytes());
+        }
+        std::fs::write(preview_archive_sidecar_path(path), index)
+            .expect("write duplicate lz4 block archive index fixture");
     }
 
     fn write_lz4_block_archive_with_lengths(

--- a/magik-gui/catalog/src/preview_worker.rs
+++ b/magik-gui/catalog/src/preview_worker.rs
@@ -3,6 +3,8 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::fs::FileExt;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc;
 use std::sync::Arc;
@@ -185,6 +187,7 @@ pub enum PreviewLoadSource {
     DecodedCache,
     #[default]
     ArchiveMem,
+    IndexPread,
 }
 
 impl PreviewLoadSource {
@@ -192,6 +195,7 @@ impl PreviewLoadSource {
         match self {
             Self::DecodedCache => "decoded_cache",
             Self::ArchiveMem => "archive_mem",
+            Self::IndexPread => "index_pread",
         }
     }
 }
@@ -376,7 +380,6 @@ fn preview_selected_thread(
     decoded_cache: SharedPreviewDecodedCache,
 ) {
     lower_thread_priority();
-    let _ = preview_archives();
     let mut scratch = PreviewArchiveScratch::default();
     while let Ok(mut req) = rx.recv() {
         while let Ok(next) = rx.try_recv() {
@@ -395,7 +398,6 @@ fn preview_prefetch_thread(
     decoded_cache: SharedPreviewDecodedCache,
 ) {
     lower_thread_priority();
-    let _ = preview_archives();
     let mut queue: Vec<PreviewRequest> = Vec::new();
     let mut scratch = PreviewArchiveScratch::default();
     loop {
@@ -681,6 +683,21 @@ fn load_raw565_preview_asset_timed(
         return Err("preview asset missing archive path or key".to_string());
     }
     let entry_name = format!("{asset_key}.rgb565");
+    if let Some(archives) = cached_preview_archives_for_paths(&[archive_path.to_string()]) {
+        for archive in archives.iter() {
+            if let Some(loaded) = archive.load_timed(&entry_name, scratch)? {
+                return Ok(loaded);
+            }
+        }
+    }
+    if let Some(loaded) = try_load_raw565_preview_asset_from_index(
+        Path::new(archive_path),
+        &entry_name,
+        scratch,
+    ) {
+        start_background_preview_archive_load(archive_path.to_string());
+        return Ok(loaded);
+    }
     let Some(archives) = preview_archives_for_paths(vec![archive_path.to_string()])? else {
         return Err(format!("preview archive not configured {archive_path}"));
     };
@@ -699,6 +716,18 @@ struct PreviewArchiveEntry {
     raw_len: usize,
     compressed_len: usize,
     offset: u64,
+}
+
+#[derive(Clone, Debug)]
+struct PreviewArchiveSidecarIndex {
+    entries: HashMap<String, PreviewArchiveEntry>,
+}
+
+#[derive(Clone, Debug)]
+struct CachedPreviewArchiveSidecarIndex {
+    archive_fingerprint: PreviewArchiveFingerprint,
+    index_fingerprint: PreviewArchiveFingerprint,
+    index: Arc<PreviewArchiveSidecarIndex>,
 }
 
 struct PreviewArchive {
@@ -741,10 +770,7 @@ pub fn warm_preview_archives_from_env() -> Result<bool, String> {
 fn preview_archives_for_paths(
     paths: Vec<String>,
 ) -> Result<Option<Arc<Vec<PreviewArchive>>>, String> {
-    static ARCHIVES: OnceLock<Mutex<Option<CachedPreviewArchives>>> = OnceLock::new();
-    static MISSING: OnceLock<Mutex<Vec<MissingPreviewArchive>>> = OnceLock::new();
-
-    let cache = ARCHIVES.get_or_init(|| Mutex::new(None));
+    let cache = preview_archive_cache();
     if paths.is_empty() {
         if let Ok(mut cached) = cache.lock() {
             *cached = None;
@@ -752,7 +778,7 @@ fn preview_archives_for_paths(
         return Ok(None);
     }
 
-    let missing_cache = MISSING.get_or_init(|| Mutex::new(Vec::new()));
+    let missing_cache = missing_preview_archive_cache();
     if let Some(error) = cached_missing_preview_archive_error(missing_cache, &paths) {
         return Err(error);
     }
@@ -790,6 +816,33 @@ fn preview_archives_for_paths(
         });
     }
     Ok(Some(archives))
+}
+
+fn preview_archive_cache() -> &'static Mutex<Option<CachedPreviewArchives>> {
+    static ARCHIVES: OnceLock<Mutex<Option<CachedPreviewArchives>>> = OnceLock::new();
+    ARCHIVES.get_or_init(|| Mutex::new(None))
+}
+
+fn missing_preview_archive_cache() -> &'static Mutex<Vec<MissingPreviewArchive>> {
+    static MISSING: OnceLock<Mutex<Vec<MissingPreviewArchive>>> = OnceLock::new();
+    MISSING.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+fn cached_preview_archives_for_paths(paths: &[String]) -> Option<Arc<Vec<PreviewArchive>>> {
+    let cache = preview_archive_cache();
+    let cached = cache.lock().ok()?;
+    let cached = cached.as_ref()?;
+    if cached.fingerprints.len() != paths.len()
+        || cached
+            .fingerprints
+            .iter()
+            .zip(paths.iter())
+            .any(|(fingerprint, path)| fingerprint.path != *path)
+    {
+        return None;
+    }
+    let fingerprints = preview_archive_fingerprints_for_paths(paths.to_vec()).ok()?;
+    (cached.fingerprints == fingerprints).then(|| Arc::clone(&cached.archives))
 }
 
 fn cached_missing_preview_archive_error(
@@ -1200,6 +1253,239 @@ fn size_qualified_archive_path_for_system(
     size_qualified_screenshot_pack_path_in_root(root, system, image_size)
         .ok()
         .map(|path| path.display().to_string())
+}
+
+fn try_load_raw565_preview_asset_from_index(
+    archive_path: &Path,
+    entry_name: &str,
+    scratch: &mut PreviewArchiveScratch,
+) -> Option<LoadedPreviewPixels> {
+    match load_raw565_preview_asset_from_index(archive_path, entry_name, scratch) {
+        Ok(loaded) => loaded,
+        Err(error) => {
+            if preview_trace_enabled() {
+                eprintln!(
+                    "preview_trace index_pread_failed archive_path={} asset_key={} error={}",
+                    archive_path.display(),
+                    entry_name,
+                    error
+                );
+            }
+            None
+        }
+    }
+}
+
+fn load_raw565_preview_asset_from_index(
+    archive_path: &Path,
+    entry_name: &str,
+    scratch: &mut PreviewArchiveScratch,
+) -> Result<Option<LoadedPreviewPixels>, String> {
+    let Some(index) = preview_archive_sidecar_index(archive_path)? else {
+        return Ok(None);
+    };
+    let key = entry_name.to_ascii_lowercase();
+    let Some(entry) = index.entries.get(&key).copied() else {
+        return Ok(None);
+    };
+    let total_t = Instant::now();
+    let read_t = Instant::now();
+    let mut payload = vec![0u8; entry.compressed_len];
+    let file = File::open(archive_path)
+        .map_err(|e| format!("open preview archive {}: {e}", archive_path.display()))?;
+    read_exact_at(&file, &mut payload, entry.offset)
+        .map_err(|e| format!("pread preview archive {}: {e}", archive_path.display()))?;
+    let read_us = read_t.elapsed().as_micros() as u64;
+
+    let decode_t = Instant::now();
+    let data = decode_lz4_block_entry_into(&payload, entry.raw_len, &mut scratch.raw)
+        .map_err(|e| format!("preview archive index decode {entry_name}: {e}"))?;
+    let image = decode_raw565_preview_bytes(data)?;
+    let decode_us = decode_t.elapsed().as_micros() as u64;
+    let total_us = total_t.elapsed().as_micros() as u64;
+    Ok(Some(LoadedPreviewPixels {
+        timing: ImageLoadTiming {
+            read_us,
+            decode_us,
+            resize_us: 0,
+            total_us,
+            encoded_bytes: entry.compressed_len,
+            source_width: image.width(),
+            source_height: image.height(),
+            load_source: PreviewLoadSource::IndexPread,
+        },
+        image,
+    }))
+}
+
+fn preview_archive_sidecar_index(
+    archive_path: &Path,
+) -> Result<Option<Arc<PreviewArchiveSidecarIndex>>, String> {
+    let index_path = preview_archive_sidecar_path(archive_path);
+    if !index_path.is_file() {
+        return Ok(None);
+    }
+    let archive_fingerprint = preview_archive_fingerprint(archive_path)?;
+    let index_fingerprint = preview_archive_fingerprint(&index_path)?;
+    let cache = preview_archive_sidecar_index_cache();
+    let cache_key = archive_path.display().to_string();
+    if let Ok(cache) = cache.lock() {
+        if let Some(cached) = cache.get(&cache_key) {
+            if cached.archive_fingerprint == archive_fingerprint
+                && cached.index_fingerprint == index_fingerprint
+            {
+                return Ok(Some(Arc::clone(&cached.index)));
+            }
+        }
+    }
+    let index = Arc::new(read_preview_archive_sidecar_index(
+        &index_path,
+        archive_fingerprint.size,
+    )?);
+    if let Ok(mut cache) = cache.lock() {
+        cache.insert(
+            cache_key,
+            CachedPreviewArchiveSidecarIndex {
+                archive_fingerprint,
+                index_fingerprint,
+                index: Arc::clone(&index),
+            },
+        );
+    }
+    Ok(Some(index))
+}
+
+fn preview_archive_sidecar_index_cache(
+) -> &'static Mutex<HashMap<String, CachedPreviewArchiveSidecarIndex>> {
+    static INDEXES: OnceLock<Mutex<HashMap<String, CachedPreviewArchiveSidecarIndex>>> =
+        OnceLock::new();
+    INDEXES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn preview_archive_sidecar_path(archive_path: &Path) -> PathBuf {
+    let mut path = archive_path.as_os_str().to_os_string();
+    path.push(".idx");
+    PathBuf::from(path)
+}
+
+fn preview_archive_fingerprint(path: &Path) -> Result<PreviewArchiveFingerprint, String> {
+    let path_text = path.display().to_string();
+    let meta = preview_archive_metadata(&path_text)
+        .map_err(|e| format!("metadata preview archive {path_text}: {e}"))?;
+    let mtime_secs = meta
+        .modified()
+        .ok()
+        .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+        .map(|duration| duration.as_nanos().min(i64::MAX as u128) as i64)
+        .unwrap_or(0);
+    Ok(PreviewArchiveFingerprint {
+        path: path_text,
+        size: meta.len(),
+        mtime_secs,
+    })
+}
+
+fn read_preview_archive_sidecar_index(
+    index_path: &Path,
+    archive_bytes: u64,
+) -> Result<PreviewArchiveSidecarIndex, String> {
+    let bytes = std::fs::read(index_path)
+        .map_err(|e| format!("read preview archive index {}: {e}", index_path.display()))?;
+    if bytes.len() < 84 {
+        return Err(format!("{}: preview archive index too short", index_path.display()));
+    }
+    if &bytes[..8] != b"MMIDX01\0" {
+        return Err(format!("{}: bad preview archive index magic", index_path.display()));
+    }
+    let indexed_archive_bytes = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+    if indexed_archive_bytes != archive_bytes {
+        return Err(format!(
+            "{}: archive byte mismatch indexed={} actual={archive_bytes}",
+            index_path.display(),
+            indexed_archive_bytes
+        ));
+    }
+    let archive_sha = std::str::from_utf8(&bytes[16..80])
+        .map_err(|e| format!("preview archive index sha utf8: {e}"))?;
+    if archive_sha.len() != 64 || !archive_sha.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        return Err(format!("{}: bad preview archive index sha", index_path.display()));
+    }
+    let count = u32::from_le_bytes(bytes[80..84].try_into().unwrap()) as usize;
+    let mut pos = 84usize;
+    let mut entries = HashMap::with_capacity(count);
+    for _ in 0..count {
+        if bytes.len().saturating_sub(pos) < 18 {
+            return Err(format!("{}: truncated preview archive index", index_path.display()));
+        }
+        let name_len = u16::from_le_bytes(bytes[pos..pos + 2].try_into().unwrap()) as usize;
+        pos += 2;
+        let raw_len = u32::from_le_bytes(bytes[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+        let compressed_len =
+            u32::from_le_bytes(bytes[pos..pos + 4].try_into().unwrap()) as usize;
+        pos += 4;
+        let offset = u64::from_le_bytes(bytes[pos..pos + 8].try_into().unwrap());
+        pos += 8;
+        let end = pos
+            .checked_add(name_len)
+            .ok_or_else(|| format!("{}: preview archive index name overflow", index_path.display()))?;
+        if end > bytes.len() {
+            return Err(format!("{}: truncated preview archive index name", index_path.display()));
+        }
+        let name = String::from_utf8(bytes[pos..end].to_vec())
+            .map_err(|e| format!("preview archive index name utf8: {e}"))?;
+        pos = end;
+        let payload_end = offset
+            .checked_add(compressed_len as u64)
+            .ok_or_else(|| format!("{}: preview archive index offset overflow", index_path.display()))?;
+        if payload_end > archive_bytes {
+            return Err(format!(
+                "{}: preview archive index payload outside archive",
+                index_path.display()
+            ));
+        }
+        entries.insert(
+            name.to_ascii_lowercase(),
+            PreviewArchiveEntry {
+                raw_len,
+                compressed_len,
+                offset,
+            },
+        );
+    }
+    Ok(PreviewArchiveSidecarIndex { entries })
+}
+
+#[cfg(unix)]
+fn read_exact_at(file: &File, buf: &mut [u8], offset: u64) -> std::io::Result<()> {
+    let mut done = 0usize;
+    while done < buf.len() {
+        let read = file.read_at(&mut buf[done..], offset + done as u64)?;
+        if read == 0 {
+            return Err(std::io::Error::from(std::io::ErrorKind::UnexpectedEof));
+        }
+        done += read;
+    }
+    Ok(())
+}
+
+fn start_background_preview_archive_load(archive_path: String) {
+    static LOADING: OnceLock<Mutex<HashSet<String>>> = OnceLock::new();
+    let loading = LOADING.get_or_init(|| Mutex::new(HashSet::new()));
+    if let Ok(mut loading) = loading.lock() {
+        if !loading.insert(archive_path.clone()) {
+            return;
+        }
+    }
+    let loading = LOADING.get_or_init(|| Mutex::new(HashSet::new()));
+    let _ = std::thread::Builder::new()
+        .name("preview-archive-load".to_string())
+        .spawn(move || {
+            let _ = preview_archives_for_paths(vec![archive_path.clone()]);
+            if let Ok(mut loading) = loading.lock() {
+                loading.remove(&archive_path);
+            }
+        });
 }
 
 impl PreviewArchive {
@@ -1708,6 +1994,74 @@ mod tests {
     }
 
     #[test]
+    fn preview_load_uses_index_pread_before_archive_cache() {
+        let path = std::env::temp_dir().join(format!(
+            "mister-magik-preview-index-pread-{}.mmlz4b",
+            std::process::id()
+        ));
+        write_lz4_block_archive_with_index(
+            &path,
+            "tiny.rgb565",
+            &raw565_fixture(3, 1, &[0xf800, 0x07e0, 0x001f]),
+        );
+        let mut scratch = PreviewArchiveScratch::default();
+        let resize = PreviewResizeSpec {
+            filter: PreviewResizeFilter::Hybrid,
+            max_w: 320,
+            max_h: 320,
+        };
+
+        let first = load_preview_pixels(&path.display().to_string(), "tiny", &mut scratch, resize)
+            .expect("load via index pread");
+
+        assert_eq!(first.timing.load_source, PreviewLoadSource::IndexPread);
+        assert_eq!(first.timing.source_width, 3);
+        assert_eq!(first.timing.source_height, 1);
+
+        let _ = preview_archives_for_paths(vec![path.display().to_string()])
+            .expect("warm archive after index pread");
+        let second = load_preview_pixels(&path.display().to_string(), "tiny", &mut scratch, resize)
+            .expect("load via warmed archive");
+        assert_eq!(second.timing.load_source, PreviewLoadSource::ArchiveMem);
+
+        let _ = std::fs::remove_file(preview_archive_sidecar_path(&path));
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[test]
+    fn invalid_preview_index_falls_back_to_archive_mem() {
+        let path = std::env::temp_dir().join(format!(
+            "mister-magik-preview-index-fallback-{}.mmlz4b",
+            std::process::id()
+        ));
+        write_lz4_block_archive(
+            &path,
+            "tiny.rgb565",
+            &raw565_fixture(1, 1, &[0xf800]),
+        );
+        std::fs::write(preview_archive_sidecar_path(&path), b"bad-index")
+            .expect("write bad index");
+        let mut scratch = PreviewArchiveScratch::default();
+
+        let loaded = load_preview_pixels(
+            &path.display().to_string(),
+            "tiny",
+            &mut scratch,
+            PreviewResizeSpec {
+                filter: PreviewResizeFilter::Hybrid,
+                max_w: 320,
+                max_h: 320,
+            },
+        )
+        .expect("fall back to full archive");
+
+        assert_eq!(loaded.timing.load_source, PreviewLoadSource::ArchiveMem);
+        let _ = std::fs::remove_file(preview_archive_sidecar_path(&path));
+        let _ = std::fs::remove_file(path);
+    }
+
+
+    #[test]
     fn auto_preview_archive_uses_assets_arcade_pack() {
         let root =
             std::env::temp_dir().join(format!("mister-magik-preview-auto-{}", std::process::id()));
@@ -2127,6 +2481,24 @@ mod tests {
 
     fn write_lz4_block_archive(path: &Path, name: &str, payload: &[u8]) {
         write_lz4_block_archive_with_lengths(path, name, payload, payload.len(), payload.len() + 1);
+    }
+
+    fn write_lz4_block_archive_with_index(path: &Path, name: &str, payload: &[u8]) {
+        write_lz4_block_archive(path, name, payload);
+        let archive_bytes = std::fs::metadata(path).unwrap().len();
+        let index_len = 8 + 4 + 2 + 4 + 4 + 8 + name.len();
+        let mut index = Vec::new();
+        index.extend_from_slice(b"MMIDX01\0");
+        index.extend_from_slice(&archive_bytes.to_le_bytes());
+        index.extend_from_slice(b"0000000000000000000000000000000000000000000000000000000000000000");
+        index.extend_from_slice(&1u32.to_le_bytes());
+        index.extend_from_slice(&(name.len() as u16).to_le_bytes());
+        index.extend_from_slice(&(payload.len() as u32).to_le_bytes());
+        index.extend_from_slice(&((payload.len() + 1) as u32).to_le_bytes());
+        index.extend_from_slice(&(index_len as u64).to_le_bytes());
+        index.extend_from_slice(name.as_bytes());
+        std::fs::write(preview_archive_sidecar_path(path), index)
+            .expect("write lz4 block archive index fixture");
     }
 
     fn write_lz4_block_archive_with_lengths(

--- a/magik-gui/src/media_bench_download.rs
+++ b/magik-gui/src/media_bench_download.rs
@@ -973,6 +973,7 @@ mod tests {
             image_size: "320x320".to_string(),
             raw: test_variant(),
             variants: vec![test_variant()],
+            index: None,
         }
     }
 

--- a/magik-gui/src/media_update.rs
+++ b/magik-gui/src/media_update.rs
@@ -1,5 +1,5 @@
 use serde_json::Value;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub use mister_magik_catalog::media_identity::{
     DEFAULT_SCREENSHOT_ASSET_DIR as DEFAULT_ASSET_DIR,
@@ -31,6 +31,7 @@ pub struct MediaPack {
     pub image_size: String,
     pub raw: MediaVariant,
     pub variants: Vec<MediaVariant>,
+    pub index: Option<MediaIndex>,
 }
 
 impl MediaPack {
@@ -59,6 +60,17 @@ pub struct MediaVariant {
     pub bytes: u64,
     pub sha256: String,
     pub url: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MediaIndex {
+    pub codec: String,
+    pub object: String,
+    pub bytes: u64,
+    pub sha256: String,
+    pub url: String,
+    pub archive_bytes: u64,
+    pub archive_sha256: String,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -105,6 +117,8 @@ pub enum LocalPackStatus {
     Current,
     Missing,
     Stale { reason: String },
+    IndexMissing,
+    IndexStale { reason: String },
 }
 
 impl LocalPackStatus {
@@ -112,8 +126,19 @@ impl LocalPackStatus {
         match self {
             Self::Current => "current",
             Self::Missing => "missing",
-            Self::Stale { .. } => "stale",
+            Self::Stale { .. } | Self::IndexMissing | Self::IndexStale { .. } => "stale",
         }
+    }
+
+    pub fn requires_pack_download(&self) -> bool {
+        matches!(self, Self::Missing | Self::Stale { .. })
+    }
+
+    pub fn requires_index_download(&self) -> bool {
+        matches!(
+            self,
+            Self::Missing | Self::Stale { .. } | Self::IndexMissing | Self::IndexStale { .. }
+        )
     }
 }
 
@@ -203,12 +228,17 @@ fn parse_pack(origin: &str, value: &Value) -> Result<MediaPack, String> {
             "pack {id} variants do not include compression=none"
         ));
     }
+    let index = value
+        .get("index")
+        .map(|index| parse_index(origin, id, &raw, index))
+        .transpose()?;
     Ok(MediaPack {
         id: id.to_string(),
         version,
         image_size,
         raw,
         variants,
+        index,
     })
 }
 
@@ -226,6 +256,40 @@ fn parse_variant(origin: &str, value: &Value) -> Result<MediaVariant, String> {
     .with_url(origin)
 }
 
+fn parse_index(
+    origin: &str,
+    pack_id: &str,
+    raw: &MediaVariant,
+    value: &Value,
+) -> Result<MediaIndex, String> {
+    let index = MediaIndex {
+        codec: required_string(value, "codec")?.to_string(),
+        object: required_string(value, "object")?.to_string(),
+        bytes: required_u64(value, "bytes")?,
+        sha256: required_string(value, "sha256")?.to_string(),
+        url: String::new(),
+        archive_bytes: required_u64(value, "archive_bytes")?,
+        archive_sha256: required_string(value, "archive_sha256")?.to_string(),
+    }
+    .with_url(origin)?;
+    if index.codec != "mmlz4b-index-v1" {
+        return Err(format!(
+            "pack {pack_id} uses unsupported index codec {}",
+            index.codec
+        ));
+    }
+    if index.archive_bytes != raw.bytes {
+        return Err(format!(
+            "pack {pack_id} index archive_bytes mismatch expected={} got={}",
+            raw.bytes, index.archive_bytes
+        ));
+    }
+    if index.archive_sha256 != raw.sha256 {
+        return Err(format!("pack {pack_id} index archive_sha256 mismatch"));
+    }
+    Ok(index)
+}
+
 fn normalize_compression(value: &str) -> Option<&'static str> {
     match value {
         "none" | "identity" => Some("none"),
@@ -241,6 +305,25 @@ impl MediaVariant {
         validate_sha256(&self.sha256)?;
         if self.bytes == 0 {
             return Err(format!("media object {} has zero bytes", self.object));
+        }
+        self.url = format!("{}/{}", origin.trim_end_matches('/'), self.object);
+        Ok(self)
+    }
+}
+
+impl MediaIndex {
+    fn with_url(mut self, origin: &str) -> Result<Self, String> {
+        validate_index_object_path(&self.object)?;
+        validate_sha256(&self.sha256)?;
+        validate_sha256(&self.archive_sha256)?;
+        if self.bytes == 0 {
+            return Err(format!("media index {} has zero bytes", self.object));
+        }
+        if self.archive_bytes == 0 {
+            return Err(format!(
+                "media index {} has zero archive bytes",
+                self.object
+            ));
         }
         self.url = format!("{}/{}", origin.trim_end_matches('/'), self.object);
         Ok(self)
@@ -293,6 +376,12 @@ pub fn state_path(asset_dir: &str) -> String {
     screenshot_media_state_path(asset_dir)
 }
 
+pub fn index_path_for_pack_path(pack_path: &Path) -> PathBuf {
+    let mut path = pack_path.as_os_str().to_os_string();
+    path.push(".idx");
+    PathBuf::from(path)
+}
+
 pub fn pack_status_from_state(
     pack: &MediaPack,
     local_path: &Path,
@@ -323,6 +412,55 @@ pub fn pack_status_from_state(
                 return LocalPackStatus::Stale {
                     reason: format!("{key}-missing"),
                 };
+            }
+        }
+    }
+    if let Some(index) = &pack.index {
+        let index_path = index_path_for_pack_path(local_path);
+        if !index_path.exists() {
+            return LocalPackStatus::IndexMissing;
+        }
+        let Some(index_state) = entry.get("index").and_then(Value::as_object) else {
+            return LocalPackStatus::IndexStale {
+                reason: "index-state-missing".to_string(),
+            };
+        };
+        for (key, expected) in [
+            ("codec", index.codec.as_str()),
+            ("object", index.object.as_str()),
+            ("sha256", index.sha256.as_str()),
+            ("archive_sha256", index.archive_sha256.as_str()),
+        ] {
+            match index_state.get(key).and_then(Value::as_str) {
+                Some(got) if got == expected => {}
+                Some(got) => {
+                    return LocalPackStatus::IndexStale {
+                        reason: format!("{key}-mismatch:{got}"),
+                    };
+                }
+                None => {
+                    return LocalPackStatus::IndexStale {
+                        reason: format!("{key}-missing"),
+                    };
+                }
+            }
+        }
+        for (key, expected) in [
+            ("bytes", index.bytes),
+            ("archive_bytes", index.archive_bytes),
+        ] {
+            match index_state.get(key).and_then(Value::as_u64) {
+                Some(got) if got == expected => {}
+                Some(got) => {
+                    return LocalPackStatus::IndexStale {
+                        reason: format!("{key}-mismatch:{got}"),
+                    };
+                }
+                None => {
+                    return LocalPackStatus::IndexStale {
+                        reason: format!("{key}-missing"),
+                    };
+                }
             }
         }
     }
@@ -374,6 +512,26 @@ fn validate_object_path(object: &str) -> Result<(), String> {
     validate_sha256(sha)
 }
 
+fn validate_index_object_path(object: &str) -> Result<(), String> {
+    if object.contains("..") || object.starts_with('/') {
+        return Err(format!("unsafe media index object path: {object}"));
+    }
+    let parts: Vec<_> = object.split('/').collect();
+    match parts.as_slice() {
+        ["mister-magik", "v1", "packs", system, "screenshots", size, version, _file]
+            if is_supported_pack_id(system)
+                && valid_image_size(size)
+                && valid_version_component(version) => {}
+        _ => return Err(format!("unexpected media index object path: {object}")),
+    }
+    let file = parts.last().copied().unwrap_or("");
+    if !file.ends_with(".mmlz4b.idx") {
+        return Err(format!("unexpected media index object extension: {object}"));
+    }
+    let sha = file.split('.').next().unwrap_or("");
+    validate_sha256(sha)
+}
+
 fn validate_sha256(value: &str) -> Result<(), String> {
     if value.len() == 64 && value.chars().all(|ch| ch.is_ascii_hexdigit()) {
         Ok(())
@@ -409,6 +567,7 @@ mod tests {
 
     const SHA: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
     const GZ_SHA: &str = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    const IDX_SHA: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
     fn raw_manifest(extra: &str) -> String {
         format!(
@@ -430,6 +589,19 @@ mod tests {
         )
     }
 
+    fn indexed_manifest() -> String {
+        raw_manifest(&format!(
+            r#""index": {{
+        "object": "mister-magik/v1/packs/arcade/screenshots/320x320/2026.06.22/{IDX_SHA}.mmlz4b.idx",
+        "bytes": 456,
+        "sha256": "{IDX_SHA}",
+        "codec": "mmlz4b-index-v1",
+        "archive_bytes": 123,
+        "archive_sha256": "{SHA}"
+      }},"#
+        ))
+    }
+
     #[test]
     fn parses_raw_only_manifest_with_default_size() {
         let manifest = parse_manifest_json(DEFAULT_MANIFEST_URL, &raw_manifest("")).unwrap();
@@ -449,6 +621,34 @@ mod tests {
         );
         assert_eq!(pack.variants.len(), 1);
         assert_eq!(pack.variants[0].compression, "none");
+    }
+
+    #[test]
+    fn parses_manifest_index_sidecar() {
+        let manifest = parse_manifest_json(DEFAULT_MANIFEST_URL, &indexed_manifest()).unwrap();
+        let pack = &manifest.packs[0];
+        let index = pack.index.as_ref().expect("index sidecar");
+
+        assert_eq!(index.codec, "mmlz4b-index-v1");
+        assert_eq!(index.bytes, 456);
+        assert_eq!(index.archive_bytes, pack.raw.bytes);
+        assert_eq!(index.archive_sha256, pack.raw.sha256);
+        assert_eq!(
+            index.url,
+            format!("https://assets.mistermagik.com/mister-magik/v1/packs/arcade/screenshots/320x320/2026.06.22/{IDX_SHA}.mmlz4b.idx")
+        );
+    }
+
+    #[test]
+    fn rejects_index_sidecar_for_different_archive() {
+        let text = indexed_manifest().replace(
+            &format!(r#""archive_sha256": "{SHA}""#),
+            r#""archive_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc""#,
+        );
+
+        assert!(parse_manifest_json(DEFAULT_MANIFEST_URL, &text)
+            .unwrap_err()
+            .contains("archive_sha256"));
     }
 
     #[test]
@@ -592,6 +792,82 @@ mod tests {
             LocalPackStatus::Stale { .. }
         ));
         let _ = std::fs::remove_file(local_path);
+        let _ = std::fs::remove_dir(root);
+    }
+
+    #[test]
+    fn classifies_index_status_from_state_and_file() {
+        let manifest = parse_manifest_json(DEFAULT_MANIFEST_URL, &indexed_manifest()).unwrap();
+        let pack = &manifest.packs[0];
+        let root = std::env::temp_dir().join(format!(
+            "mister-magik-media-index-state-{}",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        let local_path = root.join("arcade-screenshots-320x320.mmlz4b");
+        let index_path = index_path_for_pack_path(&local_path);
+        std::fs::write(&local_path, b"pack").unwrap();
+
+        let state = serde_json::json!({
+            "systems": {
+                "arcade": {
+                    "packs": {
+                        "320x320": {
+                            "version": "2026.06.22",
+                            "image_size": "320x320",
+                            "sha256": SHA,
+                            "index": {
+                                "codec": "mmlz4b-index-v1",
+                                "object": format!("mister-magik/v1/packs/arcade/screenshots/320x320/2026.06.22/{IDX_SHA}.mmlz4b.idx"),
+                                "bytes": 456,
+                                "sha256": IDX_SHA,
+                                "archive_bytes": 123,
+                                "archive_sha256": SHA
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        assert_eq!(
+            pack_status_from_state(pack, &local_path, Some(&state)),
+            LocalPackStatus::IndexMissing
+        );
+
+        std::fs::write(&index_path, b"idx").unwrap();
+        assert_eq!(
+            pack_status_from_state(pack, &local_path, Some(&state)),
+            LocalPackStatus::Current
+        );
+
+        let stale = serde_json::json!({
+            "systems": {
+                "arcade": {
+                    "packs": {
+                        "320x320": {
+                            "version": "2026.06.22",
+                            "image_size": "320x320",
+                            "sha256": SHA,
+                            "index": {
+                                "codec": "mmlz4b-index-v1",
+                                "object": format!("mister-magik/v1/packs/arcade/screenshots/320x320/2026.06.22/{IDX_SHA}.mmlz4b.idx"),
+                                "bytes": 1,
+                                "sha256": IDX_SHA,
+                                "archive_bytes": 123,
+                                "archive_sha256": SHA
+                            }
+                        }
+                    }
+                }
+            }
+        });
+        assert!(matches!(
+            pack_status_from_state(pack, &local_path, Some(&stale)),
+            LocalPackStatus::IndexStale { .. }
+        ));
+        let _ = std::fs::remove_file(local_path);
+        let _ = std::fs::remove_file(index_path);
         let _ = std::fs::remove_dir(root);
     }
 

--- a/magik-gui/src/preview_state.rs
+++ b/magik-gui/src/preview_state.rs
@@ -937,11 +937,15 @@ pub(crate) fn apply_ready_preview(
         if let Some(image) = result.image {
             if preview_trace_enabled() && is_selected_result {
                 eprintln!(
-                    "preview_trace apply generation={} priority={:?} selected={} age_us={} archive_path={} asset_key={}",
+                    "preview_trace apply generation={} priority={:?} selected={} age_us={} load_source={} total_us={} read_us={} decode_us={} archive_path={} asset_key={}",
                     result.generation,
                     result.priority,
                     is_selected_result,
                     result.request_age_us,
+                    result.load_source.label(),
+                    result.total_us,
+                    result.read_us,
+                    result.decode_us,
                     result.preview_archive_path,
                     result.preview_asset_key
                 );

--- a/magik-gui/src/ui_runner/launcher_bench.rs
+++ b/magik-gui/src/ui_runner/launcher_bench.rs
@@ -3,6 +3,7 @@ use super::*;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum LauncherBenchScenario {
     Idle,
+    PreviewIdle,
     HomeNav,
     QuickTap,
     RapidTaps,
@@ -21,6 +22,7 @@ impl LauncherBenchScenario {
             .as_str()
         {
             "idle" => Some(Self::Idle),
+            "preview-idle" | "preview_idle" => Some(Self::PreviewIdle),
             "home-nav" | "home_nav" => Some(Self::HomeNav),
             "velocity-scroll" | "velocity_scroll" => Some(Self::HeldScroll),
             "quick-tap" | "quick_tap" => Some(Self::QuickTap),
@@ -39,6 +41,7 @@ impl LauncherBenchScenario {
     pub(super) fn label(self) -> &'static str {
         match self {
             Self::Idle => "idle",
+            Self::PreviewIdle => "preview-idle",
             Self::HomeNav => "home-nav",
             Self::QuickTap => "quick-tap",
             Self::RapidTaps => "rapid-taps",
@@ -52,7 +55,7 @@ impl LauncherBenchScenario {
 
     pub(super) fn period(self) -> Duration {
         match self {
-            Self::Idle | Self::LaunchHandoff => Duration::MAX,
+            Self::Idle | Self::PreviewIdle | Self::LaunchHandoff => Duration::MAX,
             Self::HomeNav => Duration::from_millis(300),
             Self::ModelSync => Duration::from_millis(300),
             Self::QuickTap
@@ -70,6 +73,7 @@ impl LauncherBenchScenario {
                 | Self::RapidTaps
                 | Self::HeldScroll
                 | Self::TurboHold
+                | Self::PreviewIdle
                 | Self::PreviewStepHold
                 | Self::LaunchHandoff
         )
@@ -115,7 +119,9 @@ pub(super) fn launcher_bench_step(
     now: Instant,
 ) -> bool {
     match scenario {
-        LauncherBenchScenario::Idle | LauncherBenchScenario::LaunchHandoff => false,
+        LauncherBenchScenario::Idle
+        | LauncherBenchScenario::PreviewIdle
+        | LauncherBenchScenario::LaunchHandoff => false,
         LauncherBenchScenario::HomeNav => {
             let count = catalog.systems.len();
             if count == 0 {
@@ -527,5 +533,25 @@ mod tests {
         assert_eq!(step, 1);
         assert_eq!(nav.arcade.selected, 1);
         assert!(nav.arcade.is_scroll_active());
+    }
+
+    #[test]
+    fn preview_idle_starts_on_arcade_without_running_steps() {
+        let catalog = empty_catalog();
+        let mut nav = LauncherNav::new();
+        let ran = launcher_bench_step(
+            LauncherBenchScenario::PreviewIdle,
+            &mut nav,
+            &catalog,
+            Some(10),
+            0,
+            Instant::now(),
+        );
+
+        assert!(LauncherBenchScenario::PreviewIdle.starts_on_arcade());
+        assert_eq!(LauncherBenchScenario::PreviewIdle.period(), Duration::MAX);
+        assert!(!ran);
+        assert_eq!(nav.arcade.selected, 0);
+        assert!(!nav.arcade.is_scroll_active());
     }
 }

--- a/magik-gui/src/ui_runner/launcher_loop.rs
+++ b/magik-gui/src/ui_runner/launcher_loop.rs
@@ -318,6 +318,15 @@ fn launcher_return_reveal_enabled() -> bool {
     )
 }
 
+fn preview_archive_warm_skip_enabled() -> bool {
+    matches!(
+        std::env::var("MISTER_PREVIEW_SCROLL_SKIP_ARCHIVE_WARM")
+            .ok()
+            .as_deref(),
+        Some("1") | Some("on") | Some("true") | Some("yes")
+    )
+}
+
 fn launcher_reveal_settle_frames() -> u32 {
     std::env::var("MISTER_LAUNCHER_REVEAL_SETTLE_FRAMES")
         .ok()
@@ -410,7 +419,7 @@ pub(super) fn run_launcher_loop(
         }
     }
     let mut pacer = VsyncPacer::from_env();
-    if launcher_bench_scenario.is_some() {
+    if launcher_bench_scenario.is_some() && !preview_archive_warm_skip_enabled() {
         let warm_t = Instant::now();
         match preview_worker::warm_preview_archives_from_env() {
             Ok(loaded) => print_startup_event(
@@ -428,6 +437,8 @@ pub(super) fn run_launcher_loop(
                 std::process::exit(13);
             }
         }
+    } else if launcher_bench_scenario.is_some() {
+        print_startup_event(start, "preview_archive_warm_skipped", "env=1");
     }
     let mut preview = PreviewState::new();
     let mut launcher_bench_waiting_for_initial_preview =

--- a/magik-gui/src/ui_runner/media_worker.rs
+++ b/magik-gui/src/ui_runner/media_worker.rs
@@ -3,9 +3,9 @@ use crate::artifact_publish::{
     timestamped_temp_path_for, ArtifactPublishLabels,
 };
 use mister_magik_fb::media_update::{
-    pack_status_from_state, parse_manifest_json, size_qualified_pack_path, state_path,
-    valid_image_size, LocalPackStatus, MediaPack, MediaUpdatePolicy, MediaVariant,
-    DEFAULT_ASSET_DIR, DEFAULT_IMAGE_SIZE, DEFAULT_MANIFEST_URL,
+    index_path_for_pack_path, pack_status_from_state, parse_manifest_json,
+    size_qualified_pack_path, state_path, valid_image_size, LocalPackStatus, MediaIndex, MediaPack,
+    MediaUpdatePolicy, MediaVariant, DEFAULT_ASSET_DIR, DEFAULT_IMAGE_SIZE, DEFAULT_MANIFEST_URL,
 };
 use serde_json::Value;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
@@ -365,6 +365,7 @@ fn start_ready_downloads(
             ),
         });
         cleanup_pack_publish_temps(&local_path);
+        cleanup_pack_publish_temps(&index_path_for_pack_path(&local_path));
         send_progress(
             tx,
             MediaProgressEvent::for_pack(
@@ -386,6 +387,20 @@ fn start_ready_downloads(
         let detail = match &status {
             LocalPackStatus::Stale { reason } => {
                 format!("local_path={} reason={reason}", local_path.display())
+            }
+            LocalPackStatus::IndexMissing => {
+                format!(
+                    "local_path={} index_path={} reason=index-missing",
+                    local_path.display(),
+                    index_path_for_pack_path(&local_path).display()
+                )
+            }
+            LocalPackStatus::IndexStale { reason } => {
+                format!(
+                    "local_path={} index_path={} reason={reason}",
+                    local_path.display(),
+                    index_path_for_pack_path(&local_path).display()
+                )
             }
             _ => format!("local_path={}", local_path.display()),
         };
@@ -427,14 +442,16 @@ fn start_ready_downloads(
         let download_config = config.clone();
         let download_pack = pack.clone();
         let download_local_path = local_path.clone();
+        let download_status = status.clone();
         let download_tx = tx.clone();
         std::thread::Builder::new()
             .name(format!("screenshot-media-{}", pack.id))
             .spawn(move || {
-                let result = download_raw_pack(
+                let result = download_pack_assets(
                     &download_config,
                     &download_pack,
                     &download_local_path,
+                    &download_status,
                     request.pack_index,
                     pack_count,
                     &download_tx,
@@ -531,7 +548,27 @@ fn poll_active_downloads(
     }
 }
 
-fn download_raw_pack(
+fn download_pack_assets(
+    config: &MediaWorkerConfig,
+    pack: &MediaPack,
+    local_path: &Path,
+    status: &LocalPackStatus,
+    pack_index: usize,
+    pack_count: usize,
+    tx: &mpsc::Sender<MediaWorkerMessage>,
+) -> Result<(), String> {
+    if status.requires_pack_download() {
+        return download_raw_pack_and_index(config, pack, local_path, pack_index, pack_count, tx);
+    }
+    if status.requires_index_download() {
+        return download_index_for_current_pack(
+            config, pack, local_path, pack_index, pack_count, tx,
+        );
+    }
+    Ok(())
+}
+
+fn download_raw_pack_and_index(
     config: &MediaWorkerConfig,
     pack: &MediaPack,
     local_path: &Path,
@@ -561,6 +598,19 @@ fn download_raw_pack(
             parent: "pack destination parent",
         },
     )?;
+    let index_path = index_path_for_pack_path(local_path);
+    let index_publish = if pack.index.is_some() {
+        Some(prepare_artifact_publish(
+            &index_path,
+            hidden_timestamped_temp_path_for(&index_path, "screenshot-pack-index", unix_ms_now()),
+            ArtifactPublishLabels {
+                destination: "pack index destination",
+                parent: "pack index destination parent",
+            },
+        )?)
+    } else {
+        None
+    };
     let result = stream_variant_to_publish_temp(
         variant,
         pack,
@@ -585,8 +635,57 @@ fn download_raw_pack(
         Ok((streamed, metadata))
     })
     .and_then(|(streamed, metadata)| {
-        install_streamed_pack(&publish, &streamed, pack, pack_index, pack_count, tx)
-            .map(|()| metadata)
+        if let (Some(index), Some(index_publish)) = (&pack.index, index_publish.as_ref()) {
+            let index_headers_tmp = work_dir.join(format!(
+                "{}-{}-{}-index.headers",
+                pack.id,
+                pack.image_size,
+                unix_ms_now()
+            ));
+            let index_result = stream_index_to_publish_temp(
+                index,
+                pack,
+                index_publish,
+                &index_headers_tmp,
+                pack_index,
+                pack_count,
+                tx,
+            )
+            .and_then(|(index_streamed, index_metadata)| {
+                let _ = tx.send(MediaWorkerMessage::CacheMetadata {
+                    scope: format!("pack-index:{}", pack.id),
+                    metadata: index_metadata,
+                });
+                send_progress(
+                    tx,
+                    MediaProgressEvent::for_pack(pack, "index", "verify", pack_index, pack_count)
+                        .with_done_bytes(index.bytes),
+                );
+                verify_streamed_download(&index_streamed, index.bytes, &index.sha256)?;
+                Ok(index_streamed)
+            });
+            let _ = fs::remove_file(index_headers_tmp);
+            index_result.map(|index_streamed| (streamed, metadata, Some(index_streamed)))
+        } else {
+            Ok((streamed, metadata, None))
+        }
+    })
+    .and_then(|(streamed, metadata, index_streamed)| {
+        install_streamed_pack(&publish, &streamed, pack, pack_index, pack_count, tx)?;
+        if let (Some(index), Some(index_publish), Some(index_streamed)) =
+            (&pack.index, index_publish.as_ref(), index_streamed.as_ref())
+        {
+            install_streamed_index(
+                index_publish,
+                index_streamed,
+                index,
+                pack,
+                pack_index,
+                pack_count,
+                tx,
+            )?;
+        }
+        Ok(metadata)
     })
     .and_then(|metadata| {
         write_download_state(
@@ -596,6 +695,74 @@ fn download_raw_pack(
             variant,
             Some(&metadata),
         )
+    });
+    if result.is_err() {
+        publish.cleanup_temp();
+        if let Some(index_publish) = index_publish.as_ref() {
+            index_publish.cleanup_temp();
+        }
+    }
+    let _ = fs::remove_file(headers_tmp);
+    result
+}
+
+fn download_index_for_current_pack(
+    config: &MediaWorkerConfig,
+    pack: &MediaPack,
+    local_path: &Path,
+    pack_index: usize,
+    pack_count: usize,
+    tx: &mpsc::Sender<MediaWorkerMessage>,
+) -> Result<(), String> {
+    let index = pack
+        .index
+        .as_ref()
+        .ok_or_else(|| format!("pack {} has no index sidecar", pack.id))?;
+    let variant = pack
+        .variant_for_compression("none")
+        .ok_or_else(|| format!("pack {} has no compression=none variant", pack.id))?;
+    fs::create_dir_all(&config.asset_dir)
+        .map_err(|e| format!("create asset dir {}: {e}", config.asset_dir.display()))?;
+    let work_dir = PathBuf::from("/tmp/mister-magik-media-download");
+    fs::create_dir_all(&work_dir)
+        .map_err(|e| format!("create media work dir {}: {e}", work_dir.display()))?;
+    let index_path = index_path_for_pack_path(local_path);
+    let headers_tmp = work_dir.join(format!(
+        "{}-{}-{}-index.headers",
+        pack.id,
+        pack.image_size,
+        unix_ms_now()
+    ));
+    let publish = prepare_artifact_publish(
+        &index_path,
+        hidden_timestamped_temp_path_for(&index_path, "screenshot-pack-index", unix_ms_now()),
+        ArtifactPublishLabels {
+            destination: "pack index destination",
+            parent: "pack index destination parent",
+        },
+    )?;
+    let result = stream_index_to_publish_temp(
+        index,
+        pack,
+        &publish,
+        &headers_tmp,
+        pack_index,
+        pack_count,
+        tx,
+    )
+    .and_then(|(streamed, metadata)| {
+        let _ = tx.send(MediaWorkerMessage::CacheMetadata {
+            scope: format!("pack-index:{}", pack.id),
+            metadata,
+        });
+        send_progress(
+            tx,
+            MediaProgressEvent::for_pack(pack, "index", "verify", pack_index, pack_count)
+                .with_done_bytes(index.bytes),
+        );
+        verify_streamed_download(&streamed, index.bytes, &index.sha256)?;
+        install_streamed_index(&publish, &streamed, index, pack, pack_index, pack_count, tx)?;
+        write_download_state(&config.asset_dir, pack, local_path, variant, None)
     });
     if result.is_err() {
         publish.cleanup_temp();
@@ -619,9 +786,64 @@ fn stream_variant_to_publish_temp(
     pack_count: usize,
     tx: &mpsc::Sender<MediaWorkerMessage>,
 ) -> Result<(StreamedPackDownload, HttpCacheMetadata), String> {
+    stream_media_object_to_publish_temp(
+        &variant.url,
+        variant.bytes,
+        "identity",
+        "pack",
+        pack,
+        publish,
+        headers_path,
+        pack_index,
+        pack_count,
+        tx,
+    )
+}
+
+fn stream_index_to_publish_temp(
+    index: &MediaIndex,
+    pack: &MediaPack,
+    publish: &crate::artifact_publish::ArtifactPublishPlan,
+    headers_path: &Path,
+    pack_index: usize,
+    pack_count: usize,
+    tx: &mpsc::Sender<MediaWorkerMessage>,
+) -> Result<(StreamedPackDownload, HttpCacheMetadata), String> {
+    stream_media_object_to_publish_temp(
+        &index.url,
+        index.bytes,
+        "index",
+        "pack index",
+        pack,
+        publish,
+        headers_path,
+        pack_index,
+        pack_count,
+        tx,
+    )
+}
+
+fn stream_media_object_to_publish_temp(
+    url: &str,
+    expected_bytes: u64,
+    progress_variant: &str,
+    object_label: &str,
+    pack: &MediaPack,
+    publish: &crate::artifact_publish::ArtifactPublishPlan,
+    headers_path: &Path,
+    pack_index: usize,
+    pack_count: usize,
+    tx: &mpsc::Sender<MediaWorkerMessage>,
+) -> Result<(StreamedPackDownload, HttpCacheMetadata), String> {
     send_progress(
         tx,
-        MediaProgressEvent::for_pack(pack, "identity", "download_start", pack_index, pack_count),
+        MediaProgressEvent::for_pack(
+            pack,
+            progress_variant,
+            "download_start",
+            pack_index,
+            pack_count,
+        ),
     );
     let headers = File::create(headers_path)
         .map_err(|e| format!("create headers file {}: {e}", headers_path.display()))?;
@@ -635,7 +857,7 @@ fn stream_variant_to_publish_temp(
         .arg("Accept-Encoding: identity")
         .arg("-O")
         .arg("-")
-        .arg(&variant.url)
+        .arg(url)
         .stdout(Stdio::piped())
         .stderr(Stdio::from(headers))
         .spawn()
@@ -667,27 +889,37 @@ fn stream_variant_to_publish_temp(
                 break;
             }
             output.write_all(&buffer[..read]).map_err(|e| {
-                format!("write streamed pack {}: {e}", publish.temp_path().display())
+                format!(
+                    "write streamed {object_label} {}: {e}",
+                    publish.temp_path().display()
+                )
             })?;
             sha_stdin
                 .write_all(&buffer[..read])
                 .map_err(|e| format!("write sha256 stdin: {e}"))?;
             bytes += read as u64;
-            if last_emit.elapsed() >= Duration::from_millis(250) || bytes >= variant.bytes {
+            if last_emit.elapsed() >= Duration::from_millis(250) || bytes >= expected_bytes {
                 last_emit = Instant::now();
                 send_progress(
                     tx,
                     MediaProgressEvent::for_pack(
-                        pack, "identity", "download", pack_index, pack_count,
+                        pack,
+                        progress_variant,
+                        "download",
+                        pack_index,
+                        pack_count,
                     )
-                    .with_bytes(bytes, variant.bytes)
+                    .with_bytes(bytes, expected_bytes)
                     .with_download_mbps(mbps(bytes, started.elapsed())),
                 );
             }
         }
-        output
-            .flush()
-            .map_err(|e| format!("flush streamed pack {}: {e}", publish.temp_path().display()))
+        output.flush().map_err(|e| {
+            format!(
+                "flush streamed {object_label} {}: {e}",
+                publish.temp_path().display()
+            )
+        })
     })();
     drop(sha_stdin);
     drop(output);
@@ -706,16 +938,22 @@ fn stream_variant_to_publish_temp(
     let header_text = fs::read_to_string(headers_path).unwrap_or_default();
     send_progress(
         tx,
-        MediaProgressEvent::for_pack(pack, "identity", "download_done", pack_index, pack_count)
-            .with_bytes(bytes, variant.bytes)
-            .with_download_mbps(mbps(bytes, started.elapsed())),
+        MediaProgressEvent::for_pack(
+            pack,
+            progress_variant,
+            "download_done",
+            pack_index,
+            pack_count,
+        )
+        .with_bytes(bytes, expected_bytes)
+        .with_download_mbps(mbps(bytes, started.elapsed())),
     );
     Ok((
         StreamedPackDownload {
             bytes,
             sha256: actual_sha,
         },
-        parse_wget_headers(&header_text, &variant.url, "response"),
+        parse_wget_headers(&header_text, url, "response"),
     ))
 }
 
@@ -756,10 +994,64 @@ fn install_streamed_pack(
     pack_count: usize,
     tx: &mpsc::Sender<MediaWorkerMessage>,
 ) -> Result<(), String> {
+    install_streamed_object(
+        publish,
+        streamed,
+        pack,
+        "identity",
+        "screenshot pack",
+        pack_index,
+        pack_count,
+        tx,
+    )
+}
+
+fn install_streamed_index(
+    publish: &crate::artifact_publish::ArtifactPublishPlan,
+    streamed: &StreamedPackDownload,
+    index: &MediaIndex,
+    pack: &MediaPack,
+    pack_index: usize,
+    pack_count: usize,
+    tx: &mpsc::Sender<MediaWorkerMessage>,
+) -> Result<(), String> {
+    if streamed.bytes != index.bytes {
+        return Err(format!(
+            "streamed index size mismatch expected={} actual={}",
+            index.bytes, streamed.bytes
+        ));
+    }
+    install_streamed_object(
+        publish,
+        streamed,
+        pack,
+        "index",
+        "screenshot pack index",
+        pack_index,
+        pack_count,
+        tx,
+    )
+}
+
+fn install_streamed_object(
+    publish: &crate::artifact_publish::ArtifactPublishPlan,
+    streamed: &StreamedPackDownload,
+    pack: &MediaPack,
+    progress_variant: &str,
+    install_label: &str,
+    pack_index: usize,
+    pack_count: usize,
+    tx: &mpsc::Sender<MediaWorkerMessage>,
+) -> Result<(), String> {
     let bytes = publish
         .temp_path()
         .metadata()
-        .map_err(|e| format!("stat streamed pack {}: {e}", publish.temp_path().display()))?
+        .map_err(|e| {
+            format!(
+                "stat streamed {install_label} {}: {e}",
+                publish.temp_path().display()
+            )
+        })?
         .len();
     if bytes != streamed.bytes {
         return Err(format!(
@@ -769,7 +1061,7 @@ fn install_streamed_pack(
     }
     send_progress(
         tx,
-        MediaProgressEvent::for_pack(pack, "identity", "save", pack_index, pack_count)
+        MediaProgressEvent::for_pack(pack, progress_variant, "save", pack_index, pack_count)
             .with_done_bytes(streamed.bytes),
     );
     let file = File::options()
@@ -778,21 +1070,31 @@ fn install_streamed_pack(
         .map_err(|e| format!("open streamed pack {}: {e}", publish.temp_path().display()))?;
     send_progress(
         tx,
-        MediaProgressEvent::for_pack(pack, "identity", "sync", pack_index, pack_count)
+        MediaProgressEvent::for_pack(pack, progress_variant, "sync", pack_index, pack_count)
             .with_done_bytes(streamed.bytes),
     );
-    file.sync_all()
-        .map_err(|e| format!("sync streamed pack {}: {e}", publish.temp_path().display()))?;
+    file.sync_all().map_err(|e| {
+        format!(
+            "sync streamed {install_label} {}: {e}",
+            publish.temp_path().display()
+        )
+    })?;
     send_progress(
         tx,
-        MediaProgressEvent::for_pack(pack, "identity", "rename", pack_index, pack_count)
+        MediaProgressEvent::for_pack(pack, progress_variant, "rename", pack_index, pack_count)
             .with_done_bytes(streamed.bytes),
     );
-    publish.install_temp(Some("screenshot pack"))?;
+    publish.install_temp(Some(install_label))?;
     send_progress(
         tx,
-        MediaProgressEvent::for_pack(pack, "identity", "parent-sync", pack_index, pack_count)
-            .with_done_bytes(streamed.bytes),
+        MediaProgressEvent::for_pack(
+            pack,
+            progress_variant,
+            "parent-sync",
+            pack_index,
+            pack_count,
+        )
+        .with_done_bytes(streamed.bytes),
     );
     sync_path_with_fallback(publish.parent());
     Ok(())
@@ -880,6 +1182,17 @@ fn write_download_state(
     });
     if let Some(metadata) = metadata {
         pack_state["cache"] = cache_metadata_json(metadata);
+    }
+    if let Some(index) = &pack.index {
+        pack_state["index"] = serde_json::json!({
+            "codec": index.codec,
+            "object": index.object,
+            "bytes": index.bytes,
+            "sha256": index.sha256,
+            "archive_bytes": index.archive_bytes,
+            "archive_sha256": index.archive_sha256,
+            "local_path": index_path_for_pack_path(local_path).display().to_string(),
+        });
     }
     packs.insert(pack.image_size.clone(), pack_state);
     root.insert("schema".to_string(), Value::from(1));
@@ -1310,6 +1623,37 @@ mod tests {
             .remove(0)
     }
 
+    fn indexed_pack_fixture() -> MediaPack {
+        let text = format!(
+            r#"{{
+  "schema": 1,
+  "generated_at": "2026-06-22T16:58:28Z",
+  "packs": [
+    {{
+      "id": "arcade",
+      "version": "2026.06.22",
+      "object": "mister-magik/v1/packs/arcade/screenshots/320x320/2026.06.22/{SHA}.mmlz4b",
+      "bytes": 4,
+      "sha256": "{SHA}",
+      "codec": "mmlz4b",
+      "index": {{
+        "object": "mister-magik/v1/packs/arcade/screenshots/320x320/2026.06.22/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.mmlz4b.idx",
+        "bytes": 2,
+        "sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "codec": "mmlz4b-index-v1",
+        "archive_bytes": 4,
+        "archive_sha256": "{SHA}"
+      }}
+    }}
+  ]
+}}"#
+        );
+        parse_manifest_json(DEFAULT_MANIFEST_URL, &text)
+            .unwrap()
+            .packs
+            .remove(0)
+    }
+
     fn pack_with_id(id: &str) -> MediaPack {
         let mut pack = pack_fixture();
         pack.id = id.to_string();
@@ -1617,6 +1961,30 @@ mod tests {
         assert_eq!(
             state["systems"]["arcade"]["packs"]["320x320"]["cache"]["content_length"],
             "4"
+        );
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn write_download_state_records_pack_index() {
+        let dir = temp_dir("mister-magik-write-index-state");
+        let pack = indexed_pack_fixture();
+        let local_path = dir.join("arcade-screenshots-320x320.mmlz4b");
+        let variant = pack.variant_for_compression("none").unwrap();
+
+        write_download_state(&dir, &pack, &local_path, variant, None).unwrap();
+
+        let state: Value = serde_json::from_str(
+            &fs::read_to_string(dir.join(".screenshot-media-state.json")).unwrap(),
+        )
+        .unwrap();
+        let index_state = &state["systems"]["arcade"]["packs"]["320x320"]["index"];
+        assert_eq!(index_state["codec"], "mmlz4b-index-v1");
+        assert_eq!(index_state["bytes"], 2);
+        assert_eq!(index_state["archive_bytes"], 4);
+        assert_eq!(
+            index_state["local_path"],
+            index_path_for_pack_path(&local_path).display().to_string()
         );
         let _ = fs::remove_dir_all(dir);
     }

--- a/scripts/magik-cloud
+++ b/scripts/magik-cloud
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Resolve or run commands in the private magik-cloud checkout.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+usage() {
+  cat <<EOF
+Usage:
+  scripts/magik-cloud path
+  scripts/magik-cloud run -- COMMAND [ARG...]
+
+Resolution order:
+  1. MAGIK_CLOUD_DIR
+  2. private/magik-cloud submodule
+  3. ../magik-cloud legacy sibling checkout
+EOF
+}
+
+candidate_ok() {
+  [[ -n "${1:-}" && -d "$1" && ( -d "$1/.git" || -f "$1/.git" ) ]]
+}
+
+resolve_magik_cloud_dir() {
+  if candidate_ok "${MAGIK_CLOUD_DIR:-}"; then
+    (cd "$MAGIK_CLOUD_DIR" && pwd)
+    return 0
+  fi
+
+  local nested="$ROOT/private/magik-cloud"
+  if candidate_ok "$nested"; then
+    (cd "$nested" && pwd)
+    return 0
+  fi
+
+  local legacy="$ROOT/../magik-cloud"
+  if candidate_ok "$legacy"; then
+    (cd "$legacy" && pwd)
+    return 0
+  fi
+
+  cat >&2 <<EOF
+ERROR: magik-cloud checkout not found.
+
+Initialize the private submodule:
+  git submodule update --init private/magik-cloud
+
+Or point MAGIK_CLOUD_DIR at an existing checkout.
+EOF
+  return 1
+}
+
+case "${1:-}" in
+  path)
+    resolve_magik_cloud_dir
+    ;;
+  run)
+    shift
+    if [[ "${1:-}" == "--" ]]; then
+      shift
+    fi
+    if [[ $# -eq 0 ]]; then
+      usage >&2
+      exit 2
+    fi
+    cloud_dir="$(resolve_magik_cloud_dir)"
+    (cd "$cloud_dir" && "$@")
+    ;;
+  -h|--help|"")
+    usage
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+esac

--- a/scripts/package-distribution.sh
+++ b/scripts/package-distribution.sh
@@ -33,7 +33,7 @@ Options:
                        Default if --hbmame-sqlite-default: $DEFAULT_HBMAME
   --installer PATH     MiSTer Scripts menu installer.
                        Default: $DEFAULT_INSTALLER
-  --asset-pack PATH    Optional preview asset pack. Build/publish packs from ../magik-cloud.
+  --asset-pack PATH    Optional preview asset pack. Build/publish packs from private/magik-cloud.
   --hbmame-sqlite-default
                        Include the default HBMame metadata DB if present.
   --main-bin PATH      Optional MiSTer_MagiK Main fork binary.

--- a/scripts/profile-first-preview.sh
+++ b/scripts/profile-first-preview.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# Measure the first selected Arcade screenshot with preview archive warmup disabled.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="$HERE/build/preview-scroll-profiles"
+
+secs="8"
+label="first-preview-$(date -u +%Y%m%dT%H%M%SZ)"
+deploy="--skip-build"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/profile-first-preview.sh [LABEL] [--secs N] [--skip-build|--deploy-device]
+
+Runs the supervised launcher Arcade preview trace with
+MISTER_PREVIEW_SCROLL_SKIP_ARCHIVE_WARM=1, then summarizes the first selected
+preview decode/apply timing from the device log.
+EOF
+}
+
+positionals=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --secs)
+      secs="${2:?--secs needs a value}"
+      shift 2
+      ;;
+    --skip-build)
+      deploy="--skip-build"
+      shift
+      ;;
+    --deploy-device)
+      deploy="--deploy-device"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      echo "unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+    *)
+      positionals+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#positionals[@]}" -ge 1 ]]; then label="${positionals[0]}"; fi
+if [[ "${#positionals[@]}" -gt 1 ]]; then usage >&2; exit 2; fi
+if [[ ! "$secs" =~ ^[0-9]+$ ]]; then echo "secs must be an integer" >&2; exit 2; fi
+if [[ ! "$label" =~ ^[A-Za-z0-9_.-]+$ ]]; then echo "label must contain only letters, numbers, _, ., or -" >&2; exit 2; fi
+
+mkdir -p "$OUT_DIR"
+"$HERE/scripts/profile-preview-scroll.sh" \
+  "$secs" \
+  preview-idle \
+  "$label" \
+  "$deploy" \
+  --skip-preview-warm \
+  --visual-captures 0
+
+log="$OUT_DIR/${label}-arcade.log"
+if [[ ! -f "$log" ]]; then
+  echo "missing preview log: $log" >&2
+  exit 1
+fi
+
+awk -v label="$label" '
+  function field(name, fallback,    i, kv) {
+    for (i = 1; i <= NF; i++) {
+      split($i, kv, "=")
+      if (kv[1] == name) return kv[2]
+    }
+    return fallback
+  }
+  /preview_trace decoded / && decoded_seen == 0 {
+    priority = field("priority", "")
+    if (priority == "Selected") {
+      decoded_seen = 1
+      decoded_queue_age_us = field("queue_age_us", "0")
+      decoded_load_source = field("load_source", "unknown")
+      decoded_total_us = field("total_us", "0")
+      decoded_read_us = field("read_us", "0")
+      decoded_decode_us = field("decode_us", "0")
+      decoded_encoded_bytes = field("encoded_bytes", "0")
+    }
+  }
+  /preview_trace apply / && apply_seen == 0 {
+    selected = field("selected", "")
+    if (selected == "true" || selected == "1") {
+      apply_seen = 1
+      apply_age_us = field("age_us", "0")
+      apply_load_source = field("load_source", "unknown")
+    }
+  }
+  END {
+    printf "first_preview_tsv\tlabel=%s\tdecoded_seen=%d\tapply_seen=%d\tdecoded_queue_age_us=%s\tapply_age_us=%s\tdecoded_load_source=%s\tapply_load_source=%s\tdecoded_total_us=%s\tdecoded_read_us=%s\tdecoded_decode_us=%s\tdecoded_encoded_bytes=%s\n",
+      label, decoded_seen + 0, apply_seen + 0, decoded_queue_age_us + 0,
+      apply_age_us + 0, decoded_load_source, apply_load_source,
+      decoded_total_us + 0, decoded_read_us + 0, decoded_decode_us + 0,
+      decoded_encoded_bytes + 0
+  }
+' "$log"

--- a/scripts/profile-preview-scroll.sh
+++ b/scripts/profile-preview-scroll.sh
@@ -12,9 +12,9 @@ ORIGINAL_ARGS=("$@")
 
 usage() {
   cat <<'EOF'
-Usage: scripts/profile-preview-scroll.sh [SECS] [SCENARIO] [LABEL] [--skip-build|--deploy-device] [--cpu-profile] [--self-test] [--visual-captures N]
+Usage: scripts/profile-preview-scroll.sh [SECS] [SCENARIO] [LABEL] [--skip-build|--deploy-device] [--cpu-profile] [--self-test] [--visual-captures N] [--skip-preview-warm]
 
-Scenarios: velocity-scroll | held-scroll | turbo-hold | preview-step-hold
+Scenarios: velocity-scroll | held-scroll | turbo-hold | preview-step-hold | preview-idle
 Runs the real launcher Arcade screen under Main_MiSTer supervision by writing
 /media/fat/mister-magik/launcher.env and sending mister_magik_restart_launcher.
 
@@ -22,6 +22,8 @@ Runs the real launcher Arcade screen under Main_MiSTer supervision by writing
 Arcade scenario with MISTER_PPROF=1, exits after the trace window, and pulls a
 non-empty CPU SVG artifact.
 --visual-captures captures fixed Arcade indices from the real launcher screen.
+--skip-preview-warm skips launcher benchmark archive preloading so first-preview
+measurement can exercise the .idx + pread fast lane.
 
 Do not use row-step scenarios such as list-scroll/smooth-scroll for Arcade
 performance benchmarking. They do not reproduce real velocity scrolling.
@@ -37,6 +39,7 @@ visual_captures="4"
 allow_hotpath_misses="${MISTER_ALLOW_PREVIEW_HOTPATH_MISSES:-0}"
 cpu_profile="0"
 cpu_profile_remote_svg=""
+skip_preview_warm="${MISTER_PREVIEW_SCROLL_SKIP_ARCHIVE_WARM:-0}"
 positionals=()
 
 while [[ $# -gt 0 ]]; do
@@ -46,6 +49,7 @@ while [[ $# -gt 0 ]]; do
     --cpu-profile) cpu_profile="1"; shift ;;
     --self-test) self_test="1"; shift ;;
     --visual-captures) visual_captures="${2:-}"; shift 2 ;;
+    --skip-preview-warm|--cold-preview-load) skip_preview_warm="1"; shift ;;
     -h|--help) usage; exit 0 ;;
     --*) echo "unknown option: $1" >&2; usage >&2; exit 2 ;;
     *) positionals+=("$1"); shift ;;
@@ -58,9 +62,9 @@ if [[ "${#positionals[@]}" -ge 3 ]]; then label="${positionals[2]}"; fi
 if [[ "${#positionals[@]}" -gt 3 ]]; then usage >&2; exit 2; fi
 
 case "$scenario" in
-  velocity-scroll|held-scroll|turbo-hold|preview-step-hold) ;;
+  velocity-scroll|held-scroll|turbo-hold|preview-step-hold|preview-idle) ;;
   list-scroll|smooth-scroll|selected-first|stress-scroll|cache-warm|preview|preview-changes|screenshot-stress|preview-stress)
-    echo "row-step/jump scenario '$scenario' is not valid for preview benchmarking; use velocity-scroll, turbo-hold, or preview-step-hold" >&2
+    echo "row-step/jump scenario '$scenario' is not valid for preview benchmarking; use velocity-scroll, turbo-hold, preview-step-hold, or preview-idle" >&2
     exit 2
     ;;
   *) echo "unknown scenario: $scenario" >&2; usage >&2; exit 2 ;;
@@ -162,10 +166,10 @@ emit_run_context_row() {
   commit="$(git -C "$HERE" rev-parse --short HEAD 2>/dev/null || echo unknown)"
   command_text="scripts/profile-preview-scroll.sh ${ORIGINAL_ARGS[*]}"
   started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-  printf 'run_context_tsv\tlabel=%s\tcommit=%s\tcommand=%s\tdevice=mister\tscenario=%s\tremote_scenario=%s\tsecs=%s\tdeploy=%s\tcpu_profile=%s\tvisual_captures=%s\tstarted_at=%s\n' \
+  printf 'run_context_tsv\tlabel=%s\tcommit=%s\tcommand=%s\tdevice=mister\tscenario=%s\tremote_scenario=%s\tsecs=%s\tdeploy=%s\tcpu_profile=%s\tvisual_captures=%s\tskip_preview_warm=%s\tstarted_at=%s\n' \
     "$(tsv_value "$label")" "$commit" "$(tsv_value "$command_text")" \
     "$(tsv_value "$scenario")" "$(tsv_value "$remote_scenario")" "$secs" "$deploy" \
-    "$cpu_profile" "$visual_captures" "$started_at"
+    "$cpu_profile" "$visual_captures" "$skip_preview_warm" "$started_at"
 }
 
 cleanup() {
@@ -204,6 +208,9 @@ write_launcher_env() {
     printf 'export MISTER_PREVIEW_SCROLL_TRACE_SECS=%q\n' "$secs"
     if [[ -n "$trace_path" ]]; then printf 'export MISTER_PREVIEW_SCROLL_TRACE=%q\n' "$trace_path"; fi
     if [[ -n "$selected_index" ]]; then printf 'export MISTER_ARCADE_SELECTED_INDEX=%q\n' "$selected_index"; fi
+    if [[ "$skip_preview_warm" == "1" || "$skip_preview_warm" == "true" || "$skip_preview_warm" == "yes" || "$skip_preview_warm" == "on" ]]; then
+      printf 'export MISTER_PREVIEW_SCROLL_SKIP_ARCHIVE_WARM=1\n'
+    fi
     if [[ "$cpu_profile" == "1" ]]; then
       printf 'export MISTER_PPROF=1\n'
       printf 'export MISTER_PPROF_OUT=%q\n' "$cpu_profile_remote_svg"
@@ -616,17 +623,18 @@ summarize_preview_timing() {
       if (cache_hit == "true" || cache_hit == "1") cache_hits++
       if (load_source == "archive_mem") archive_mem++
       else if (load_source == "decoded_cache") decoded_cache++
+      else if (load_source == "index_pread") index_pread++
       else if (read > 0) unexpected_file_reads++
       if (read > 5000) slow_reads++
     }
     END {
       if (n == 0) {
-        printf "%s\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\n", name
+        printf "%s\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\t0\n", name
       } else {
-        printf "%s\t%d\t%.0f\t%d\t%.0f\t%d\t%.0f\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
+        printf "%s\t%d\t%.0f\t%d\t%.0f\t%d\t%.0f\t%d\t%d\t%d\t%d\t%d\t%d\t%d\t%d\n",
           name, n, total_sum / n, total_max, read_sum / n, read_max, decode_sum / n, decode_max,
           cache_hits + 0, unexpected_file_reads + 0, slow_reads + 0,
-          archive_mem + 0, decoded_cache + 0,
+          archive_mem + 0, decoded_cache + 0, index_pread + 0,
           selected_file_reads + 0
       }
     }
@@ -728,11 +736,12 @@ check_preview_hotpath_io_gate() {
         else if (kv[1] == "priority") priority = kv[2]
       }
       if (load_source == "archive_mem") archive_backed = 1
-      if (load_source != "archive_mem" && load_source != "decoded_cache" && read > 0) {
+      if (load_source == "index_pread") index_pread++
+      if (load_source != "archive_mem" && load_source != "decoded_cache" && load_source != "index_pread" && read > 0) {
         unexpected_file_reads++
         if (read > 5000) slow_reads++
       }
-      if (priority == "Selected" && load_source != "archive_mem" && load_source != "decoded_cache" && read > 0) {
+      if (priority == "Selected" && load_source != "archive_mem" && load_source != "decoded_cache" && load_source != "index_pread" && read > 0) {
         selected_file_reads++
         if (selected_file_reads <= 10) {
           printf "%s selected preview unexpected file read: source=%s read_us=%d line=%s\n", name, load_source, read, $0 > "/dev/stderr"
@@ -745,7 +754,7 @@ check_preview_hotpath_io_gate() {
         printf "%s preview hot-path io gate failed: archive_backed=1 unexpected_file_reads=%d slow_reads=%d selected_file_reads=%d\n", name, unexpected_file_reads + 0, slow_reads + 0, selected_file_reads + 0 > "/dev/stderr"
         exit 7
       }
-      printf "%s preview_hotpath_io_gate archive_backed=%d unexpected_file_reads=%d slow_reads=%d selected_file_reads=%d allow=%s\n", name, archive_backed + 0, unexpected_file_reads + 0, slow_reads + 0, selected_file_reads + 0, allow
+      printf "%s preview_hotpath_io_gate archive_backed=%d index_pread=%d unexpected_file_reads=%d slow_reads=%d selected_file_reads=%d allow=%s\n", name, archive_backed + 0, index_pread + 0, unexpected_file_reads + 0, slow_reads + 0, selected_file_reads + 0, allow
     }
   ' "$log"
 }
@@ -979,7 +988,7 @@ printf "arcade decoded=%s apply=%s\n" \
   "$(grep -c 'preview_trace apply' "$arcade_log" 2>/dev/null || true)"
 
 echo
-echo $'preview_timing\trows\tavg_total_us\tmax_total_us\tavg_read_us\tmax_read_us\tavg_decode_us\tmax_decode_us\tcache_hits\tunexpected_file_reads\tslow_reads\tarchive_mem\tdecoded_cache\tselected_file_reads'
+echo $'preview_timing\trows\tavg_total_us\tmax_total_us\tavg_read_us\tmax_read_us\tavg_decode_us\tmax_decode_us\tcache_hits\tunexpected_file_reads\tslow_reads\tarchive_mem\tdecoded_cache\tindex_pread\tselected_file_reads'
 summarize_preview_timing arcade "$arcade_log"
 
 echo

--- a/tools/mister/src/media.rs
+++ b/tools/mister/src/media.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use ssh2::{ExtendedData, Session};
 use std::collections::BTreeMap;
 use std::env;
@@ -13,6 +13,7 @@ type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 const DEFAULT_REMOTE_ASSET_DIR: &str = "/media/fat/mister-magik/assets";
 const DEFAULT_ARCADE_ARCHIVE_PATH: &str =
     "/media/fat/mister-magik/assets/arcade-screenshots.mmlz4b";
+const DEFAULT_IMAGE_SIZE: &str = "320x320";
 const DEFAULT_MANIFEST_URL: &str = "https://assets.mistermagik.com/mister-magik/v1/manifest.json";
 const REMOTE_STATE_PATH: &str = "/media/fat/mister-magik/assets/.screenshot-media-state.json";
 const BENCH_TSV: &str = "history/toolchain-bench/results-screenshot-download.tsv";
@@ -29,9 +30,12 @@ struct MediaManifest {
 #[derive(Clone, Debug)]
 struct MediaPack {
     system: String,
+    version: String,
+    image_size: String,
     local_path: String,
     asset_count: Option<u64>,
     identity: MediaVariant,
+    index: Option<MediaIndex>,
 }
 
 #[derive(Clone, Debug)]
@@ -40,6 +44,16 @@ struct MediaVariant {
     decoded_bytes: u64,
     decoded_sha256: String,
     etag: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+struct MediaIndex {
+    object: String,
+    bytes: u64,
+    sha256: String,
+    codec: String,
+    archive_bytes: u64,
+    archive_sha256: String,
 }
 
 #[derive(Clone, Debug)]
@@ -79,11 +93,12 @@ pub(crate) fn media_check(sess: &Session, args: &[String]) -> Result<()> {
     for pack in selected_packs(&manifest, &parsed.system)? {
         let status = remote_pack_status(sess, pack)?;
         println!(
-            "media_check\t{}\t{}\tlocal_path={}\tremote_url={}\tetag={}",
+            "media_check\t{}\t{}\tlocal_path={}\tremote_url={}\tindex_url={}\tetag={}",
             pack.system,
             status,
             pack.local_path,
             manifest_url_for_pack(&manifest, pack),
+            manifest_url_for_index(&manifest, pack).unwrap_or_default(),
             pack.identity.etag.as_deref().unwrap_or("")
         );
     }
@@ -95,22 +110,48 @@ pub(crate) fn media_download(sess: &Session, args: &[String]) -> Result<()> {
     let manifest = load_manifest(&parsed.manifest_url)?;
     let packs = selected_packs(&manifest, &parsed.system)?;
     for pack in packs {
-        if remote_pack_status(sess, pack)? == "current" {
+        let status = remote_pack_status(sess, pack)?;
+        if status == "current" {
             println!(
                 "media_download\t{}\tskipped-current\tlocal_path={}",
                 pack.system, pack.local_path
             );
             continue;
         }
+        let mut pack_row = None;
+        let mut index_row = None;
         let variant = resolve_variant(sess, pack, &parsed.variant)?;
-        let row = run_remote_media_download(sess, &manifest, pack, &parsed.label, &variant, true)?;
-        println!("{}", row.to_tsv());
-        if row.result != "downloaded" {
-            return Err(
-                format!("media download failed for {}: {}", pack.system, row.result).into(),
-            );
+        let index_only_repair = status == "index-missing" || status.starts_with("index-stale:");
+        if !index_only_repair {
+            let row =
+                run_remote_media_download(sess, &manifest, pack, &parsed.label, &variant, true)?;
+            println!("{}", row.to_tsv());
+            if row.result != "downloaded" {
+                return Err(
+                    format!("media download failed for {}: {}", pack.system, row.result).into(),
+                );
+            }
+            pack_row = Some(row);
         }
-        update_remote_state(sess, pack, &variant, &row)?;
+        if pack.index.is_some() {
+            let row = run_remote_index_download(sess, &manifest, pack, &parsed.label, true)?;
+            println!("{}", row.to_tsv());
+            if row.result != "downloaded" {
+                return Err(format!(
+                    "media index download failed for {}: {}",
+                    pack.system, row.result
+                )
+                .into());
+            }
+            index_row = Some(row);
+        }
+        update_remote_state_after_download(
+            sess,
+            pack,
+            &variant,
+            pack_row.as_ref(),
+            index_row.as_ref(),
+        )?;
     }
     Ok(())
 }
@@ -329,6 +370,13 @@ fn parse_manifest(value: &Value, manifest_url: &str) -> Result<MediaManifest> {
             .map(str::to_string)
             .unwrap_or_else(|| default_local_path_for_pack(&system));
         let asset_count = pack.get("asset_count").and_then(Value::as_u64);
+        let version = pack
+            .get("version")
+            .and_then(Value::as_str)
+            .unwrap_or(&published_at)
+            .to_string();
+        let image_size =
+            image_size_from_pack(pack).unwrap_or_else(|| DEFAULT_IMAGE_SIZE.to_string());
         let identity_value = pack
             .get("variants")
             .and_then(|variants| variants.get("identity"))
@@ -368,11 +416,18 @@ fn parse_manifest(value: &Value, manifest_url: &str) -> Result<MediaManifest> {
         if codec != "mmlz4b" {
             return Err(format!("pack {system} uses unsupported codec {codec}").into());
         }
+        let index = pack
+            .get("index")
+            .map(|value| parse_index(&system, &identity, value))
+            .transpose()?;
         packs.push(MediaPack {
             system,
+            version,
+            image_size,
             local_path,
             asset_count,
             identity,
+            index,
         });
     }
     Ok(MediaManifest {
@@ -429,11 +484,21 @@ fn print_manifest_summary(manifest: &MediaManifest) {
 }
 
 fn remote_pack_status(sess: &Session, pack: &MediaPack) -> Result<String> {
-    let cmd = format!(
-        "if [ -f {path} ]; then got=$(sha256sum {path} 2>/dev/null | awk '{{print $1}}'); if [ \"$got\" = {sha} ]; then echo current; else echo stale:$got; fi; else echo missing; fi",
-        path = shell_quote(&pack.local_path),
-        sha = shell_quote(&pack.identity.decoded_sha256),
-    );
+    let cmd = if let Some(index) = &pack.index {
+        format!(
+            "if [ ! -f {path} ]; then echo missing; exit 0; fi; got=$(sha256sum {path} 2>/dev/null | awk '{{print $1}}'); if [ \"$got\" != {sha} ]; then echo stale:$got; exit 0; fi; if [ ! -f {index_path} ]; then echo index-missing; exit 0; fi; idxgot=$(sha256sum {index_path} 2>/dev/null | awk '{{print $1}}'); if [ \"$idxgot\" != {index_sha} ]; then echo index-stale:$idxgot; exit 0; fi; echo current",
+            path = shell_quote(&pack.local_path),
+            sha = shell_quote(&pack.identity.decoded_sha256),
+            index_path = shell_quote(&local_index_path_for_pack(pack)),
+            index_sha = shell_quote(&index.sha256),
+        )
+    } else {
+        format!(
+            "if [ -f {path} ]; then got=$(sha256sum {path} 2>/dev/null | awk '{{print $1}}'); if [ \"$got\" = {sha} ]; then echo current; else echo stale:$got; fi; else echo missing; fi",
+            path = shell_quote(&pack.local_path),
+            sha = shell_quote(&pack.identity.decoded_sha256),
+        )
+    };
     Ok(exec_stdout(sess, &cmd)?.trim().to_string())
 }
 
@@ -501,6 +566,53 @@ fn run_remote_media_download(
     Ok(row)
 }
 
+fn run_remote_index_download(
+    sess: &Session,
+    manifest: &MediaManifest,
+    pack: &MediaPack,
+    label: &str,
+    publish: bool,
+) -> Result<RemoteBenchRow> {
+    let Some(index) = &pack.index else {
+        return Err(format!("pack {} has no media index", pack.system).into());
+    };
+    let script = remote_script();
+    let remote_script = format!("/tmp/mister-magik-media-index-{}.sh", unix_ms_now());
+    sftp_write(sess, &remote_script, script.as_bytes())?;
+    let url = manifest_url_for_index(manifest, pack).ok_or("pack index URL missing")?;
+    let mode = if publish { "publish" } else { "bench" };
+    let cmd = format!(
+        "chmod +x {script}; {script} {mode} {label} {system} index identity {url} {local} {sha} {bytes}; rc=$?; rm -f {script}; exit $rc",
+        script = shell_quote(&remote_script),
+        mode = shell_quote(mode),
+        label = shell_quote(label),
+        system = shell_quote(&format!("{}-index", pack.system)),
+        url = shell_quote(&url),
+        local = shell_quote(&local_index_path_for_pack(pack)),
+        sha = shell_quote(&index.sha256),
+        bytes = shell_quote(&index.bytes.to_string()),
+    );
+    let out = exec(sess, &cmd)?;
+    if !out.stderr.trim().is_empty() {
+        eprint!("{}", out.stderr);
+    }
+    let row_line = out
+        .stdout
+        .lines()
+        .find(|line| line.starts_with("screenshot_download_bench_tsv\t"))
+        .ok_or_else(|| {
+            format!(
+                "remote index media runner produced no benchmark row: {}",
+                out.stdout
+            )
+        })?;
+    let row = parse_remote_row(row_line)?;
+    if out.rc != 0 && row.result != "downloaded" && row.result != "bench-ok" {
+        return Ok(row);
+    }
+    Ok(row)
+}
+
 fn parse_remote_row(line: &str) -> Result<RemoteBenchRow> {
     let parts: Vec<_> = line.split('\t').collect();
     if parts.len() < 17 {
@@ -532,6 +644,16 @@ fn update_remote_state(
     variant: &str,
     row: &RemoteBenchRow,
 ) -> Result<()> {
+    update_remote_state_after_download(sess, pack, variant, Some(row), None)
+}
+
+fn update_remote_state_after_download(
+    sess: &Session,
+    pack: &MediaPack,
+    variant: &str,
+    row: Option<&RemoteBenchRow>,
+    index_row: Option<&RemoteBenchRow>,
+) -> Result<()> {
     let cmd = format!("cat {} 2>/dev/null || true", shell_quote(REMOTE_STATE_PATH));
     let current = exec_stdout(sess, &cmd)?;
     let mut root = serde_json::from_str::<Value>(&current)
@@ -544,23 +666,45 @@ fn update_remote_state(
         .remove("systems")
         .and_then(|v| v.as_object().cloned())
         .unwrap_or_default();
-    systems.insert(
-        pack.system.clone(),
-        json!({
-            "local_path": pack.local_path,
-            "sha256": pack.identity.decoded_sha256,
-            "bytes": pack.identity.decoded_bytes,
-            "asset_count": pack.asset_count,
-            "etag": pack.identity.etag,
-            "preferred_variant": variant,
-            "last_result": row.result,
-            "last_total_ms": row.total_ms,
-            "last_download_ms": row.download_ms,
-            "last_decompress_ms": row.decompress_ms,
-            "last_save_ms": row.save_ms,
-            "last_verify_ms": row.verify_ms,
-        }),
-    );
+    let mut entry = Map::new();
+    entry.insert("local_path".to_string(), json!(pack.local_path));
+    entry.insert("version".to_string(), json!(pack.version));
+    entry.insert("image_size".to_string(), json!(pack.image_size));
+    entry.insert("sha256".to_string(), json!(pack.identity.decoded_sha256));
+    entry.insert("bytes".to_string(), json!(pack.identity.decoded_bytes));
+    entry.insert("asset_count".to_string(), json!(pack.asset_count));
+    entry.insert("etag".to_string(), json!(pack.identity.etag));
+    entry.insert("preferred_variant".to_string(), json!(variant));
+    if let Some(row) = row {
+        entry.insert("last_result".to_string(), json!(row.result));
+        entry.insert("last_total_ms".to_string(), json!(row.total_ms));
+        entry.insert("last_download_ms".to_string(), json!(row.download_ms));
+        entry.insert("last_decompress_ms".to_string(), json!(row.decompress_ms));
+        entry.insert("last_save_ms".to_string(), json!(row.save_ms));
+        entry.insert("last_verify_ms".to_string(), json!(row.verify_ms));
+    }
+    if let Some(index) = &pack.index {
+        let mut index_entry = Map::new();
+        index_entry.insert("codec".to_string(), json!(index.codec));
+        index_entry.insert("object".to_string(), json!(index.object));
+        index_entry.insert("bytes".to_string(), json!(index.bytes));
+        index_entry.insert("sha256".to_string(), json!(index.sha256));
+        index_entry.insert("archive_bytes".to_string(), json!(index.archive_bytes));
+        index_entry.insert("archive_sha256".to_string(), json!(index.archive_sha256));
+        index_entry.insert(
+            "local_path".to_string(),
+            json!(local_index_path_for_pack(pack)),
+        );
+        if let Some(row) = index_row {
+            index_entry.insert("last_result".to_string(), json!(row.result));
+            index_entry.insert("last_total_ms".to_string(), json!(row.total_ms));
+            index_entry.insert("last_download_ms".to_string(), json!(row.download_ms));
+            index_entry.insert("last_save_ms".to_string(), json!(row.save_ms));
+            index_entry.insert("last_verify_ms".to_string(), json!(row.verify_ms));
+        }
+        entry.insert("index".to_string(), Value::Object(index_entry));
+    }
+    systems.insert(pack.system.clone(), Value::Object(entry));
     root.insert("systems".to_string(), Value::Object(systems));
     let bytes = serde_json::to_vec_pretty(&Value::Object(root))?;
     let tmp = format!("/tmp/mister-magik-media-state-{}.json", unix_ms_now());
@@ -578,18 +722,123 @@ fn update_remote_state(
     Ok(())
 }
 
+fn parse_index(system: &str, identity: &MediaVariant, value: &Value) -> Result<MediaIndex> {
+    let index = MediaIndex {
+        object: value
+            .get("object")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("pack {system} index missing object"))?
+            .to_string(),
+        bytes: value
+            .get("bytes")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| format!("pack {system} index missing bytes"))?,
+        sha256: value
+            .get("sha256")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("pack {system} index missing sha256"))?
+            .to_ascii_lowercase(),
+        codec: value
+            .get("codec")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("pack {system} index missing codec"))?
+            .to_string(),
+        archive_bytes: value
+            .get("archive_bytes")
+            .and_then(Value::as_u64)
+            .ok_or_else(|| format!("pack {system} index missing archive_bytes"))?,
+        archive_sha256: value
+            .get("archive_sha256")
+            .and_then(Value::as_str)
+            .ok_or_else(|| format!("pack {system} index missing archive_sha256"))?
+            .to_ascii_lowercase(),
+    };
+    if index.codec != "mmlz4b-index-v1" {
+        return Err(format!("pack {system} uses unsupported index codec {}", index.codec).into());
+    }
+    if index.bytes == 0 {
+        return Err(format!("pack {system} index has zero bytes").into());
+    }
+    if !index.object.ends_with(".mmlz4b.idx") {
+        return Err(format!("pack {system} index object must end with .mmlz4b.idx").into());
+    }
+    if index.archive_bytes != identity.decoded_bytes {
+        return Err(format!(
+            "pack {system} index archive_bytes mismatch expected={} got={}",
+            identity.decoded_bytes, index.archive_bytes
+        )
+        .into());
+    }
+    if index.archive_sha256 != identity.decoded_sha256 {
+        return Err(format!("pack {system} index archive_sha256 mismatch").into());
+    }
+    Ok(index)
+}
+
+fn image_size_from_pack(value: &Value) -> Option<String> {
+    for key in [
+        "image_size",
+        "preview_size",
+        "pack_size",
+        "size",
+        "resolution",
+    ] {
+        let Some(size) = value.get(key).and_then(Value::as_str) else {
+            continue;
+        };
+        if valid_image_size(size) {
+            return Some(size.to_string());
+        }
+    }
+    let width = value
+        .get("image_width")
+        .or_else(|| value.get("width"))
+        .and_then(Value::as_u64)?;
+    let height = value
+        .get("image_height")
+        .or_else(|| value.get("height"))
+        .and_then(Value::as_u64)?;
+    let size = format!("{width}x{height}");
+    valid_image_size(&size).then_some(size)
+}
+
+fn valid_image_size(value: &str) -> bool {
+    let Some((width, height)) = value.split_once('x') else {
+        return false;
+    };
+    let Ok(width) = width.parse::<u32>() else {
+        return false;
+    };
+    let Ok(height) = height.parse::<u32>() else {
+        return false;
+    };
+    width > 0 && height > 0
+}
+
 fn manifest_url_for_pack(manifest: &MediaManifest, pack: &MediaPack) -> String {
-    if pack.identity.remote_path.starts_with("http://")
-        || pack.identity.remote_path.starts_with("https://")
-    {
-        pack.identity.remote_path.clone()
+    manifest_url_for_object(manifest, &pack.identity.remote_path)
+}
+
+fn manifest_url_for_index(manifest: &MediaManifest, pack: &MediaPack) -> Option<String> {
+    pack.index
+        .as_ref()
+        .map(|index| manifest_url_for_object(manifest, &index.object))
+}
+
+fn manifest_url_for_object(manifest: &MediaManifest, object: &str) -> String {
+    if object.starts_with("http://") || object.starts_with("https://") {
+        object.to_string()
     } else {
         format!(
             "{}/{}",
             manifest.base_url.trim_end_matches('/'),
-            pack.identity.remote_path.trim_start_matches('/')
+            object.trim_start_matches('/')
         )
     }
+}
+
+fn local_index_path_for_pack(pack: &MediaPack) -> String {
+    format!("{}.idx", pack.local_path)
 }
 
 fn accept_encoding_for_variant(variant: &str) -> &'static str {
@@ -971,16 +1220,26 @@ mod tests {
     #[test]
     fn parses_magik_cloud_manifest_shape() {
         let sha = "c5fa5b54d2f2955e87e4d245a8942ce641a9cc84d320ce245b4a259a095c7b42";
+        let idx_sha = "e5fa5b54d2f2955e87e4d245a8942ce641a9cc84d320ce245b4a259a095c7b42";
         let value = json!({
             "schema": 1,
             "generated_at": "2026-06-22T16:52:03Z",
             "packs": [{
                 "id": "arcade",
+                "size": "320x320",
                 "version": "2026.06.22",
                 "object": format!("mister-magik/v1/packs/arcade/2026.06.22/{sha}.mmlz4b"),
                 "bytes": 1234,
                 "sha256": sha,
-                "codec": "mmlz4b"
+                "codec": "mmlz4b",
+                "index": {
+                    "object": format!("mister-magik/v1/packs/arcade/2026.06.22/{idx_sha}.mmlz4b.idx"),
+                    "bytes": 321,
+                    "sha256": idx_sha.to_ascii_uppercase(),
+                    "codec": "mmlz4b-index-v1",
+                    "archive_bytes": 1234,
+                    "archive_sha256": sha.to_ascii_uppercase()
+                }
             }]
         });
 
@@ -993,10 +1252,26 @@ mod tests {
         assert_eq!(manifest.schema_version, 1);
         assert_eq!(manifest.published_at, "2026-06-22T16:52:03Z");
         assert_eq!(manifest.packs[0].system, "arcade");
+        assert_eq!(manifest.packs[0].version, "2026.06.22");
+        assert_eq!(manifest.packs[0].image_size, "320x320");
         assert_eq!(manifest.packs[0].local_path, DEFAULT_ARCADE_ARCHIVE_PATH);
         assert_eq!(
             manifest_url_for_pack(&manifest, &manifest.packs[0]),
             format!("https://assets.mistermagik.com/mister-magik/v1/packs/arcade/2026.06.22/{sha}.mmlz4b")
+        );
+        let index = manifest.packs[0].index.as_ref().unwrap();
+        assert_eq!(index.bytes, 321);
+        assert_eq!(index.sha256, idx_sha);
+        assert_eq!(
+            local_index_path_for_pack(&manifest.packs[0]),
+            format!("{DEFAULT_ARCADE_ARCHIVE_PATH}.idx")
+        );
+        let expected_index_url = format!(
+            "https://assets.mistermagik.com/mister-magik/v1/packs/arcade/2026.06.22/{idx_sha}.mmlz4b.idx"
+        );
+        assert_eq!(
+            manifest_url_for_index(&manifest, &manifest.packs[0]).as_deref(),
+            Some(expected_index_url.as_str())
         );
     }
 
@@ -1113,5 +1388,27 @@ mod tests {
         let err =
             parse_manifest(&unsupported_codec, "https://example.test/manifest.json").unwrap_err();
         assert!(err.to_string().contains("unsupported codec zip"));
+
+        let index_mismatch = json!({
+            "schema_version": 1,
+            "packs": [{
+                "system": "nes",
+                "remote_path": "packs/nes.mmlz4b",
+                "bytes": 10,
+                "sha256": "aaaaaaaa",
+                "codec": "mmlz4b",
+                "index": {
+                    "object": "packs/nes.mmlz4b.idx",
+                    "bytes": 4,
+                    "sha256": "bbbbbbbb",
+                    "codec": "mmlz4b-index-v1",
+                    "archive_bytes": 11,
+                    "archive_sha256": "aaaaaaaa"
+                }
+            }]
+        });
+        let err =
+            parse_manifest(&index_mismatch, "https://example.test/manifest.json").unwrap_err();
+        assert!(err.to_string().contains("index archive_bytes mismatch"));
     }
 }


### PR DESCRIPTION
## Summary
- adds deterministic .mmlz4b.idx sidecar support through the private magik-cloud submodule gitlink
- downloads/verifies/installs pack indexes with screenshot packs and requires matching indexes for current local media state
- uses index + pread for selected/prefetch previews before the full pack is loaded, then returns to archive_mem steady state
- adds no-warm first-preview and scroll-while-loading benchmark paths

## Publish / R2
- published version 2026.06.25-idx1 with raw packs plus index sidecars
- remote verify passed for arcade, neogeo, and saturn raw/index objects
- pruned old 2026.06.23 raw/gzip/brotli pack objects after successful verify

## Validation
- scripts/magik-cloud run -- cargo test
- scripts/magik-cloud run -- tests/run.sh
- scripts/dev-rust test
- scripts/dev-rust check
- scripts/dev-rust host-tools
- cargo test --manifest-path magik-gui/Cargo.toml --features ui --no-default-features
- cargo test --manifest-path magik-gui/catalog/Cargo.toml
- cargo clippy --manifest-path magik-gui/Cargo.toml --lib --no-default-features -- -D warnings
- cargo clippy --manifest-path tools/mister/Cargo.toml --all-targets -- -D warnings
- scripts/device-catalog-acceptance.sh

## Device Benchmarks
- FIRST-IDX2-20260625: selected decode/apply both index_pread; apply_age_us=31308, decoded_total_us=15202
- SCROLL-IDX-20260625: index_pread=10 early decodes, archive_mem=239 steady decodes, unexpected_file_reads=0, selected_file_reads=0
