### PR TITLE
CI measurement lab

### DIFF
--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -186,6 +186,7 @@ jobs:
           magik-gui/build-arm.sh ${{ matrix.args }}
           end_epoch=$(date +%s)
           duration_seconds=$((end_epoch - start_epoch))
+          echo "ci_timing_tsv	job=${{ matrix.name }}	step=build-arm-binary	duration_seconds=${duration_seconds}"
           {
             echo "### ARM build timing"
             echo
@@ -259,6 +260,7 @@ jobs:
           MISTER_ARM_BUILD_BACKEND=cross scripts/build-mister-agent.sh
           end_epoch=$(date +%s)
           duration_seconds=$((end_epoch - start_epoch))
+          echo "ci_timing_tsv	job=agent-arm-build	step=build-arm-agent	duration_seconds=${duration_seconds}"
           {
             echo "### ARM agent build timing"
             echo

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -186,7 +186,9 @@ jobs:
           magik-gui/build-arm.sh ${{ matrix.args }}
           end_epoch=$(date +%s)
           duration_seconds=$((end_epoch - start_epoch))
-          echo "ci_timing_tsv	job=${{ matrix.name }}	step=build-arm-binary	duration_seconds=${duration_seconds}"
+          timing_marker_prefix="ci_timing_"
+          timing_marker="${timing_marker_prefix}tsv"
+          printf "%s\tjob=%s\tstep=build-arm-binary\tduration_seconds=%s\n" "$timing_marker" "${{ matrix.name }}" "$duration_seconds"
           {
             echo "### ARM build timing"
             echo
@@ -260,7 +262,9 @@ jobs:
           MISTER_ARM_BUILD_BACKEND=cross scripts/build-mister-agent.sh
           end_epoch=$(date +%s)
           duration_seconds=$((end_epoch - start_epoch))
-          echo "ci_timing_tsv	job=agent-arm-build	step=build-arm-agent	duration_seconds=${duration_seconds}"
+          timing_marker_prefix="ci_timing_"
+          timing_marker="${timing_marker_prefix}tsv"
+          printf "%s\tjob=agent-arm-build\tstep=build-arm-agent\tduration_seconds=%s\n" "$timing_marker" "$duration_seconds"
           {
             echo "### ARM agent build timing"
             echo

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -181,7 +181,18 @@ jobs:
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 
       - name: Build ARM binary
-        run: magik-gui/build-arm.sh ${{ matrix.args }}
+        run: |
+          start_epoch=$(date +%s)
+          magik-gui/build-arm.sh ${{ matrix.args }}
+          end_epoch=$(date +%s)
+          duration_seconds=$((end_epoch - start_epoch))
+          {
+            echo "### ARM build timing"
+            echo
+            echo "| Variant | Duration |"
+            echo "| --- | ---: |"
+            echo "| ${{ matrix.name }} | ${duration_seconds}s |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Check ARM shared libraries
         run: magik-gui/scripts/check-arm-shared-libs.sh magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/mister-magik-fb
@@ -243,7 +254,18 @@ jobs:
             target-agent-arm-${{ runner.os }}-
 
       - name: Build ARM agent
-        run: MISTER_ARM_BUILD_BACKEND=cross scripts/build-mister-agent.sh
+        run: |
+          start_epoch=$(date +%s)
+          MISTER_ARM_BUILD_BACKEND=cross scripts/build-mister-agent.sh
+          end_epoch=$(date +%s)
+          duration_seconds=$((end_epoch - start_epoch))
+          {
+            echo "### ARM agent build timing"
+            echo
+            echo "| Target | Duration |"
+            echo "| --- | ---: |"
+            echo "| mister-magik-agent | ${duration_seconds}s |"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Upload ARM agent
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
Measurement lane lab for Rust ARM CI timing instrumentation. This PR is parked as draft/lab evidence by coordinator direction. Active campaign work is narrowed to Docker image strategy and ARM cache creation/cache-boundary work only. Do not resume experiments, push commits, or rerun CI from this lane unless the coordinator explicitly reactivates it.

This PR is instrumentation only; it does not claim a CI-speed win and does not remove coverage.

What changed:
- Wrap the ARM binary build step and ARM agent build step with start/end wall-clock measurement.
- Write a short Markdown timing table to the GitHub Actions step summary.
- Emit one searchable ci_timing_tsv payload row per ARM build job so future timing comparisons can be scraped from logs.
- Keep all existing jobs, cache steps, build commands, shared-library checks, uploads, and host checks in place.

Current rolling baseline:
- Main Rust ARM run 28819211229 at a114896878d48c1318c7a8c3ff02a7fea67c1d28.
- Timings: workflow about 2m40s; host-dev about 1m26s; ci-clippy about 22s; agent-arm-build about 56s; release about 2m18s with Build ARM binary about 1m45s; release-video about 2m36s with Build ARM binary about 1m49s.
- Prior green baseline was run 28817249872 at c629c66ea1b5a64a913f2410957875e44384e8d2, created 2026-07-06T19:21:43Z and completed 2026-07-06T19:24:27Z. Its timings were host-dev 1m30s; ci-clippy 23s; agent-arm-build 47s; release 2m39s with Build ARM binary about 1m53s; release-video 2m33s with Build ARM binary about 1m56s.

Measured PR runs:
- 28816953003 at 11672f7: failed from inherited host-dev Clippy MagiK agent issue; ARM jobs green. Partial timing only.
- 28817172636 at add408c: failed from inherited host-dev Clippy MagiK agent issue; ARM jobs green. Verified ci_timing_tsv payload values, but simple grep also matched shell echo command lines.
- 28817437098 at e260526: full green PR run before the rebase. Timings: host-dev 1m24s; ci-clippy 21s; agent-arm-build 54s with Build ARM agent 31s; release 2m28s with Build ARM binary 1m51s / payload duration_seconds=111; release-video 2m32s with Build ARM binary 1m56s / payload duration_seconds=116. The ci_timing_tsv scrape returned exactly one payload row per ARM build job.

Post-rebase validation:
- Branch was rebased onto c629c66.
- Workflow_dispatch run 28817676581 on head 0107957 completed successfully. Record this as manual validation, not PR-status validation. Timings: host-dev about 1m24s; ci-clippy completed successfully with stale-looking JSON status noise; agent-arm-build about 56s with Build ARM agent about 29s; release about 2m38s with Build ARM binary about 1m53s; release-video about 2m48s with Build ARM binary about 2m01s.
- Pull_request run 28817761780 completed successfully on its first attempt, but GitHub briefly left agent-arm-build with status in_progress despite conclusion success and a completed timestamp. A no-op rerun of the same pull_request run cleared that status reporting issue without changing the branch.
- Settled pull_request rerun 28817761780 is the current clean PR check validation. Timings: host-dev 1m20s; ci-clippy 28s; agent-arm-build 57s with Build ARM agent payload duration_seconds=27; release 2m30s with Build ARM binary payload duration_seconds=114; release-video 2m27s with Build ARM binary payload duration_seconds=107. gh pr checks, PR metadata, and raw Actions jobs all report completed/success.

Why this should not weaken CI:
- The workflow still runs the same host-dev, ci-clippy, agent-arm-build, release, and release-video jobs.
- Existing build commands are unchanged apart from wall-clock wrappers around the same commands.
- Existing artifact uploads and shared-library checks remain unchanged.
- The added output is summary/log instrumentation for auditability of future timing comparisons.

Review note:
- Parked draft/lab evidence only. The run-to-run timing spread above should not be treated as proof of a CI-speed win. The newer main baseline at a114896 makes strict candidate comparisons harder for PR #15 and host-only cleanup lanes.