### PR TITLE
ci: ARM cache lab

### DIFF
--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -175,8 +175,10 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-prune-build-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
+            target-arm-prune-build-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 
@@ -216,6 +218,24 @@ jobs:
           name: binary-size-${{ matrix.name }}
           path: build/binary-size.tsv
           if-no-files-found: error
+
+      - name: Prune ARM cache build directories
+        shell: bash
+        run: |
+          for dir in \
+            "magik-gui/target/${{ matrix.profile }}" \
+            "magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}"
+          do
+            if [ -d "$dir/build" ]; then
+              rm -rf "$dir/build"
+            fi
+            if [ -d "$dir" ]; then
+              echo "::group::pruned $dir"
+              du -sh "$dir"
+              find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20
+              echo "::endgroup::"
+            fi
+          done
 
   agent-arm-build:
     name: agent-arm-build

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -172,9 +172,14 @@ jobs:
       - name: Cache ARM build outputs
         uses: actions/cache@v6
         with:
-          path: magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          path: |
+            magik-gui/target/${{ matrix.profile }}
+            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
+          key: target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-${{ matrix.name }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
+            target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-${{ matrix.name }}-
+            target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.profile }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -169,13 +169,21 @@ jobs:
           path: magik-gui/target/ffmpeg-minimal/armv7
           key: ffmpeg-minimal-${{ runner.os }}-8.1.2-${{ hashFiles('magik-gui/scripts/build-minimal-ffmpeg.sh', 'magik-gui/Dockerfile.cross-armv7') }}
 
-      - name: Cache ARM build outputs
+      - name: Cache ARM native build outputs
         uses: actions/cache@v6
         with:
           path: magik-gui/target/${{ matrix.profile }}
-          key: target-arm-native-profile-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-native-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-native-profile-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-native-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+
+      - name: Cache ARM target build outputs
+        uses: actions/cache@v6
+        with:
+          path: magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
+          key: target-arm-cross-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          restore-keys: |
+            target-arm-cross-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
 
       - name: Build ARM binary
         run: magik-gui/build-arm.sh ${{ matrix.args }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -169,20 +169,7 @@ jobs:
           path: magik-gui/target/ffmpeg-minimal/armv7
           key: ffmpeg-minimal-${{ runner.os }}-8.1.2-${{ hashFiles('magik-gui/scripts/build-minimal-ffmpeg.sh', 'magik-gui/Dockerfile.cross-armv7') }}
 
-      - name: Restore ARM build outputs
-        if: github.event_name == 'pull_request'
-        uses: actions/cache/restore@v6
-        with:
-          path: |
-            magik-gui/target/${{ matrix.profile }}
-            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
-          restore-keys: |
-            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
-            target-arm-${{ runner.os }}-${{ matrix.name }}-
-
       - name: Cache ARM build outputs
-        if: github.event_name != 'pull_request'
         uses: actions/cache@v6
         with:
           path: |
@@ -192,6 +179,23 @@ jobs:
           restore-keys: |
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
+
+      - name: Measure ARM cache footprint
+        shell: bash
+        run: |
+          for dir in \
+            "magik-gui/target/${{ matrix.profile }}" \
+            "magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}"
+          do
+            if [ -d "$dir" ]; then
+              echo "::group::$dir"
+              du -sh "$dir"
+              find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20
+              echo "::endgroup::"
+            else
+              echo "missing $dir"
+            fi
+          done
 
       - name: Build ARM binary
         run: magik-gui/build-arm.sh ${{ matrix.args }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -172,9 +172,7 @@ jobs:
       - name: Cache ARM build outputs
         uses: actions/cache@v6
         with:
-          path: |
-            magik-gui/target/${{ matrix.profile }}
-            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
+          path: magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
           key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -175,8 +175,10 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-prune-rmeta-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
+            target-arm-prune-rmeta-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 
@@ -244,6 +246,22 @@ jobs:
           name: binary-size-${{ matrix.name }}
           path: build/binary-size.tsv
           if-no-files-found: error
+
+      - name: Prune ARM cache rmeta metadata
+        shell: bash
+        run: |
+          for dir in \
+            "magik-gui/target/${{ matrix.profile }}" \
+            "magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}"
+          do
+            if [ -d "$dir/deps" ]; then
+              echo "::group::prune rmeta $dir/deps"
+              find "$dir/deps" -type f -name '*.rmeta' -print -delete | wc -l
+              du -sh "$dir"
+              find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20
+              echo "::endgroup::"
+            fi
+          done
 
   agent-arm-build:
     name: agent-arm-build

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -175,11 +175,10 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-${{ matrix.name }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-${{ matrix.name }}-
-            target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.profile }}-
+            target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -169,21 +169,29 @@ jobs:
           path: magik-gui/target/ffmpeg-minimal/armv7
           key: ffmpeg-minimal-${{ runner.os }}-8.1.2-${{ hashFiles('magik-gui/scripts/build-minimal-ffmpeg.sh', 'magik-gui/Dockerfile.cross-armv7') }}
 
-      - name: Cache ARM native build outputs
-        uses: actions/cache@v6
+      - name: Restore ARM build outputs
+        if: github.event_name == 'pull_request'
+        uses: actions/cache/restore@v6
         with:
-          path: magik-gui/target/${{ matrix.profile }}
-          key: target-arm-native-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          path: |
+            magik-gui/target/${{ matrix.profile }}
+            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
+          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-native-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.name }}-
 
-      - name: Cache ARM target build outputs
+      - name: Cache ARM build outputs
+        if: github.event_name != 'pull_request'
         uses: actions/cache@v6
         with:
-          path: magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-cross-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          path: |
+            magik-gui/target/${{ matrix.profile }}
+            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
+          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-cross-split-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-${{ runner.os }}-${{ matrix.name }}-
 
       - name: Build ARM binary
         run: magik-gui/build-arm.sh ${{ matrix.args }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -175,10 +175,8 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-prune-rmeta-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-prune-rmeta-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
-            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 
@@ -246,22 +244,6 @@ jobs:
           name: binary-size-${{ matrix.name }}
           path: build/binary-size.tsv
           if-no-files-found: error
-
-      - name: Prune ARM cache rmeta metadata
-        shell: bash
-        run: |
-          for dir in \
-            "magik-gui/target/${{ matrix.profile }}" \
-            "magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}"
-          do
-            if [ -d "$dir/deps" ]; then
-              echo "::group::prune rmeta $dir/deps"
-              find "$dir/deps" -type f -name '*.rmeta' -print -delete | wc -l
-              du -sh "$dir"
-              find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20
-              echo "::endgroup::"
-            fi
-          done
 
   agent-arm-build:
     name: agent-arm-build

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -175,12 +175,7 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
-          restore-keys: |
-            target-arm-${{ runner.os }}-${{ matrix.profile }}-
-            target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ matrix.features }}-
-            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
-            target-arm-${{ runner.os }}-${{ matrix.name }}-
+          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
 
       - name: Build ARM binary
         run: magik-gui/build-arm.sh ${{ matrix.args }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -183,20 +183,21 @@ jobs:
       - name: Measure ARM cache payload
         shell: bash
         run: |
+          set +e
           for dir in \
             "magik-gui/target/${{ matrix.profile }}" \
             "magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}"
           do
             if [ -d "$dir" ]; then
               echo "::group::$dir"
-              du -sh "$dir"
-              find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20
+              du -sh "$dir" || true
+              find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20 || true
               echo "::endgroup::"
 
               for child in deps build; do
                 if [ -d "$dir/$child" ]; then
                   echo "::group::$dir/$child file payload"
-                  find "$dir/$child" -type f -printf '%s %p\n' | sort -nr | head -30
+                  find "$dir/$child" -type f -printf '%s %p\n' | sort -nr | head -30 || true
                   find "$dir/$child" -type f -printf '%f %s\n' | awk '
                     {
                       name=$1
@@ -214,7 +215,7 @@ jobs:
                         printf "%12d %8d %s\n", bytes[ext], count[ext], ext
                       }
                     }
-                  ' | sort -nr | head -20
+                  ' | sort -nr | head -20 || true
                   echo "::endgroup::"
                 fi
               done
@@ -222,6 +223,7 @@ jobs:
               echo "missing $dir"
             fi
           done
+          exit 0
 
       - name: Build ARM binary
         run: magik-gui/build-arm.sh ${{ matrix.args }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -172,16 +172,10 @@ jobs:
       - name: Cache ARM build outputs
         uses: actions/cache@v6
         with:
-          path: |
-            magik-gui/target/${{ matrix.profile }}/.fingerprint
-            magik-gui/target/${{ matrix.profile }}/build
-            magik-gui/target/${{ matrix.profile }}/deps
-            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/.fingerprint
-            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/build
-            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/deps
-          key: target-arm-intermediates-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          path: magik-gui/target/${{ matrix.profile }}
+          key: target-arm-native-profile-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-intermediates-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
+            target-arm-native-profile-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
 
       - name: Build ARM binary
         run: magik-gui/build-arm.sh ${{ matrix.args }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -175,14 +175,12 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-prune-build-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-prune-build-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
-            target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 
-      - name: Measure ARM cache footprint
+      - name: Measure ARM cache payload
         shell: bash
         run: |
           for dir in \
@@ -194,6 +192,32 @@ jobs:
               du -sh "$dir"
               find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20
               echo "::endgroup::"
+
+              for child in deps build; do
+                if [ -d "$dir/$child" ]; then
+                  echo "::group::$dir/$child file payload"
+                  find "$dir/$child" -type f -printf '%s %p\n' | sort -nr | head -30
+                  find "$dir/$child" -type f -printf '%f %s\n' | awk '
+                    {
+                      name=$1
+                      size=$2
+                      ext="(none)"
+                      if (name ~ /\./) {
+                        ext=name
+                        sub(/^.*\./, ".", ext)
+                      }
+                      bytes[ext]+=size
+                      count[ext]+=1
+                    }
+                    END {
+                      for (ext in bytes) {
+                        printf "%12d %8d %s\n", bytes[ext], count[ext], ext
+                      }
+                    }
+                  ' | sort -nr | head -20
+                  echo "::endgroup::"
+                fi
+              done
             else
               echo "missing $dir"
             fi
@@ -218,24 +242,6 @@ jobs:
           name: binary-size-${{ matrix.name }}
           path: build/binary-size.tsv
           if-no-files-found: error
-
-      - name: Prune ARM cache build directories
-        shell: bash
-        run: |
-          for dir in \
-            "magik-gui/target/${{ matrix.profile }}" \
-            "magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}"
-          do
-            if [ -d "$dir/build" ]; then
-              rm -rf "$dir/build"
-            fi
-            if [ -d "$dir" ]; then
-              echo "::group::pruned $dir"
-              du -sh "$dir"
-              find "$dir" -mindepth 1 -maxdepth 1 -exec du -sh {} + | sort -h | tail -20
-              echo "::endgroup::"
-            fi
-          done
 
   agent-arm-build:
     name: agent-arm-build

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -173,9 +173,15 @@ jobs:
         uses: actions/cache@v6
         with:
           path: |
-            magik-gui/target/${{ matrix.profile }}
-            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+            magik-gui/target/${{ matrix.profile }}/.fingerprint
+            magik-gui/target/${{ matrix.profile }}/build
+            magik-gui/target/${{ matrix.profile }}/deps
+            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/.fingerprint
+            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/build
+            magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}/deps
+          key: target-arm-intermediates-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          restore-keys: |
+            target-arm-intermediates-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
 
       - name: Build ARM binary
         run: magik-gui/build-arm.sh ${{ matrix.args }}


### PR DESCRIPTION
ARM cache lane lab notebook.

Current rolling baseline for timing claims: Rust ARM main run 28817249872 at c629c66ea1b5a64a913f2410957875e44384e8d2, created 2026-07-06T19:21:43Z and completed 19:24:27Z. Baseline jobs: workflow about 2m44s, host-dev 1m30s, ci-clippy 23s, agent-arm-build 47s, release 2m39s with Build ARM binary about 1m53s, release-video 2m33s with Build ARM binary about 1m56s. Fresh main comparison run 28819211229 is also useful: workflow about 2m40s, release about 2m18, release-video about 2m36, release Build ARM binary about 1m45, release-video Build ARM binary about 1m49.

Experiment 1, commit 899fc02 before rebase / 7bc9c67 after rebase: narrowed ARM target cache to only magik-gui/target/armv7-unknown-linux-gnueabihf/release-device. Result: rejected. Run 28816964973 inherited host-dev clippy noise from then-current main; ARM jobs passed but regressed badly: release 3m47s and release-video 3m54s versus the then-baseline about 2m44s/2m43s. Native target artifacts are important for reuse.

Experiment 2, commit f047a12 before rebase / 69111f37 after rebase: profile-first restore-key shape while preserving both target cache paths. Result: no clear 5% win. Green but noisy runs 28817804803 and 28817701194 show release sometimes slightly better, but release-video/full workflow are not: manual 28817701194 had release 2m34 with Build ARM binary 1m49, release-video 3m01 with Build ARM binary 1m53, workflow about 7m31 due queue/stale timing effects. Not a candidate.

Experiment 3, commit c9129be: shared ARM target cache key across release and release-video variants. Result: rejected. Runs 28818105095 and 28818183880 were green but regressed/noisy. Clean manual 28818105095: workflow about 3m27, agent-arm-build 54s, release about 3m21 with Build ARM binary about 2m32, release-video about 3m08 with Build ARM binary about 2m07. PR run 28818183880 was also slower/noisy.

Experiment 4, commit b883bf7: exact ARM target cache hits only; preserved baseline target cache paths and primary key shape, removed ARM target restore-keys. Result: rejected. Run 28818424583 green but slower than baseline: workflow about 2m55, host-dev 1m32, agent-arm-build 46s, release 2m50 with Build ARM binary about 2m06, release-video 2m47 with Build ARM binary about 1m54. Removing restore-keys regressed both release wall time and full workflow wall time.

Experiment 5, commit d8c9a05: new cache namespace for Cargo intermediate directories only (.fingerprint/build/deps under host and arm target profile), avoiding whole-profile target archives. Result: rejected, not just inconclusive cold noise. Run 28818733463 was green but a large ARM regression: workflow about 4m22, host-dev 1m23, agent-arm-build 59s, release about 4m01 with Build ARM binary about 3m24, release-video about 4m17 with Build ARM binary about 3m37. No warm rerun; this cache shape removes too much reusable target output.

Experiment 6, commit 98c6997: cache only the native profile root magik-gui/target/release-device and leave the ARM target profile uncached. Result: rejected. Run 28819074010 was green but much slower than baseline and fresh main: workflow about 4m09, release 3m55 with Build ARM binary 3m19, release-video 4m05 with Build ARM binary 3m37, host-dev 1m18, ci-clippy 22s, agent-arm-build 1m00. This confirms both profile roots matter; no warm rerun.

Experiment 7, commit dc37948: split the two useful ARM build-output roots into separate full-profile caches, one native and one cross target. Result: rejected. Run 28819547912 was cancelled after slow release legs. Release job wall was about 3m49 and Build ARM binary had completed at about 3m22, far slower than fresh main's release Build ARM binary about 1m45. Release-video job wall was about 4m02 and Build ARM binary had already run about 3m31 before cancellation, far slower than fresh main's release-video Build ARM binary about 1m49. Host-dev 1m30, ci-clippy 24s, agent-arm-build 1m07. No warm rerun; pivot away from broad/split ARM target cache shapes with long restore/save/build interactions.

Experiment 8, commit b6450f2: restore the baseline combined ARM target cache on pull_request with actions/cache/restore@v6 so PR runs skip post-job cache saves, while preserving normal actions/cache@v6 restore/save behavior for push and workflow_dispatch. Result: rejected as speed candidate. Run 28819936316 was green: workflow about 2m52, host-dev 1m32, ci-clippy 23s, agent-arm-build 46s, release about 2m34 with Build ARM binary about 1m49, release-video about 2m48 with Build ARM binary about 1m48. The save-skip behavior worked, but did not overcome restore/build overhead versus fresh main run 28819211229: workflow about 2m40, release about 2m18, release-video about 2m36. Additional log evidence: release restored an exact 845 MB ARM target cache in about 14s; release-video restored an exact 1009 MB video cache in about 28s on the PR run, while fresh main restored the same 1009 MB video cache in about 16s. No warm rerun; pivot to cache-footprint isolation.

Experiment 9, commit d27052c: keep baseline ARM target cache behavior, but add a read-only footprint report for both restored ARM target cache roots before Build ARM binary. Result: green diagnostic, not a speed win. Run 28820440092: release 2m49 versus fresh main about 2m18; release-video 2m36, roughly equal to fresh main release-video, but no full-workflow win. Useful footprint evidence: release restored host profile 1.8G (deps 1.7G, build 156M) plus ARM profile 1.1G (deps 995M, build 65M); release-video restored host profile 2.0G (deps 1.8G, build 231M) plus ARM profile 1.5G (deps 1.4G, build 120M).

Experiment 10, commit 253c02e5: create a pruned ARM target cache namespace that falls back to the baseline target cache, then deletes only the two target-profile build/ directories after binary upload and size upload but before the cache post-job save. Result: rejected. First run 28820860985 attempt 1 was green but not a speed win: workflow about 2m51, release 2m31, release-video 2m49, Restore ARM build outputs about 10s/24s, Build ARM binary about 1m51/1m42, prune/post-save about 9-10s. Same-head warm validation attempt 2 was green but much slower than fresh main and slower than attempt 1: release 4m00, release-video 4m09, host-dev 1m18, agent-arm-build 50s, ci-clippy 29s. Likely deleting build/ removed needed build-script or proc-macro state and forced heavy rebuilds. Do not retry this exact pruning shape.

Experiment 11, commits 44e665e and 77f6981: revert to baseline ARM target cache contents and key shape, remove the rejected prune step, and expand the read-only payload report inside deps/ and build/ to list largest files and file-extension byte totals. Result: green diagnostic, not a speed candidate because it intentionally changes only logging. First run 28821631668 failed release/release-video in the diagnostic step before Build ARM binary because `find | sort | head` tripped bash `pipefail` on a broken pipe; host-dev, ci-clippy, and agent-arm-build passed. Commit 77f6981 made the diagnostic best-effort, and run 28821766487 completed green: workflow about 2m31, host-dev 1m27, ci-clippy 21s, agent-arm-build 50s, release 2m21 with Build ARM binary 1m50, release-video 2m27 with Build ARM binary 1m52. This is near or better than fresh-main wall times, but no speed claim because the cache behavior is baseline plus logging.

Experiment 11 payload evidence: restored cache contents are dominated by duplicated deps metadata and archives. Release host profile: 1.8G total, deps 1.7G, build 156M; deps include about 1007M `.rlib`, 441M `.rmeta`, 285M `.so`, and 3.5M `.d`. Release ARM profile: 1.1G total, deps 995M, build 65M; deps include about 555M `.rlib`, 390M `.rmeta`, 104M extensionless files, and 1.9M `.d`. Release-video host profile: 2.0G total, deps 1.8G, build 231M; deps include about 1107M `.rlib`, 479M `.rmeta`, 285M `.so`, and 3.7M `.d`. Release-video ARM profile: 1.5G total, deps 1.4G, build 120M; deps include about 746M `.rlib`, 534M `.rmeta`, 181M extensionless files, and 2.3M `.d`. Whole build/ pruning was harmful, so the next pruning experiment should avoid build/ and test a narrower deps metadata payload boundary.

Experiment 12, commit 6b41577: create a pruned cache namespace that keeps baseline restore fallback but deletes only `*.rmeta` files from the two restored ARM cache paths after binary upload/size upload/shared-library check and before cache save. Hypothesis: `.rmeta` files account for roughly 830M in release and 1.0G in release-video restored payload; if `.rlib` metadata is enough for the warm final binary build, this can cut cache bytes without the build-script/proc-macro damage caused by deleting build/. If warm validation rebuilds heavily, reject quickly and do not retry this exact `*.rmeta` pruning shape.

Experiment 12 attempt 1, run 28822132871: green first-pass cache-creation run, not a speed win by itself. Compared with fresh main run 28819211229 (workflow about 2m40, release about 2m18, release-video about 2m36), this was slower: workflow about 2m52 (20:46:27-20:49:19), host-dev 1m21, ci-clippy 27s, agent-arm-build 45s, release 2m46 with ARM cache restore 21s, payload measurement under 1s, Build ARM binary 1m51, prune step about 1s, post-cache save 7s; release-video 2m48 with FFmpeg 1s, ARM cache restore 13s, payload measurement about 1s, Build ARM binary 1m59, prune step under 1s, post-cache save 9s. The prune ran after shared-library check and both binary/size uploads, and post-cache save succeeded. Saved pruned cache sizes were 610,531,345 bytes for release and 736,322,323 bytes for release-video. Same-head warm validation is required before accepting or rejecting.

Decision rule: one hypothesis per push; require comparable warm runs before claims; ask for review only if about 5% faster for workflow or slowest required job without coverage loss. Continue iterating until coordinator/user stops the lane.
