### PR TITLE
CI linker/toolchain lab

### DIFF
--- a/magik-gui/Dockerfile.cross-armv7
+++ b/magik-gui/Dockerfile.cross-armv7
@@ -4,7 +4,6 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         ca-certificates \
         gcc \
-        g++-arm-linux-gnueabihf \
         gcc-arm-linux-gnueabihf \
         libc6-dev-armhf-cross \
         libclang-dev \
@@ -14,7 +13,6 @@ RUN apt-get update \
 
 ENV AR_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-ar
 ENV CC_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-gcc
-ENV CXX_armv7_unknown_linux_gnueabihf=arm-linux-gnueabihf-g++
 ENV CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc
 ENV LIBCLANG_PATH=/usr/lib/llvm-10/lib
 ENV BINDGEN_EXTRA_CLANG_ARGS="--target=arm-linux-gnueabihf --sysroot=/usr/arm-linux-gnueabihf -I/usr/arm-linux-gnueabihf/include"


### PR DESCRIPTION
Toolchain/Linker CI-speed lab for Rust ARM. Scope: .github/workflows/rust-arm.yml plus ARM toolchain/linker/setup helpers only; no MiSTer/device commands.\n\nRolling baseline for timing claims: main Rust ARM run 28817249872 at c629c66ea1b5a64a913f2410957875e44384e8d2, created 2026-07-06T19:21:43Z and completed 19:24:27Z. Jobs: host-dev 1m30s, ci-clippy 23s, agent-arm-build 47s, release 2m39s with Build ARM binary about 1m53s, release-video 2m33s with Build ARM binary about 1m56s. Full workflow wall is about 2m44s.\n\nLab notebook is in PR comments. Rejected so far: lld via GCC driver failed ARM release jobs; GNU gold linked but regressed ARM release jobs; skipping Docker preflight regressed release-video/full wall; building only the frontend bin target regressed release-video/full wall; combined container readelf checks improved one branch run but PR release-video/full wall still regressed. Current head tests preferring host GNU readelf for the ARM shared-library check while preserving the GLIBC_2.31 and dynamic FFmpeg guards.\n\nDecision rule: require green Rust ARM plus comparable warm evidence against run 28817249872. If the current experiment does not clearly improve workflow or the slowest required job without compatibility loss, record and replace it.