### PR TITLE
CI host duplication lab

### DIFF
--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Check host tools
         run: scripts/dev-rust host-tools
 
+      - name: Check MagiK agent
+        run: cargo check --manifest-path tools/magik-agent/Cargo.toml
+
       - name: Clippy host tools
         run: cargo clippy --manifest-path tools/mister/Cargo.toml --all-targets -- -D warnings
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -71,9 +71,6 @@ jobs:
       - name: Check host tools
         run: scripts/dev-rust host-tools
 
-      - name: Check MagiK agent
-        run: cargo check --manifest-path tools/magik-agent/Cargo.toml
-
       - name: Clippy host tools
         run: cargo clippy --manifest-path tools/mister/Cargo.toml --all-targets -- -D warnings
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -39,17 +39,6 @@ jobs:
           restore-keys: |
             cargo-host-${{ runner.os }}-
 
-      - name: Cache host build outputs
-        uses: actions/cache@v6
-        with:
-          path: |
-            magik-gui/target/debug
-            tools/magik-agent/target/debug
-            tools/mister/target/debug
-          key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
-          restore-keys: |
-            target-host-${{ runner.os }}-
-
       - name: Format
         working-directory: magik-gui
         run: cargo fmt --check

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -171,9 +171,8 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
-            target-arm-${{ runner.os }}-${{ matrix.profile }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           path: |
             magik-gui/target/debug
+            magik-gui/catalog/target/debug
             tools/magik-agent/target/debug
             tools/mister/target/debug
           key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -64,9 +64,9 @@ jobs:
       - name: Clippy catalog crate
         run: cargo clippy --manifest-path magik-gui/catalog/Cargo.toml --all-targets -- -D warnings
 
-      - name: Check host logic
+      - name: Clippy magik-gui host logic
         working-directory: magik-gui
-        run: cargo check --lib --no-default-features
+        run: cargo clippy --lib --no-default-features -- -D warnings
 
       - name: Check host tools
         run: scripts/dev-rust host-tools
@@ -79,42 +79,6 @@ jobs:
 
       - name: Clippy MagiK agent
         run: cargo clippy --manifest-path tools/magik-agent/Cargo.toml --all-targets -- -D warnings
-
-  ci-clippy:
-    name: ci-clippy
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Install Rust toolchain
-        working-directory: magik-gui
-        run: rustup show
-
-      - name: Cache cargo registry
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-clippy-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock') }}
-          restore-keys: |
-            cargo-clippy-${{ runner.os }}-
-            cargo-host-${{ runner.os }}-
-
-      - name: Cache Clippy build outputs
-        uses: actions/cache@v6
-        with:
-          path: magik-gui/target/debug
-          key: target-clippy-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock') }}
-          restore-keys: |
-            target-clippy-${{ runner.os }}-
-            target-host-${{ runner.os }}-
-
-      - name: Clippy magik-gui host logic
-        working-directory: magik-gui
-        run: cargo clippy --lib --no-default-features -- -D warnings
 
   arm-build:
     name: ${{ matrix.name }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -171,8 +171,9 @@ jobs:
           path: |
             magik-gui/target/${{ matrix.profile }}
             magik-gui/target/armv7-unknown-linux-gnueabihf/${{ matrix.profile }}
-          key: target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
+          key: target-arm-${{ runner.os }}-${{ matrix.profile }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/build.rs', 'magik-gui/build-arm.sh', 'magik-gui/Dockerfile.cross-armv7') }}
           restore-keys: |
+            target-arm-${{ runner.os }}-${{ matrix.profile }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-${{ matrix.profile }}-${{ matrix.features }}-
             target-arm-${{ runner.os }}-${{ matrix.name }}-
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           path: |
             magik-gui/target/debug
-            magik-gui/catalog/target/debug
             tools/magik-agent/target/debug
             tools/mister/target/debug
           key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -64,10 +64,6 @@ jobs:
       - name: Clippy catalog crate
         run: cargo clippy --manifest-path magik-gui/catalog/Cargo.toml --all-targets -- -D warnings
 
-      - name: Clippy magik-gui host logic
-        working-directory: magik-gui
-        run: cargo clippy --lib --no-default-features -- -D warnings
-
       - name: Check host tools
         run: scripts/dev-rust host-tools
 
@@ -79,6 +75,42 @@ jobs:
 
       - name: Clippy MagiK agent
         run: cargo clippy --manifest-path tools/magik-agent/Cargo.toml --all-targets -- -D warnings
+
+  ci-clippy:
+    name: ci-clippy
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        working-directory: magik-gui
+        run: rustup show
+
+      - name: Cache cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-clippy-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock') }}
+          restore-keys: |
+            cargo-clippy-${{ runner.os }}-
+            cargo-host-${{ runner.os }}-
+
+      - name: Cache Clippy build outputs
+        uses: actions/cache@v6
+        with:
+          path: magik-gui/target/debug
+          key: target-clippy-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock') }}
+          restore-keys: |
+            target-clippy-${{ runner.os }}-
+            target-host-${{ runner.os }}-
+
+      - name: Clippy magik-gui host logic
+        working-directory: magik-gui
+        run: cargo clippy --lib --no-default-features -- -D warnings
 
   arm-build:
     name: ${{ matrix.name }}


### PR DESCRIPTION
Host duplication lane lab notebook.

Baseline for timing claims: Rust ARM main run 28817249872 at c629c66ea1b5a64a913f2410957875e44384e8d2, created 2026-07-06T19:21:43Z, completed 19:24:27Z. Jobs: workflow wall about 2m44s; host-dev 1m30s; ci-clippy 23s; agent-arm-build 47s; release 2m39s with Build ARM binary about 1m53s; release-video 2m33s with Build ARM binary about 1m56s.

Scope: normal CI means `.github/workflows/rust-arm.yml` only. No MiSTer/device commands. Current steering: keep this host lane to host-dev/host-duplication cleanup or host-only speed work; do not perturb ARM release jobs for this lane.

Current experiment: host-only cache-overhead test.

Hypothesis:

- Keep `ci-clippy` as the isolated magik-gui clippy signal.
- Remove `host-dev`'s duplicate magik-gui `cargo check`.
- Remove `host-dev`'s target build-output cache restore/save. Recent runs showed host target cache restore/post-cache often costs meaningful seconds; if restored objects are not saving enough compile time, dropping this cache can shorten host-dev without touching ARM jobs.
- Keep cargo registry caching and all ARM job definitions unchanged.

Coverage preservation on current head:

- Required magik-gui clippy coverage is preserved exactly in `ci-clippy`: `cargo clippy --manifest-path magik-gui/Cargo.toml --lib --no-default-features -- -D warnings`.
- The removed `host-dev` magik-gui `cargo check --lib --no-default-features` checked the same lib/no-default-features target that `ci-clippy` continues to compile/check with stricter linting.
- Removing a target cache step changes no coverage. It only removes reuse of build artifacts in `host-dev`.
- MagiK-agent coverage is explicit: `cargo check --manifest-path tools/magik-agent/Cargo.toml` and `cargo clippy --manifest-path tools/magik-agent/Cargo.toml --all-targets -- -D warnings` both run in `host-dev`.
- Other host coverage remains in `host-dev`: format, host logic tests, catalog tests, catalog clippy, host tools check, host tools clippy, and MagiK-agent check/clippy. ARM build/release coverage is unchanged.

Rejected/narrowed experiments:

- Folded `ci-clippy` into `host-dev`: preserved coverage and improved host-dev, but did not produce a clean workflow wall-time win; release-video was noisy/regressed in multiple samples. Classified as host-dev-only candidate, not promotable for normal CI wall time.
- Removed `Check MagiK agent`: coverage was plausibly preserved by `Clippy MagiK agent --all-targets`, but it produced no useful host-dev win and the settled run was not a candidate, so the explicit check was restored.
- Added `magik-gui/catalog/target/debug` to host cache: host-dev/release-video regressed, reverted.
- ARM target-cache sharing was considered locally, then abandoned under lane steering before collecting PR evidence; current head has ARM cache keys restored to baseline shape.

Local validation:

- `cargo clippy --manifest-path magik-gui/Cargo.toml --lib --no-default-features -- -D warnings` passed.
- `cargo check --manifest-path tools/magik-agent/Cargo.toml` passed.
- `cargo clippy --manifest-path tools/magik-agent/Cargo.toml --all-targets -- -D warnings` passed.
- `git diff --check` passed.
- Repo pre-commit host suite passed.

CI evidence against rolling baseline 28817249872:

| Run | Head | Diff | Result | Workflow wall | host-dev | ci-clippy | agent-arm-build | release | release-video | Notes |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 28818265400 | f14590a1 | Fold magik-gui clippy into host-dev; remove `ci-clippy`; reverted target-cache experiment; still had `Check MagiK agent` | green | about 3m43s from run created/updated; job fanout was delayed | 1m28s | removed | 1m04s | 2m21s, Build ARM 1m48s | 2m31s, Build ARM 1m55s | Release/release-video better than baseline, but workflow wall not comparable because jobs started at different times. |
| 28818332980 attempt 1 | 77cfb12e | Also remove duplicate `Check MagiK agent` | green | about 2m47s | 1m30s | removed | 54s | about 2m23s, Build ARM 1m53s | about 2m31s, Build ARM 1m57s | Promising ARM/release-video sample, but workflow wall slightly worse than baseline. |
| 28818332980 attempt 2 | 77cfb12e | Same as attempt 1 | green | noisy delayed/rerun scheduling; job span about 2m56s | 1m29s | removed | 51s | 2m21s, Build ARM 1m50s | 2m55s, Build ARM 1m59s | PR checks reported normally, but release-video regressed; not promotable. |
| 28818908345 | c5268029 | Restore explicit `Check MagiK agent`; only ci-clippy fold | green | about 2m51s | 1m18s | removed | 48s | 2m35s, Build ARM 1m50s | 2m48s, Build ARM 1m53s | Host-dev-only candidate, not promotable for normal CI wall time; release-video regressed vs 2m33s baseline. |
| 28819179743 attempt 1 | a557482c | Restore `ci-clippy`; remove only host-dev `Check host logic` | green | about 2m44s | 1m19s | 24s | 53s | 2m39s, Build ARM 1m51s | 2m35s, Build ARM 1m58s | Clean sample but not a speed win: wall roughly equals baseline and release-video is +2s. |
| 28819179743 attempt 2 | a557482c | Same as attempt 1 | green | about 3m26s job span | 1m27s | 28s | 1m11s | 2m30s, Build ARM 1m50s | 3m25s, Build ARM 2m22s | Cleanup-only/noisy; release-video regressed badly. |
| pending | bd742c2 | Host-only: remove host-dev target cache restore/save, keep isolated ci-clippy layout | pending | pending | pending | pending | pending | pending | pending | Tests whether target cache overhead was hiding the host-dev cleanup. |

Current interpretation:

- The isolated `ci-clippy` layout is not a normal CI speed candidate by itself; it is host-dev cleanup/simplification.
- Current head asks a stricter host-only question: can host-dev become materially faster by avoiding target-cache restore/save overhead, without changing coverage or ARM jobs?
