### PR TITLE
ci: host pipeline lab

### DIFF
--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -68,6 +68,40 @@ jobs:
         working-directory: magik-gui
         run: cargo check --lib --no-default-features
 
+  host-tools:
+    name: host-tools
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        working-directory: magik-gui
+        run: rustup show
+
+      - name: Cache cargo registry
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-host-tools-${{ runner.os }}-${{ hashFiles('tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
+          restore-keys: |
+            cargo-host-tools-${{ runner.os }}-
+            cargo-host-${{ runner.os }}-
+
+      - name: Cache host tools build outputs
+        uses: actions/cache@v6
+        with:
+          path: |
+            tools/magik-agent/target/debug
+            tools/mister/target/debug
+          key: target-host-tools-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
+          restore-keys: |
+            target-host-tools-${{ runner.os }}-
+            target-host-${{ runner.os }}-
+
       - name: Check host tools
         run: scripts/dev-rust host-tools
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: cargo-host-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
+          key: cargo-host-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock', 'magik-gui/catalog/Cargo.lock') }}
           restore-keys: |
             cargo-host-${{ runner.os }}-
 
@@ -44,9 +44,7 @@ jobs:
         with:
           path: |
             magik-gui/target/debug
-            tools/magik-agent/target/debug
-            tools/mister/target/debug
-          key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
+          key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/catalog/Cargo.lock') }}
           restore-keys: |
             target-host-${{ runner.os }}-
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -54,6 +54,12 @@ jobs:
         working-directory: magik-gui
         run: cargo fmt --check
 
+      - name: Check MagiK agent
+        run: cargo check --manifest-path tools/magik-agent/Cargo.toml
+
+      - name: Clippy MagiK agent
+        run: cargo clippy --manifest-path tools/magik-agent/Cargo.toml --all-targets -- -D warnings
+
       - name: Test host logic
         working-directory: magik-gui
         run: cargo test --lib --no-default-features
@@ -68,52 +74,11 @@ jobs:
         working-directory: magik-gui
         run: cargo check --lib --no-default-features
 
-  host-tools:
-    name: host-tools
-    needs: host-dev
-    runs-on: ubuntu-24.04
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      - name: Install Rust toolchain
-        working-directory: magik-gui
-        run: rustup show
-
-      - name: Cache cargo registry
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-          key: cargo-host-tools-${{ runner.os }}-${{ hashFiles('tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
-          restore-keys: |
-            cargo-host-tools-${{ runner.os }}-
-            cargo-host-${{ runner.os }}-
-
-      - name: Cache host tools build outputs
-        uses: actions/cache@v6
-        with:
-          path: |
-            tools/magik-agent/target/debug
-            tools/mister/target/debug
-          key: target-host-tools-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
-          restore-keys: |
-            target-host-tools-${{ runner.os }}-
-            target-host-${{ runner.os }}-
-
       - name: Check host tools
         run: scripts/dev-rust host-tools
 
-      - name: Check MagiK agent
-        run: cargo check --manifest-path tools/magik-agent/Cargo.toml
-
       - name: Clippy host tools
         run: cargo clippy --manifest-path tools/mister/Cargo.toml --all-targets -- -D warnings
-
-      - name: Clippy MagiK agent
-        run: cargo clippy --manifest-path tools/magik-agent/Cargo.toml --all-targets -- -D warnings
 
   ci-clippy:
     name: ci-clippy

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -70,6 +70,7 @@ jobs:
 
   host-tools:
     name: host-tools
+    needs: host-dev
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     steps:

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: cargo-host-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock', 'magik-gui/catalog/Cargo.lock') }}
+          key: cargo-host-${{ runner.os }}-${{ hashFiles('magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
           restore-keys: |
             cargo-host-${{ runner.os }}-
 
@@ -44,7 +44,9 @@ jobs:
         with:
           path: |
             magik-gui/target/debug
-          key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'magik-gui/catalog/Cargo.lock') }}
+            tools/magik-agent/target/debug
+            tools/mister/target/debug
+          key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
           restore-keys: |
             target-host-${{ runner.os }}-
 

--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -44,8 +44,6 @@ jobs:
         with:
           path: |
             magik-gui/target/debug
-            tools/magik-agent/target/debug
-            tools/mister/target/debug
           key: target-host-${{ runner.os }}-${{ hashFiles('magik-gui/rust-toolchain.toml', 'magik-gui/Cargo.lock', 'tools/magik-agent/Cargo.lock', 'tools/mister/Cargo.lock') }}
           restore-keys: |
             target-host-${{ runner.os }}-


### PR DESCRIPTION
## Host Pipeline Lab

Rolling baseline for timing claims is now the newer green Rust ARM main run:
- Run: 28817249872
- Commit: c629c66ea1b5a64a913f2410957875e44384e8d2
- Created: 2026-07-06T19:21:43Z, completed 19:24:27Z
- Jobs: host-dev 1m30s, ci-clippy 23s, agent-arm-build 47s, release 2m39s, release-video 2m33s
- Build ARM binary: release about 1m53s, release-video about 1m56s

Earlier baseline while main was red:
- Run: 28805364342
- Commit: f40923e6ad9eae3d48735742975e612023384ad5
- Jobs: host-dev 1m25s, ci-clippy 25s, agent-arm-build 1m00s, release 2m44s, release-video 2m43s

Main was temporarily red in host-dev at Clippy MagiK agent on runs 28814024523 and 28816675025, so inherited MagiK-agent clippy failures are not performance results.

## Experiment 1: split host tool checks

Hypothesis: moving host-tool and MagiK-agent checks out of serial host-dev into a parallel host-tools job preserves all host gates while reducing the slowest host-side feedback path.

Commit: 5cb52a8 ci: split host tool checks
Run: 28817381899

Local validation:
- Parsed .github/workflows/rust-arm.yml with Ruby YAML loader.
- Pre-commit host gates passed locally, including fmt, host logic tests, catalog tests, catalog clippy, host logic check, host tool checks, MagiK agent check, host tool clippy, and MagiK agent clippy.

CI result:
- Green.
- host-dev 1m16s plus separate host-tools 53s.
- ci-clippy 22s, agent-arm-build 50s, release 2m32s, release-video 2m48s.
- Promising for host feedback versus rolling baseline host-dev 1m30s, but not a full workflow win because release-video was slower than baseline and total wall time is not clearly improved.

## Experiment 2: narrow host-dev caches after split

Hypothesis: after moving tool checks to host-tools, host-dev can restore/save only GUI/catalog target outputs and use GUI/catalog lockfiles for its cargo key, reducing cache overhead without changing coverage.

Commit: 307c68a ci: narrow host dev caches
Run: 28817636318

CI result:
- Not kept.
- host-dev 1m24s, ci-clippy 21s, agent-arm-build 46s, release 2m44s.
- PR/GitHub metadata stayed incomplete for host-tools and release-video even though the run object concluded success, so this run is not suitable for wall-time claims.
- The available signal is worse than Experiment 1 for host-dev and worse than rolling baseline for release, so revert/replace.

## Experiment 3: restore split-only shape for repeat

Hypothesis: the original split-only shape is the cleaner candidate; revert Experiment 2 and rerun to get a comparable repeat against the rolling baseline without the cache-trim regression.

Commit: cf0a006 Revert ci: narrow host dev caches
Run: 28817798009

CI result:
- Green.
- host-dev 1m23, host-tools 31s, agent-arm-build 47s, release 2m28s, release-video 2m53s, workflow about 2m59s.
- Host feedback repeated better than rolling baseline host-dev 1m30s, and release improved, but release-video was slower again, so this split-only scheduling is not clean under the release-video guardrail.

## Experiment 4: run host-tools after host-dev

Hypothesis: keep host-dev as the fast host feedback job, but make host-tools depend on host-dev so the additional host-tools runner does not join the initial concurrency burst with the ARM release jobs. Coverage remains unchanged; release-video is the guardrail.

Commit: 3e61609 ci: schedule host tools after host dev
Run: 28818163134

CI result:
- Green.
- host-dev 1m12, ci-clippy 22s, agent-arm-build 48s, release 2m32s, release-video 2m37s, host-tools 59s after host-dev, workflow about 3m06.
- Better release-video than Experiment 3 but still slower than baseline 2m33, and total wall time regressed because host-tools became the final required job. Not a merge candidate.

## Experiment 5: single host-dev with faster fail order

Hypothesis: avoid adding required jobs or extra initial concurrency. Restore the single host-dev job shape, but reorder checks so cheap/failure-prone host signals run earlier while preserving every required gate. This targets host feedback ergonomics without risking release-video contention from new jobs.

Commit: 4e6edc5 ci: keep host checks in one job
Run: 28818514331 attempt 1

CI result:
- Green.
- Workflow 2m34, host-dev 1m29, ci-clippy 27s, agent-arm-build 56s, release 2m21, release-video 2m30.
- Fast but non-causal for ARM wall time: this diff only reorders checks inside host-dev. It does not change ARM release/release-video work, cache keys, or scheduling, so the release/release-video speedup is likely run/cache variance rather than caused by the experiment.
- Host-dev duration is neutral versus rolling baseline 1m30, but MagiK-agent check/clippy now run early inside host-dev.
- Not promoted as a CI-speed candidate on this single fast run.

## Experiment 5 repeat

Same commit/shape as Experiment 5, rerun unchanged for warm comparability and variance check.

Run: 28818514331 attempt 2

CI result:
- Green.
- Workflow about 2m41, host-dev 1m24, ci-clippy 28s, agent-arm-build 46s, release 2m25, release-video 2m37.
- Confirms attempt 1 ARM speed was noisy/non-causal. Workflow is slightly faster than baseline, but release-video misses the 2m33 guardrail. Not a merge candidate as a CI-speed change.

## Experiment 6: narrow single host-dev target cache

Hypothesis: keep the single required host-dev job, but remove tool target directories from the host-dev target cache after moving MagiK-agent checks earlier. This may reduce initial host cache transfer contention against ARM caches without adding jobs or dropping coverage. Guardrail remains release-video and workflow wall time.

Commit: pending.
Run: pending.