### PR TITLE
Add private Quartus GHCR image workflow

### DIFF
--- a/.github/workflows/quartus-ghcr-image.yml
+++ b/.github/workflows/quartus-ghcr-image.yml
@@ -1,0 +1,88 @@
+name: Quartus GHCR Image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/nigelbreslaw/mister-magik-quartus-lite
+
+jobs:
+  build:
+    name: Build and publish Quartus image
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+
+    steps:
+      - name: Checkout MagiK repo
+        uses: actions/checkout@v4
+
+      - name: Verify installer URL secrets are present
+        env:
+          QUARTUS_RUN_URL: ${{ secrets.QUARTUS_17_0_RUN_URL }}
+          CYCLONEV_QDZ_URL: ${{ secrets.QUARTUS_17_0_CYCLONEV_QDZ_URL }}
+        run: |
+          set -euo pipefail
+          test -n "$QUARTUS_RUN_URL"
+          test -n "$CYCLONEV_QDZ_URL"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: containers/quartus-lite-17.0
+          file: containers/quartus-lite-17.0/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:17.0.0.595-cyclonev-ubuntu18
+            ${{ env.IMAGE_NAME }}:17.0-cyclonev-ubuntu18
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          secrets: |
+            quartus_run_url=${{ secrets.QUARTUS_17_0_RUN_URL }}
+            cyclonev_qdz_url=${{ secrets.QUARTUS_17_0_CYCLONEV_QDZ_URL }}
+
+      - name: Pull pushed digest for smoke test
+        run: docker pull "${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+
+      - name: Smoke test Quartus tools
+        run: |
+          set -euo pipefail
+          image="${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+          docker run --platform linux/amd64 --rm "$image" test -x /opt/intelFPGA_lite/17.0/quartus/bin/quartus_sh
+          docker run --platform linux/amd64 --rm "$image" quartus_sh --version
+          docker run --platform linux/amd64 --rm "$image" quartus_map --version
+
+      - name: Report image details
+        run: |
+          set -euo pipefail
+          image="${IMAGE_NAME}@${{ steps.build.outputs.digest }}"
+          size_bytes="$(docker image inspect "$image" --format '{{.Size}}')"
+          size_human="$(numfmt --to=iec --suffix=B "$size_bytes")"
+          {
+            echo "### Quartus GHCR image"
+            echo
+            echo "- Image: \`$IMAGE_NAME\`"
+            echo "- Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "- Digest pull: \`$image\`"
+            echo "- Tags:"
+            echo "  - \`17.0.0.595-cyclonev-ubuntu18\`"
+            echo "  - \`17.0-cyclonev-ubuntu18\`"
+            echo "  - \`sha-${{ github.sha }}\`"
+            echo "- Local pulled size: \`$size_human\` (\`$size_bytes\` bytes)"
+            echo
+            echo "Manual release gate: confirm the GHCR package visibility is Private before wiring other workflows to this image."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/containers/quartus-lite-17.0/Dockerfile
+++ b/containers/quartus-lite-17.0/Dockerfile
@@ -1,0 +1,110 @@
+# syntax=docker/dockerfile:1.7
+FROM ubuntu:18.04
+
+LABEL org.opencontainers.image.source="https://github.com/NigelBreslaw/MiSTer-MagiK"
+LABEL org.opencontainers.image.description="MiSTer MagiK Quartus Prime Lite 17.0 Cyclone V build image"
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    bash ca-certificates curl file make perl procps python3 strace tar gzip xz-utils locales \
+    libc6-i386 lib32stdc++6 lib32z1 \
+    libfontconfig1 libfreetype6 libglib2.0-0 libice6 libncurses5 libsm6 \
+    libx11-6 libxau6 libxdmcp6 libxext6 libxft2 libxi6 libxrender1 libxt6 \
+    libxtst6 \
+  && locale-gen en_US.UTF-8 \
+  && rm -rf /var/lib/apt/lists/*
+
+ENV LC_ALL=en_US.UTF-8
+ENV LANG=en_US.UTF-8
+ENV PATH=/opt/intelFPGA_lite/17.0/quartus/bin:$PATH
+
+RUN --mount=type=secret,id=quartus_run_url,required=true \
+    --mount=type=secret,id=cyclonev_qdz_url,required=true \
+    bash <<'EOF'
+set -euo pipefail
+
+install_dir=/opt/intelFPGA_lite/17.0
+payload_dir=/tmp/quartus-installer
+quartus_run="$payload_dir/QuartusLiteSetup-17.0.0.595-linux.run"
+cyclonev_qdz="$payload_dir/cyclonev-17.0.0.595.qdz"
+quartus_url="$(cat /run/secrets/quartus_run_url)"
+cyclonev_url="$(cat /run/secrets/cyclonev_qdz_url)"
+
+download_payload() {
+  local url="$1"
+  local output="$2"
+  curl \
+    --fail \
+    --location \
+    --show-error \
+    --retry 5 \
+    --retry-all-errors \
+    --retry-delay 10 \
+    --retry-max-time 900 \
+    --connect-timeout 30 \
+    --max-time 900 \
+    --speed-time 120 \
+    --speed-limit 1048576 \
+    --output "$output" \
+    "$url"
+}
+
+verify_sha1() {
+  local path="$1"
+  local expected="$2"
+  local actual
+  actual="$(sha1sum "$path" | awk '{print $1}')"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "sha1 mismatch for $path" >&2
+    echo "expected $expected" >&2
+    echo "actual   $actual" >&2
+    exit 1
+  fi
+}
+
+mkdir -p "$payload_dir" /opt/intelFPGA_lite
+download_payload "$quartus_url" "$quartus_run"
+download_payload "$cyclonev_url" "$cyclonev_qdz"
+verify_sha1 "$quartus_run" "99ccfb15962febceba64de2dc9b28c47e5a3b8df"
+verify_sha1 "$cyclonev_qdz" "2198dedb99866f38d43ff6c029d4bd668e2bbb59"
+
+chmod +x "$quartus_run"
+set +e
+timeout 20m bash -lc '
+  set +e
+  /tmp/quartus-installer/QuartusLiteSetup-17.0.0.595-linux.run --mode unattended --unattendedmodeui minimal --installdir /opt/intelFPGA_lite/17.0 &
+  installer_pid=$!
+  while kill -0 "$installer_pid" 2>/dev/null; do
+    echo "quartus installer still running $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    du -sh /opt/intelFPGA_lite/17.0 2>/dev/null || true
+    sleep 60
+  done &
+  heartbeat_pid=$!
+  wait "$installer_pid"
+  installer_status=$?
+  kill "$heartbeat_pid" 2>/dev/null || true
+  wait "$heartbeat_pid" 2>/dev/null || true
+  exit "$installer_status"
+'
+install_status=$?
+set -e
+
+if [[ "$install_status" -ne 0 && "$install_status" -ne 124 ]]; then
+  echo "Quartus installer failed with status $install_status" >&2
+  exit "$install_status"
+fi
+if [[ "$install_status" -eq 124 ]]; then
+  log="$install_dir/logs/quartus-17.0.0.595-linux-install.log"
+  if [[ ! -f "$log" ]] || ! tail -50 "$log" | grep -q 'Installation completed'; then
+    echo "Quartus installer timed out and completion was not found in $log" >&2
+    exit 124
+  fi
+  echo "Quartus installer timed out after completion; continuing with completed install" >&2
+fi
+
+test -x "$install_dir/quartus/bin/quartus_sh"
+rm -rf "$payload_dir" /tmp/*
+quartus_sh --version
+quartus_map --version
+EOF

--- a/docs/fpga-quartus-ghcr.md
+++ b/docs/fpga-quartus-ghcr.md
@@ -1,0 +1,82 @@
+# Private Quartus GHCR Image
+
+This repo builds the experimental FPGA vblank-latch core with Quartus Prime
+Lite 17.0 and Cyclone V support. The private GHCR image keeps that large,
+licensed toolchain out of normal workflow setup and lets CI pull one pinned
+`linux/amd64` image on GitHub-hosted x64 Linux runners.
+
+Image package:
+
+```text
+ghcr.io/nigelbreslaw/mister-magik-quartus-lite
+```
+
+Tags:
+
+```text
+17.0.0.595-cyclonev-ubuntu18
+17.0-cyclonev-ubuntu18
+sha-<commit>
+```
+
+Use digest-pinned pulls for real builds. Tags are aliases for humans and for
+finding the latest published image, not reproducibility anchors.
+
+## Publishing
+
+Run the `Quartus GHCR Image` workflow manually. It needs these repository
+secrets:
+
+```text
+QUARTUS_17_0_RUN_URL
+QUARTUS_17_0_CYCLONEV_QDZ_URL
+```
+
+The workflow downloads the official installer payloads with BuildKit secrets,
+verifies the known SHA1s, installs Quartus into `/opt/intelFPGA_lite/17.0`,
+pushes the image, pulls the pushed digest, and smoke-tests:
+
+```text
+quartus_sh --version
+quartus_map --version
+test -x /opt/intelFPGA_lite/17.0/quartus/bin/quartus_sh
+```
+
+After the first publish, confirm the GHCR package visibility is `Private` and
+that `NigelBreslaw/MiSTer-MagiK` has Actions access to the package. GitHub's
+relevant docs are:
+
+- [Working with the Container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+- [Configuring a package's access control and visibility](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility)
+
+## Consuming From Another Workflow
+
+Grant package read access and log in to GHCR:
+
+```yaml
+permissions:
+  contents: read
+  packages: read
+
+steps:
+  - uses: docker/login-action@v3
+    with:
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      password: ${{ secrets.GITHUB_TOKEN }}
+
+  - run: docker pull ghcr.io/nigelbreslaw/mister-magik-quartus-lite@sha256:<digest>
+```
+
+Then use the baked install mode in the FPGA build script:
+
+```bash
+QUARTUS_DOCKER_BAKED_INSTALL=1 \
+QUARTUS_DOCKER_IMAGE=ghcr.io/nigelbreslaw/mister-magik-quartus-lite@sha256:<digest> \
+scripts/build-fpga-vblank-latch-core.sh
+```
+
+The existing `.github/workflows/fpga-vblank-latch.yml` still uses the
+cache-mounted installer path. A later consumer PR should replace its
+`prepare-quartus` cache/install job with GHCR login plus digest pull, then run
+the existing RBF build with `QUARTUS_DOCKER_BAKED_INSTALL=1`.

--- a/scripts/build-fpga-vblank-latch-core.sh
+++ b/scripts/build-fpga-vblank-latch-core.sh
@@ -20,6 +20,7 @@ QUARTUS_DOCKER_IMAGE="${QUARTUS_DOCKER_IMAGE:-mister-magik-quartus-runtime:ubunt
 QUARTUS_DOCKER_CPUS="${QUARTUS_DOCKER_CPUS:-8}"
 QUARTUS_DOCKER_MEMORY="${QUARTUS_DOCKER_MEMORY:-12g}"
 QUARTUS_HOST_INSTALL_ROOT="${QUARTUS_HOST_INSTALL_ROOT:-$ROOT/build/quartus-lite-17.0/docker-intelFPGA_lite}"
+QUARTUS_DOCKER_BAKED_INSTALL="${QUARTUS_DOCKER_BAKED_INSTALL:-0}"
 APPLY_PATCH="${MISTER_FPGA_APPLY_PATCH:-1}"
 
 usage() {
@@ -35,6 +36,9 @@ If quartus_sh is not on PATH, the script will try the Docker runtime image
 named by QUARTUS_DOCKER_IMAGE, defaulting to
 mister-magik-quartus-runtime:ubuntu20-amd64. Create that runtime plus the
 mounted Quartus install with scripts/install-quartus-lite-docker.sh.
+
+Set QUARTUS_DOCKER_BAKED_INSTALL=1 when QUARTUS_DOCKER_IMAGE already contains
+Quartus under /opt/intelFPGA_lite/17.0.
 EOF
 }
 
@@ -72,12 +76,19 @@ fi
 QUARTUS_MODE=local
 if command -v quartus_sh >/dev/null 2>&1; then
   QUARTUS_CMD="$(command -v quartus_sh)"
+elif [[ "$QUARTUS_DOCKER_BAKED_INSTALL" = "1" ]] &&
+  command -v docker >/dev/null 2>&1 && docker image inspect "$QUARTUS_DOCKER_IMAGE" >/dev/null 2>&1; then
+  QUARTUS_MODE=docker
+  QUARTUS_CMD="docker:$QUARTUS_DOCKER_IMAGE"
 elif [[ -x "$QUARTUS_HOST_INSTALL_ROOT/17.0/quartus/bin/quartus_sh" ]] &&
   command -v docker >/dev/null 2>&1 && docker image inspect "$QUARTUS_DOCKER_IMAGE" >/dev/null 2>&1; then
   QUARTUS_MODE=docker
   QUARTUS_CMD="docker:$QUARTUS_DOCKER_IMAGE"
 else
-  if [[ ! -x "$QUARTUS_HOST_INSTALL_ROOT/17.0/quartus/bin/quartus_sh" ]]; then
+  if [[ "$QUARTUS_DOCKER_BAKED_INSTALL" = "1" ]]; then
+    echo "missing baked Quartus Docker image: $QUARTUS_DOCKER_IMAGE" >&2
+    echo "pull it first, or unset QUARTUS_DOCKER_BAKED_INSTALL to use a mounted install" >&2
+  elif [[ ! -x "$QUARTUS_HOST_INSTALL_ROOT/17.0/quartus/bin/quartus_sh" ]]; then
     echo "missing mounted Quartus install: $QUARTUS_HOST_INSTALL_ROOT/17.0/quartus/bin/quartus_sh" >&2
   else
     echo "missing Quartus Docker image: $QUARTUS_DOCKER_IMAGE" >&2
@@ -126,6 +137,7 @@ esac
   echo "quartus_strace=${QUARTUS_STRACE:-0}"
   echo "quartus_docker_privileged=${QUARTUS_DOCKER_PRIVILEGED:-0}"
   echo "quartus_docker_empty_sys=${QUARTUS_DOCKER_EMPTY_SYS:-0}"
+  echo "quartus_docker_baked_install=$QUARTUS_DOCKER_BAKED_INSTALL"
 } > "$META_OUT"
 
 build_status=0
@@ -139,6 +151,10 @@ if [[ "$QUARTUS_MODE" = "docker" ]]; then
   if [[ "${QUARTUS_DOCKER_EMPTY_SYS:-}" = "1" ]]; then
     docker_mount_args=(--tmpfs /sys:ro,nosuid,nodev,noexec,mode=0555)
   fi
+  docker_quartus_mount_args=(--volume "$WORK_DIR:/work")
+  if [[ "$QUARTUS_DOCKER_BAKED_INSTALL" != "1" ]]; then
+    docker_quartus_mount_args=(--volume "$QUARTUS_HOST_INSTALL_ROOT:/opt/intelFPGA_lite:ro" "${docker_quartus_mount_args[@]}")
+  fi
   docker_quartus_cmd=(quartus_sh --flow compile menu)
   if [[ "${QUARTUS_STRACE:-}" = "1" ]]; then
     docker_quartus_cmd=(strace -ff -tt -o "/work/$STRACE_PREFIX" quartus_sh --flow compile menu)
@@ -148,8 +164,7 @@ if [[ "$QUARTUS_MODE" = "docker" ]]; then
     "${docker_mount_args[@]}" \
     --cpus "$QUARTUS_DOCKER_CPUS" \
     --memory "$QUARTUS_DOCKER_MEMORY" \
-    --volume "$QUARTUS_HOST_INSTALL_ROOT:/opt/intelFPGA_lite:ro" \
-    --volume "$WORK_DIR:/work" \
+    "${docker_quartus_mount_args[@]}" \
     --workdir /work \
     "$QUARTUS_DOCKER_IMAGE" \
     "${docker_quartus_cmd[@]}" 2>&1 | tee "$LOG_OUT"

--- a/tools/magik-agent/src/main.rs
+++ b/tools/magik-agent/src/main.rs
@@ -312,7 +312,7 @@ mod linux {
     use std::io::{self, BufRead, BufReader, Read, Write};
     use std::mem;
     use std::net::{Ipv4Addr, Shutdown, TcpListener, TcpStream};
-    use std::os::fd::RawFd;
+    use std::os::fd::{AsRawFd, RawFd};
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, Ordering};
@@ -327,6 +327,20 @@ mod linux {
     const AGENT_PORT: u16 = 7498;
     const FRAMEBUFFER_PRODUCER_PORT: u16 = 7499;
     const TOKEN_PATH: &str = "/media/fat/mister-magik/agent.token";
+    const PLUGIN_PROBE_DEVICE: &str = "/dev/mister-magik-plugin-probe";
+    const PLUGIN_PROBE_MIN_VERSION: u32 = 2;
+    const PLUGIN_PROBE_REGION_OFFSET_BYTES: usize = 1024 * 1024;
+    const MAGIK_UIO_GET_FBUF_LATCH: u16 = 0x47;
+    const MAGIK_FBUF_STATUS_MAGIC: u16 = 0x4d48;
+    const FPGA_MGR_BASE: i64 = 0xFF70_6000;
+    const FPGA_MGR_LEN: usize = 0x1000;
+    const FPGA_GPO_OFF: usize = 0x10;
+    const FPGA_GPI_OFF: usize = 0x14;
+    const FPGA_STROBE: u32 = 1 << 17;
+    const FPGA_ACK: u32 = FPGA_STROBE;
+    const FPGA_IO_EN: u32 = 1 << 20;
+    const FPGA_BIT31: u32 = 0x8000_0000;
+    const FPGA_SPIN_LIMIT: u32 = 2_000_000;
     // Temporary while the host/device file-transfer auth flow is being reworked.
     const CONTROL_AUTH_DISABLED: bool = true;
     const LOG: &str = "/tmp/mister-magik-agent.log";
@@ -1489,21 +1503,78 @@ mod linux {
         payload: Vec<u8>,
     }
 
+    struct FramebufferRead {
+        raw: Vec<u8>,
+        geometry: FramebufferGeometry,
+        source: FramebufferCaptureSource,
+    }
+
+    enum FramebufferCaptureSource {
+        Fb0,
+        FpgaLatchedPlugin {
+            active_base: u32,
+            active_sequence: u16,
+            pending_sequence: u16,
+            flags: u16,
+            flip_count: u16,
+            post_count: u16,
+            drop_count: u16,
+            region_index: usize,
+            region_name: String,
+        },
+    }
+
+    impl FramebufferCaptureSource {
+        fn label(&self) -> &'static str {
+            match self {
+                Self::Fb0 => "fb0",
+                Self::FpgaLatchedPlugin { .. } => "fpga-latched-plugin",
+            }
+        }
+
+        fn json(&self) -> Value {
+            match self {
+                Self::Fb0 => json!({"kind": self.label()}),
+                Self::FpgaLatchedPlugin {
+                    active_base,
+                    active_sequence,
+                    pending_sequence,
+                    flags,
+                    flip_count,
+                    post_count,
+                    drop_count,
+                    region_index,
+                    region_name,
+                } => json!({
+                    "kind": self.label(),
+                    "active_base": format!("0x{active_base:08x}"),
+                    "active_sequence": active_sequence,
+                    "pending_sequence": pending_sequence,
+                    "flags": format!("0x{flags:04x}"),
+                    "flip_count": flip_count,
+                    "post_count": post_count,
+                    "drop_count": drop_count,
+                    "region_index": region_index,
+                    "region_name": region_name,
+                }),
+            }
+        }
+    }
+
     fn framebuffer_capture(request_received: Instant, started: Instant) -> Result<Value, String> {
         let start = Instant::now();
         let request_received_uptime_ms =
             request_received.duration_since(started).as_millis() as u64;
         let dispatch_us = elapsed_us(request_received);
-        let geometry_t = Instant::now();
-        let geometry = framebuffer_geometry()?;
-        let geometry_us = elapsed_us(geometry_t);
-        let expected = geometry.bytes()?;
-        let mut raw = vec![0u8; expected];
         let read_t = Instant::now();
-        let mut fb0 = File::open("/dev/fb0").map_err(|err| format!("open /dev/fb0: {err}"))?;
-        fb0.read_exact(&mut raw)
-            .map_err(|err| format!("read /dev/fb0: {err}"))?;
+        let capture = read_framebuffer_capture()?;
         let raw_read_us = elapsed_us(read_t);
+        let geometry = capture.geometry;
+        let raw = capture.raw;
+        let source = capture.source;
+        let geometry_us = 0;
+        let source_json = source.json();
+        let source_label = source.label();
         let png_t = Instant::now();
         let png = framebuffer_png(&raw, geometry)?;
         let png_total_us = elapsed_us(png_t);
@@ -1513,6 +1584,8 @@ mod linux {
         let total_us = elapsed_us(start);
         Ok(json!({
             "schema": "mister-magik-framebuffer-capture-v1",
+            "source": source_label,
+            "capture_source": source_json,
             "width": geometry.width,
             "height": geometry.height,
             "stride": geometry.stride,
@@ -1538,6 +1611,352 @@ mod linux {
         }))
     }
 
+    fn read_framebuffer_capture() -> Result<FramebufferRead, String> {
+        read_fpga_latched_plugin_capture().or_else(|_| read_fb0_capture())
+    }
+
+    fn read_fb0_capture() -> Result<FramebufferRead, String> {
+        let geometry = framebuffer_geometry()?;
+        let expected = geometry.bytes()?;
+        let mut raw = vec![0u8; expected];
+        let mut fb0 = File::open("/dev/fb0").map_err(|err| format!("open /dev/fb0: {err}"))?;
+        fb0.read_exact(&mut raw)
+            .map_err(|err| format!("read /dev/fb0: {err}"))?;
+        Ok(FramebufferRead {
+            raw,
+            geometry,
+            source: FramebufferCaptureSource::Fb0,
+        })
+    }
+
+    #[derive(Clone, Debug)]
+    struct PluginProbeRegion {
+        index: usize,
+        name: String,
+        available: bool,
+        phys: u32,
+        len: usize,
+        dma_owned: bool,
+    }
+
+    #[derive(Clone, Copy, Debug)]
+    struct LatchedFbufStatus {
+        active_sequence: u16,
+        pending_sequence: u16,
+        flags: u16,
+        flip_count: u16,
+        post_count: u16,
+        drop_count: u16,
+        active_base: u32,
+        active_width: u16,
+        active_height: u16,
+        active_stride: u16,
+    }
+
+    impl LatchedFbufStatus {
+        fn supported(self) -> bool {
+            self.active_width > 0
+                && self.active_height > 0
+                && self.active_stride >= self.active_width.saturating_mul(2)
+        }
+    }
+
+    fn read_fpga_latched_plugin_capture() -> Result<FramebufferRead, String> {
+        if !Path::new(PLUGIN_PROBE_DEVICE).exists() {
+            return Err("plugin probe device is not present".to_string());
+        }
+        let mut fpga = FpgaIo::open().map_err(|err| format!("open FPGA IO: {err}"))?;
+        let status = fpga
+            .read_latched_fbuf_status()
+            .map_err(|err| format!("read latched fbuf status: {err}"))?;
+        if !status.supported() {
+            return Err("latched framebuffer status is not active".to_string());
+        }
+        let geometry = FramebufferGeometry {
+            width: status.active_width as usize,
+            height: status.active_height as usize,
+            stride: status.active_stride as usize,
+            bpp: 16,
+        };
+        let expected = geometry.bytes()?;
+        let region = plugin_region_for_phys(status.active_base, expected)?;
+        let raw = read_plugin_region_raw(&region, expected)?;
+        Ok(FramebufferRead {
+            raw,
+            geometry,
+            source: FramebufferCaptureSource::FpgaLatchedPlugin {
+                active_base: status.active_base,
+                active_sequence: status.active_sequence,
+                pending_sequence: status.pending_sequence,
+                flags: status.flags,
+                flip_count: status.flip_count,
+                post_count: status.post_count,
+                drop_count: status.drop_count,
+                region_index: region.index,
+                region_name: region.name,
+            },
+        })
+    }
+
+    fn plugin_region_for_phys(
+        active_base: u32,
+        required_len: usize,
+    ) -> Result<PluginProbeRegion, String> {
+        let text = fs::read_to_string(PLUGIN_PROBE_DEVICE)
+            .map_err(|err| format!("read {PLUGIN_PROBE_DEVICE}: {err}"))?;
+        validate_plugin_probe_header(&text)?;
+        for line in text.lines() {
+            let Some(region) = parse_plugin_probe_region(line) else {
+                continue;
+            };
+            if region.phys != active_base {
+                continue;
+            }
+            if !region.available {
+                return Err(format!("plugin region {} is unavailable", region.name));
+            }
+            if region.dma_owned {
+                return Err(format!("plugin region {} is DMA-owned", region.name));
+            }
+            if region.len < required_len {
+                return Err(format!(
+                    "plugin region {} has {} bytes, need {required_len}",
+                    region.name, region.len
+                ));
+            }
+            return Ok(region);
+        }
+        Err(format!(
+            "no plugin probe region matches active base 0x{active_base:08x}"
+        ))
+    }
+
+    fn validate_plugin_probe_header(text: &str) -> Result<(), String> {
+        let header = text
+            .lines()
+            .find(|line| line.starts_with("plugin_probe_header_tsv\t"))
+            .ok_or_else(|| "plugin probe header is missing".to_string())?;
+        let version = plugin_tsv_field(header, "version")
+            .and_then(|value| value.parse::<u32>().ok())
+            .ok_or_else(|| "plugin probe header version is missing".to_string())?;
+        if version < PLUGIN_PROBE_MIN_VERSION {
+            return Err(format!(
+                "plugin probe version {version} is older than {PLUGIN_PROBE_MIN_VERSION}"
+            ));
+        }
+        let region_offset_bytes = plugin_tsv_field(header, "region_offset_bytes")
+            .and_then(|value| value.parse::<usize>().ok())
+            .ok_or_else(|| "plugin probe region offset is missing".to_string())?;
+        if region_offset_bytes != PLUGIN_PROBE_REGION_OFFSET_BYTES {
+            return Err(format!(
+                "plugin probe region offset {region_offset_bytes} is not {PLUGIN_PROBE_REGION_OFFSET_BYTES}"
+            ));
+        }
+        let cache_mode = plugin_tsv_field(header, "cache_mode")
+            .ok_or_else(|| "plugin probe cache mode is missing".to_string())?;
+        if cache_mode != "writecombine" {
+            return Err(format!("plugin probe cache mode is {cache_mode}"));
+        }
+        Ok(())
+    }
+
+    fn parse_plugin_probe_region(line: &str) -> Option<PluginProbeRegion> {
+        if !line.starts_with("plugin_probe_region_tsv\t") {
+            return None;
+        }
+        Some(PluginProbeRegion {
+            index: plugin_tsv_field(line, "index")?.parse().ok()?,
+            name: plugin_tsv_field(line, "name")?.to_string(),
+            available: plugin_tsv_field(line, "available")? == "1",
+            phys: parse_hex_u32(plugin_tsv_field(line, "phys")?)?,
+            len: plugin_tsv_field(line, "len")?.parse().ok()?,
+            dma_owned: plugin_tsv_field(line, "dma_owned")? == "1",
+        })
+    }
+
+    fn plugin_tsv_field<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+        line.split('\t').skip(1).find_map(|field| {
+            let (field_key, value) = field.split_once('=')?;
+            (field_key == key).then_some(value)
+        })
+    }
+
+    fn parse_hex_u32(raw: &str) -> Option<u32> {
+        let hex = raw
+            .trim()
+            .strip_prefix("0x")
+            .or_else(|| raw.trim().strip_prefix("0X"))
+            .unwrap_or(raw.trim());
+        u32::from_str_radix(hex, 16).ok()
+    }
+
+    fn read_plugin_region_raw(region: &PluginProbeRegion, len: usize) -> Result<Vec<u8>, String> {
+        let device = File::open(PLUGIN_PROBE_DEVICE)
+            .map_err(|err| format!("open {PLUGIN_PROBE_DEVICE}: {err}"))?;
+        let offset = region
+            .index
+            .checked_mul(PLUGIN_PROBE_REGION_OFFSET_BYTES)
+            .ok_or_else(|| "plugin region offset overflow".to_string())?;
+        let mem = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                len,
+                libc::PROT_READ,
+                libc::MAP_SHARED,
+                device.as_raw_fd(),
+                offset as libc::off_t,
+            )
+        };
+        if mem == libc::MAP_FAILED {
+            return Err(format!(
+                "mmap plugin region {}: {}",
+                region.name,
+                io::Error::last_os_error()
+            ));
+        }
+        if mem.is_null() {
+            return Err(format!("mmap plugin region {} returned null", region.name));
+        }
+        let raw = unsafe { std::slice::from_raw_parts(mem.cast::<u8>(), len).to_vec() };
+        unsafe {
+            libc::munmap(mem, len);
+        }
+        Ok(raw)
+    }
+
+    struct FpgaIo {
+        base: *mut u8,
+        _file: File,
+        gpo: u32,
+    }
+
+    impl FpgaIo {
+        fn open() -> io::Result<Self> {
+            let file = OpenOptions::new().read(true).write(true).open("/dev/mem")?;
+            let base = unsafe {
+                libc::mmap(
+                    std::ptr::null_mut(),
+                    FPGA_MGR_LEN,
+                    libc::PROT_READ | libc::PROT_WRITE,
+                    libc::MAP_SHARED,
+                    file.as_raw_fd(),
+                    FPGA_MGR_BASE as libc::off_t,
+                )
+            };
+            if base == libc::MAP_FAILED {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(Self {
+                base: base.cast::<u8>(),
+                _file: file,
+                gpo: FPGA_BIT31,
+            })
+        }
+
+        fn read_latched_fbuf_status(&mut self) -> io::Result<LatchedFbufStatus> {
+            let result = (|| {
+                let (magic_hi, magic_lo) = self.cmd_capture(MAGIK_UIO_GET_FBUF_LATCH)?;
+                if magic_hi != MAGIK_FBUF_STATUS_MAGIC && magic_lo != MAGIK_FBUF_STATUS_MAGIC {
+                    return Err(io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("latched framebuffer status unsupported: ack_high=0x{magic_hi:04x} ack_low=0x{magic_lo:04x}"),
+                    ));
+                }
+                let mut words = [0u16; 11];
+                for word in &mut words {
+                    *word = self.spi_capture(0)?.1;
+                }
+                Ok(LatchedFbufStatus {
+                    active_sequence: words[0],
+                    pending_sequence: words[1],
+                    flags: words[2],
+                    flip_count: words[3],
+                    post_count: words[4],
+                    drop_count: words[5],
+                    active_base: words[6] as u32 | ((words[7] as u32) << 16),
+                    active_width: words[8],
+                    active_height: words[9],
+                    active_stride: words[10],
+                })
+            })();
+            self.disable_io();
+            result
+        }
+
+        fn cmd_capture(&mut self, cmd: u16) -> io::Result<(u16, u16)> {
+            self.enable_io();
+            match self.spi_capture(cmd) {
+                Ok(res) => Ok(res),
+                Err(err) => {
+                    self.disable_io();
+                    Err(err)
+                }
+            }
+        }
+
+        fn enable_io(&mut self) {
+            self.spi_en(FPGA_IO_EN, true);
+        }
+
+        fn disable_io(&mut self) {
+            self.spi_en(FPGA_IO_EN, false);
+        }
+
+        fn spi_en(&mut self, mask: u32, en: bool) {
+            let gpo = self.gpo | FPGA_BIT31;
+            self.write(if en { gpo | mask } else { gpo & !mask });
+        }
+
+        fn spi_capture(&mut self, word: u16) -> io::Result<(u16, u16)> {
+            let gpo = (self.gpo & !(0xffff | FPGA_STROBE)) | word as u32;
+            self.write(gpo);
+            self.write(gpo | FPGA_STROBE);
+
+            let hi = self.wait_ack(word, true, gpo)?;
+            self.write(gpo);
+            let lo = self.wait_ack(word, false, gpo)?;
+            Ok((hi, lo))
+        }
+
+        fn wait_ack(&mut self, word: u16, high: bool, gpo: u32) -> io::Result<u16> {
+            for _ in 0..FPGA_SPIN_LIMIT {
+                let g = self.read();
+                if (g & FPGA_ACK != 0) == high {
+                    return Ok(g as u16);
+                }
+            }
+            if high {
+                self.write(gpo);
+            }
+            Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                format!(
+                    "FPGA SPI timeout waiting for ACK {} on word 0x{word:04x}",
+                    if high { "high" } else { "low" }
+                ),
+            ))
+        }
+
+        fn write(&mut self, value: u32) {
+            self.gpo = value;
+            unsafe {
+                std::ptr::write_volatile(self.base.add(FPGA_GPO_OFF).cast::<u32>(), value);
+            }
+        }
+
+        fn read(&self) -> u32 {
+            unsafe { std::ptr::read_volatile(self.base.add(FPGA_GPI_OFF).cast::<u32>()) }
+        }
+    }
+
+    impl Drop for FpgaIo {
+        fn drop(&mut self) {
+            unsafe {
+                libc::munmap(self.base.cast::<libc::c_void>(), FPGA_MGR_LEN);
+            }
+        }
+    }
+
     fn framebuffer_capture_raw(
         request_received: Instant,
         started: Instant,
@@ -1548,16 +1967,14 @@ mod linux {
         let request_received_uptime_ms =
             request_received.duration_since(started).as_millis() as u64;
         let dispatch_us = elapsed_us(request_received);
-        let geometry_t = Instant::now();
-        let geometry = framebuffer_geometry()?;
-        let geometry_us = elapsed_us(geometry_t);
-        let expected = geometry.bytes()?;
-        let mut raw = vec![0u8; expected];
         let read_t = Instant::now();
-        let mut fb0 = File::open("/dev/fb0").map_err(|err| format!("open /dev/fb0: {err}"))?;
-        fb0.read_exact(&mut raw)
-            .map_err(|err| format!("read /dev/fb0: {err}"))?;
+        let capture = read_framebuffer_capture()?;
         let raw_read_us = elapsed_us(read_t);
+        let geometry = capture.geometry;
+        let raw = capture.raw;
+        let source_json = capture.source.json();
+        let source_label = capture.source.label();
+        let geometry_us = 0;
         let lz4_t = Instant::now();
         let payload = if lz4 {
             lz4_flex::compress_prepend_size(&raw)
@@ -1570,6 +1987,8 @@ mod linux {
             result: json!({
                 "schema": "mister-magik-framebuffer-raw-stream-v1",
                 "boot_id": boot_id,
+                "source": source_label,
+                "capture_source": source_json,
                 "width": geometry.width,
                 "height": geometry.height,
                 "stride": geometry.stride,


### PR DESCRIPTION
## Summary
- add a manual GHCR image workflow for a private Quartus Prime Lite 17.0 + Cyclone V linux/amd64 image
- add a BuildKit-secret Dockerfile that downloads and verifies the official installer payloads during image build
- add opt-in QUARTUS_DOCKER_BAKED_INSTALL support for the FPGA build script
- document publishing, private-package checks, and digest-pinned handoff usage

## Validation
- bash -n scripts/build-fpga-vblank-latch-core.sh
- scripts/build-fpga-vblank-latch-core.sh --help
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/quartus-ghcr-image.yml"); puts "yaml ok"'
- git diff --check
- pre-commit host gates during commit: host logic tests, clippy, host logic check, host tools, MagiK agent check/clippy

## Handoff
After the manual "Quartus GHCR Image" workflow publishes and the package is confirmed Private, consume by digest:

```bash
QUARTUS_DOCKER_BAKED_INSTALL=1 \
QUARTUS_DOCKER_IMAGE=ghcr.io/nigelbreslaw/mister-magik-quartus-lite@sha256:<digest> \
scripts/build-fpga-vblank-latch-core.sh
```

A later consumer PR should replace the existing fpga-vblank-latch prepare/cache job with GHCR login + digest pull, then run the build script with QUARTUS_DOCKER_BAKED_INSTALL=1.