### PR TITLE
fpga: qualify latch-only Menu RBF

### DIFF
--- a/.github/workflows/fpga-latch-fast.yml
+++ b/.github/workflows/fpga-latch-fast.yml
@@ -49,6 +49,6 @@ jobs:
             --Mdir "$build_dir/obj" \
             experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv \
             experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
-          "$build_dir/obj/Vtb_mister_magik_vblank_latch" +verilator+coverage+file+"$build_dir/coverage.dat"
+          (cd "$build_dir" && "$build_dir/obj/Vtb_mister_magik_vblank_latch")
           verilator_coverage --annotate-all --annotate "$build_dir/annotated" "$build_dir/coverage.dat"
           scripts/check-fpga-latch-coverage.py "$build_dir/annotated"

--- a/.github/workflows/fpga-latch-fast.yml
+++ b/.github/workflows/fpga-latch-fast.yml
@@ -44,11 +44,12 @@ jobs:
           set -euo pipefail
           build_dir="$(mktemp -d)"
           trap 'rm -rf "$build_dir"' EXIT
-          verilator --binary --timing --coverage --coverage-line --coverage-toggle \
+          verilator --cc --exe --build --timing --coverage-line \
             --top-module tb_mister_magik_vblank_latch \
             --Mdir "$build_dir/obj" \
             experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv \
-            experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
+            experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv \
+            "$GITHUB_WORKSPACE/experiments/fpga-vblank-latch/verilator_coverage_main.cpp"
           (cd "$build_dir" && "$build_dir/obj/Vtb_mister_magik_vblank_latch")
-          verilator_coverage --annotate-all --annotate "$build_dir/annotated" "$build_dir/coverage.dat"
+          verilator_coverage --annotate-min 1 --annotate-all --annotate "$build_dir/annotated" "$build_dir/coverage.dat"
           scripts/check-fpga-latch-coverage.py "$build_dir/annotated"

--- a/.github/workflows/fpga-latch-fast.yml
+++ b/.github/workflows/fpga-latch-fast.yml
@@ -1,0 +1,54 @@
+name: FPGA latch fast gates
+
+on:
+  pull_request:
+    paths:
+      - "experiments/fpga-vblank-latch/**"
+      - "scripts/*fpga*latch*"
+      - "scripts/build-fpga-vblank-latch-core.sh"
+      - ".github/workflows/fpga-latch-fast.yml"
+  push:
+    paths:
+      - "experiments/fpga-vblank-latch/**"
+      - "scripts/*fpga*latch*"
+      - "scripts/build-fpga-vblank-latch-core.sh"
+      - ".github/workflows/fpga-latch-fast.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  latch-rtl:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install FPGA fast-gate tools
+        run: sudo apt-get update && sudo apt-get install -y iverilog verilator lcov
+      - name: Check out pinned Menu source
+        uses: actions/checkout@v4
+        with:
+          repository: MiSTer-devel/Menu_MiSTer
+          ref: cf4dfdee516fcaa6952bdd9fb47154e96c28567e
+          path: build/Menu_MiSTer
+      - name: Run warning-clean Icarus simulation
+        run: scripts/test-fpga-vblank-latch.sh
+      - name: Lint custom RTL
+        run: >-
+          verilator --lint-only --Wall --Wno-fatal
+          experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv
+      - name: Verify pinned patch integration and opcode ownership
+        run: scripts/check-fpga-latch-integration.py build/Menu_MiSTer
+      - name: Measure reachable custom RTL coverage
+        run: |
+          set -euo pipefail
+          build_dir="$(mktemp -d)"
+          trap 'rm -rf "$build_dir"' EXIT
+          verilator --binary --timing --coverage --coverage-line --coverage-toggle \
+            --top-module tb_mister_magik_vblank_latch \
+            --Mdir "$build_dir/obj" \
+            experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv \
+            experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
+          "$build_dir/obj/Vtb_mister_magik_vblank_latch" +verilator+coverage+file+"$build_dir/coverage.dat"
+          verilator_coverage --annotate-all --annotate "$build_dir/annotated" "$build_dir/coverage.dat"
+          scripts/check-fpga-latch-coverage.py "$build_dir/annotated"

--- a/.github/workflows/fpga-vblank-latch.yml
+++ b/.github/workflows/fpga-vblank-latch.yml
@@ -250,11 +250,13 @@ jobs:
             build/fpga-signoff/stock/menu-magik-vblank-latch.rbf
             build/fpga-signoff/stock/menu-magik-vblank-latch.metadata.txt
             build/fpga-signoff/stock/menu-magik-vblank-latch.build.log
+            build/fpga-signoff/stock/reports/*
             build/fpga-signoff/stock/Menu-work/output_files/*.rpt
             build/fpga-signoff/stock/Menu-work/output_files/*.summary
             build/fpga-signoff/patched/menu-magik-vblank-latch.rbf
             build/fpga-signoff/patched/menu-magik-vblank-latch.metadata.txt
             build/fpga-signoff/patched/menu-magik-vblank-latch.build.log
+            build/fpga-signoff/patched/reports/*
             build/fpga-signoff/patched/Menu-work/output_files/*.rpt
             build/fpga-signoff/patched/Menu-work/output_files/*.summary
             build/fpga-signoff/quartus-delta-signoff.tsv

--- a/.github/workflows/fpga-vblank-latch.yml
+++ b/.github/workflows/fpga-vblank-latch.yml
@@ -7,9 +7,9 @@ on:
   workflow_dispatch:
     inputs:
       menu_ref:
-        description: "MiSTer-devel/Menu_MiSTer ref to build"
+        description: "Full MiSTer-devel/Menu_MiSTer commit SHA to build"
         required: true
-        default: "master"
+        default: "cf4dfdee516fcaa6952bdd9fb47154e96c28567e"
       quartus_run_url:
         description: "Optional URL for QuartusLiteSetup-17.0.0.595-linux.run; falls back to secret QUARTUS_17_0_RUN_URL"
         required: false
@@ -18,10 +18,6 @@ on:
         description: "Optional URL for cyclonev-17.0.0.595.qdz; falls back to secret QUARTUS_17_0_CYCLONEV_QDZ_URL"
         required: false
         default: "https://downloads.intel.com/akdlm/software/acdsinst/17.0std/595/ib_installers/cyclonev-17.0.0.595.qdz"
-      apply_magik_patch:
-        description: "Apply the experimental MagiK vblank-latch patch before building"
-        required: true
-        default: "true"
 
 permissions:
   contents: read
@@ -216,21 +212,50 @@ jobs:
           du -sh build/quartus-lite-17.0/docker-intelFPGA_lite || true
           docker system df || true
 
-      - name: Build vblank-latched RBF
+      - name: Build matched stock and vblank-latched RBFs
         env:
           MISTER_MENU_DIR: ${{ github.workspace }}/build/Menu_MiSTer
-          MISTER_FPGA_APPLY_PATCH: ${{ github.event.inputs.apply_magik_patch || 'true' }}
           QUARTUS_DOCKER_EMPTY_SYS: "1"
           QUARTUS_STRACE: "0"
-        run: scripts/build-fpga-vblank-latch-core.sh
+        run: |
+          set -euo pipefail
+          test "$(git -C "$MISTER_MENU_DIR" rev-parse HEAD)" = "${{ github.event.inputs.menu_ref }}"
+          MISTER_FPGA_APPLY_PATCH=0 \
+            MISTER_FPGA_OUT_DIR="$GITHUB_WORKSPACE/build/fpga-signoff/stock" \
+            MISTER_MENU_BUILD_DIR="$GITHUB_WORKSPACE/build/fpga-signoff/stock/Menu-work" \
+            scripts/build-fpga-vblank-latch-core.sh
+          MISTER_FPGA_APPLY_PATCH=1 \
+            MISTER_FPGA_OUT_DIR="$GITHUB_WORKSPACE/build/fpga-signoff/patched" \
+            MISTER_MENU_BUILD_DIR="$GITHUB_WORKSPACE/build/fpga-signoff/patched/Menu-work" \
+            scripts/build-fpga-vblank-latch-core.sh
+
+      - name: Compare stock and MagiK custom delta
+        run: |
+          set -euo pipefail
+          args=()
+          while IFS= read -r -d '' report; do args+=(--stock "$report"); done < <(
+            find build/fpga-signoff/stock -type f \( -name '*.log' -o -name '*.rpt' -o -name '*.summary' \) -print0
+          )
+          while IFS= read -r -d '' report; do args+=(--patched "$report"); done < <(
+            find build/fpga-signoff/patched -type f \( -name '*.log' -o -name '*.rpt' -o -name '*.summary' \) -print0
+          )
+          scripts/check-fpga-quartus-delta.py "${args[@]}" | tee build/fpga-signoff/quartus-delta-signoff.tsv
 
       - name: Upload FPGA build evidence
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: fpga-vblank-latch-build
+          name: fpga-vblank-latch-signoff
           path: |
-            build/fpga-vblank-latch/menu-magik-vblank-latch.rbf
-            build/fpga-vblank-latch/menu-magik-vblank-latch.metadata.txt
-            build/fpga-vblank-latch/menu-magik-vblank-latch.build.log
+            build/fpga-signoff/stock/menu-magik-vblank-latch.rbf
+            build/fpga-signoff/stock/menu-magik-vblank-latch.metadata.txt
+            build/fpga-signoff/stock/menu-magik-vblank-latch.build.log
+            build/fpga-signoff/stock/Menu-work/output_files/*.rpt
+            build/fpga-signoff/stock/Menu-work/output_files/*.summary
+            build/fpga-signoff/patched/menu-magik-vblank-latch.rbf
+            build/fpga-signoff/patched/menu-magik-vblank-latch.metadata.txt
+            build/fpga-signoff/patched/menu-magik-vblank-latch.build.log
+            build/fpga-signoff/patched/Menu-work/output_files/*.rpt
+            build/fpga-signoff/patched/Menu-work/output_files/*.summary
+            build/fpga-signoff/quartus-delta-signoff.tsv
           if-no-files-found: warn

--- a/.github/workflows/fpga-vblank-latch.yml
+++ b/.github/workflows/fpga-vblank-latch.yml
@@ -240,6 +240,10 @@ jobs:
             find build/fpga-signoff/patched -type f \( -name '*.log' -o -name '*.rpt' -o -name '*.summary' \) -print0
           )
           scripts/check-fpga-quartus-delta.py "${args[@]}" | tee build/fpga-signoff/quartus-delta-signoff.tsv
+          cp build/fpga-signoff/quartus-delta-signoff.tsv build/fpga-signoff/patched/reports/quartus-delta-signoff.tsv
+          delta_sha="$(shasum -a 256 build/fpga-signoff/patched/reports/quartus-delta-signoff.tsv | awk '{print $1}')"
+          printf 'report_sha256.reports/quartus-delta-signoff.tsv=%s\nsignoff_valid=1\n' "$delta_sha" \
+            >> build/fpga-signoff/patched/menu-magik-vblank-latch.metadata.txt
 
       - name: Upload FPGA build evidence
         if: always()

--- a/docs/fpga-latch-release-signoff.md
+++ b/docs/fpga-latch-release-signoff.md
@@ -1,0 +1,116 @@
+# FPGA latch release signoff
+
+## Disposition
+
+The extracted-latch RBF is a **release candidate, not an approved commercial
+release**. Automated RTL and Quartus custom-delta signoff pass, and matched
+single-device 960x540 qualification passes. The release remains blocked by the
+open items below. Do not tag or present it as commercially qualified yet.
+
+## Candidate identity
+
+- RBF SHA-256: `69e0e312b226c004bfe7fced2cc1145954efa1110cee7a0f58de1528d52627a1`
+- Qualified MagiK source: `4e08fb4e8125f865d10167d4c9d3fd87815f4f11`
+- Menu source: `cf4dfdee516fcaa6952bdd9fb47154e96c28567e`
+- Patch SHA-256: `4bdd2bcee724bb988ab6a975c2532ccc39a4e2b5686fac6fe4c88528f9c55ba6`
+- Latch RTL SHA-256: `b810de3fdffbe79b8496e7eaa3967b07f6aa70a3d78dabb41c6428d72d994b1a`
+- Toolchain: Quartus 17.0.0 Build 595, seed 1
+- Matched Quartus workflow: run `29158797784`
+- Passing fast RTL workflow: run `29159218946`
+
+The final manifest-producing workflow must reproduce this RBF hash from the
+reviewed final source before tagging. A different RBF hash invalidates the
+device evidence in this record.
+
+## Automated evidence
+
+- Icarus exercises LATCH-001 through LATCH-008 with bounded waits. Verilator
+  lint, pinned-patch integration, opcode ownership, and complete reachable
+  custom-RTL line coverage pass without exclusions.
+- The matched Quartus delta reports `valid=1`: 153 normalized warning records
+  in both collected report sets, setup slack 0.324 ns, hold slack 0.250 ns,
+  TNS 0, 168 stock versus 166 patched unconstrained output paths, and one added
+  recognized synchronizer chain with calculable MTBF. The flow-summary warning
+  baseline and waiver policy remain in
+  [Menu FPGA Warning Waiver Ledger](fpga-menu-warning-waivers.md).
+- The release manifest binds the RBF, pinned source, patch, RTL, toolchain,
+  seed, workflow URL, and every retained Quartus report. Missing, modified,
+  dirty-source, unsigned-delta, and mailbox-era fixtures are rejected.
+
+## Device evidence
+
+The primary device is the known MiSTer at the repository's documented device
+address. All matched samples used the same current MagiK binary, including the
+preserved launcher subtitle alpha-animation change.
+
+| Gate | Baseline median p99 work | Candidate median p99 work | 3% limit | Result |
+| --- | ---: | ---: | ---: | --- |
+| Home, 960x540 | 6799.5 us | 6788.0 us | 7003.5 us | pass |
+| Arcade/preview, 960x540 | 5282.0 us | 5374.5 us | 5440.5 us | pass |
+
+All four candidate samples report zero latch deadline misses, visual latch
+misses, buffer-alternation failures, sampled flip gaps, and unexpected FPGA
+drops, with advancing post and flip counters. Deliberate faster-than-vblank
+posting increments the drop counter; normal-cadence posting subsequently
+recovers with no pending request. Reloading the same exact RBF clears the test
+counters before zero-drop motion gates.
+
+A physical USB HDMI capture was recorded at 1920x1080 from the candidate. Its
+contact strips show the expected moving Home row without an obvious horizontal
+discontinuity. The retained raw capture is intentionally outside git under
+`build/launcher-home-pan-captures/FPGA-LATCH-CANDIDATE-HDMI-USB-20260711.mov`.
+This is primary-device evidence, not the required independent second-display
+review.
+
+## Open release gates
+
+- **1280x720 hidden slots:** each production hidden slot exposes 1,040,384
+  bytes, while a 1280x720 RGB565 frame needs 1,843,200 bytes. The renderer
+  correctly falls back to `/dev/fb0`, but the hidden-latch geometry gate is not
+  satisfied. The analyzer now fails an expected-latch backend mismatch instead
+  of incorrectly reporting it valid.
+- **Game-return lifecycle:** the bounded smoke twice failed to create
+  `/tmp/mister-magik/launcher-return-state.json`. Main and the launcher remained
+  healthy with zero crash/invariant counts. The runner now removes persistent
+  `launcher.env` on every exit, but this lifecycle requirement is unresolved.
+- **Two-hour soak:** explicitly deferred; not run in this qualification session.
+- **Hardware breadth:** no second representative MiSTer/display combination has
+  been qualified.
+- **Independent review:** review of the extracted RTL, Menu integration,
+  constraints, waiver ledger, and retained evidence is not yet recorded.
+
+## Installation verification and rollback
+
+Before installation, run:
+
+```text
+scripts/verify-fpga-rbf-manifest.py build/fpga-vblank-latch/menu-magik-vblank-latch.metadata.txt
+```
+
+Deployment uploads the RBF and adjacent metadata to temporary names, verifies
+the exact hash, and only then activates the pair. Boot installation refuses a
+missing or mismatched pair. After activation, `fpga-latch-report` must show
+`0x57`/`0x58` support and advancing counters for the expected RBF command line.
+
+Rollback with `scripts/restore-stock-boot.sh`. For a one-shot candidate rollback
+without changing boot policy, launch the retained stock Menu RBF through Main's
+normal command path; do not use an external `rbf_load` while the launcher is
+active.
+
+## Release checklist
+
+- [x] Latch-only requirements and requirement-to-test matrix
+- [x] Extracted RTL and reduced Menu integration patch
+- [x] Complete reachable RTL and functional requirement coverage
+- [x] Passing matched stock-versus-patched Quartus delta
+- [x] Exact-RBF manifest and deployment verification
+- [x] Matched primary-device 960x540 performance and latch integrity
+- [x] Deliberate overflow and recovery
+- [x] Primary-device HDMI capture
+- [ ] 1280x720 hidden-latch geometry
+- [ ] Game-return lifecycle smoke
+- [ ] Two-hour motion soak
+- [ ] Second representative MiSTer/display
+- [ ] Independent release review
+
+Release tagging is prohibited while any item above remains unchecked.

--- a/docs/fpga-latch-release.md
+++ b/docs/fpga-latch-release.md
@@ -1,0 +1,93 @@
+# FPGA vblank latch release requirements
+
+This document defines the commercial-release contract for the small Menu FPGA
+delta used by MiSTer MagiK. Its scope is only the `0x57` set command, the `0x58`
+status command, and the vblank-latched framebuffer route. The retired scanout
+mailbox, commands `0x59`/`0x5a`, AXI/ACP access, DMA ownership, and completion
+fences are not part of this design or its qualification.
+
+## Behavioral requirements
+
+- **LATCH-001 — command discovery.** Starting command `0x57` returns `0x4d47`;
+  starting command `0x58` returns `0x4d48`. Other commands are unaffected.
+- **LATCH-002 — route staging.** `0x57` words 0–9 stage enable/filter/format,
+  base, width, height, horizontal and vertical bounds, and stride. Staging these
+  words must not change the active framebuffer route or create a pending post.
+- **LATCH-003 — post commit.** Word 10 supplies the 16-bit sequence, marks the
+  staged route pending, and increments the 16-bit post counter.
+- **LATCH-004 — vblank application.** A pending route is applied atomically on
+  the next rising edge from the synchronized `hdmi_vbl` signal, and never on a
+  falling edge or outside vblank. Application copies every staged route field,
+  makes the pending sequence active, increments the 16-bit flip counter, and
+  clears pending.
+- **LATCH-005 — pending replacement.** If word 10 commits while a request is
+  already pending, the newly staged request replaces it, the post counter still
+  increments, and the 16-bit drop counter increments once. The next eligible
+  vblank applies the replacement request.
+- **LATCH-006 — status layout.** `0x58` words 0–10 return, respectively: active
+  sequence; pending sequence; `{13'b0, pending, pending_enable, active_enable}`;
+  flip count; post count; drop count; active base low; active base high; active
+  width; active height; and active stride.
+- **LATCH-007 — initialization.** All MagiK staging, sequence, counter, pending,
+  and vblank-synchronizer registers power up to zero. The delta has no runtime
+  reset interface and must not add one implicitly.
+- **LATCH-008 — finite-width behavior.** Sequences are opaque 16-bit values.
+  Post, flip, and drop counters wrap modulo 65,536; wrapping must not alter
+  pending or route behavior.
+- **LATCH-009 — compatibility.** Stock `UIO_SET_FBUF` behavior and all unrelated
+  Menu commands remain unchanged. The latch remains compatible with the
+  hidden-slot renderer and its `/dev/fb0` fallback.
+
+## Requirement-to-test matrix
+
+These are release gates. A row is not satisfied merely because a test is named;
+the retained result must identify the exact source and RBF hashes under test.
+
+| Requirement | RTL simulation / assertion | Integration or hardware evidence |
+| --- | --- | --- |
+| LATCH-001 | Both magic values; unrelated opcode has no latch response | Passive `fpga-latch-report` reports both commands supported |
+| LATCH-002 | Exercise every word and prove no early pending/apply | Posted geometry and active route match |
+| LATCH-003 | Sequence commit, pending, and post-count checks | Post counter advances during launcher motion |
+| LATCH-004 | Rising/falling/no-edge cases; atomic-route assertion | Flip counter advances with zero visual/alternation misses |
+| LATCH-005 | Two posts before vblank; replacement and one drop | Deliberate over-post increments drop once, then recovers |
+| LATCH-006 | Exact readback for all eleven status words | Passive report agrees with active route and counters |
+| LATCH-007 | Power-up state and bounded startup checks | Cold boot and RBF reload start safely |
+| LATCH-008 | Sequence and all counter wrap cases | Long soak shows continued counter progress |
+| LATCH-009 | Patch integration, opcode collision check, stock comparison | Lifecycle tests and clean `/dev/fb0` fallback |
+
+## Custom-delta release signoff
+
+A release candidate is eligible only when all of the following are retained:
+
+1. The exact MagiK commit, pinned upstream Menu commit, latch patch hash,
+   Quartus 17.0 build identity and seed, RBF SHA-256, and report hashes.
+2. Passing self-checking RTL tests for every requirement above, complete
+   reachable line/branch and functional-point coverage, and reviewed assertions
+   for vblank-only and atomic application behavior.
+3. A stock-versus-patched Quartus comparison made with identical inputs. The
+   patch may add no warning, unconstrained endpoint, inferred latch, negative
+   slack, non-zero TNS, or unreviewed CDC finding. The two-stage vblank
+   synchronizer must be recognized and have a documented MTBF disposition.
+4. Hardware qualification tied to the candidate RBF hash: both command magic
+   values, advancing post/flip counters, zero unexpected drops, supported video
+   geometries, lifecycle and fallback cases, deliberate-overflow recovery, a
+   two-hour soak, and physical HDMI inspection. Qualification on only one MiSTer
+   remains single-unit qualification; commercial signoff requires a second
+   representative MiSTer/display combination.
+5. Independent review of the custom RTL, Menu integration, constraints, waiver
+   ledger, and retained evidence, plus a tested stock-RBF rollback.
+
+## Artifact status
+
+The latch-only RBF from GitHub Actions run `29153173239`, SHA-256
+`7f4f5c40260f52341f11f3cc66891c551699376dd89fc39ff03efdebd48eb5c2`, is the
+behavioral baseline documented in
+[the zero-copy retirement record](../history/2026-07-11-zero-copy-retirement.md).
+It is not the final release artifact; extraction and delta signoff will produce
+a new candidate hash.
+
+The current ignored local RBF has SHA-256
+`f61ad600ad63d8e91fc9fa8b093448fcecdd5d4370b5d330456bc53f19d5a17c` and its
+metadata includes the retired mailbox patch and RTL. It is stale, is not the
+latch-only baseline, and is ineligible for release qualification or deployment.
+

--- a/docs/fpga-latch-release.md
+++ b/docs/fpga-latch-release.md
@@ -91,3 +91,7 @@ The current ignored local RBF has SHA-256
 metadata includes the retired mailbox patch and RTL. It is stale, is not the
 latch-only baseline, and is ineligible for release qualification or deployment.
 
+The extracted-latch candidate and its current qualification disposition are
+recorded in [FPGA latch release signoff](fpga-latch-release-signoff.md). A
+candidate hash listed there is not an approved commercial release while any
+custom-delta checklist item remains open.

--- a/docs/fpga-menu-warning-waivers.md
+++ b/docs/fpga-menu-warning-waivers.md
@@ -1,0 +1,29 @@
+# Menu FPGA Warning Waiver Ledger
+
+The stock and patched builds must use the same pinned Menu commit, Quartus
+17.0.0.595, seed 1, project settings, and source tree. The automated delta gate
+requires their normalized warning identity multisets to match exactly. This is
+a waiver for inherited upstream warnings only; it is not permission to add a
+warning in the MagiK delta.
+
+The baseline build reports 50 warnings in its Quartus flow summary. Quartus
+emits 24 primary warning records; continuation/detail records account for the
+remaining summary count. The release artifact stores the complete stock log,
+reports, and normalized warning comparison. A warning is waived only when its
+code, normalized primary message, and multiplicity match that stock evidence.
+
+The known inherited groups are:
+
+- undriven upstream Menu output ports;
+- synthesized-away and connectivity-summary notices;
+- tri-state/open-drain/pin connectivity notices;
+- the Quartus LogicLock subscription notice;
+- ignored legacy `sys_top.sdc` filters and their false-path consequence;
+- the inherited `rtl/lfsr.v` combinational-loop warning;
+- ignored fast-I/O and invalid fitter assignment summaries;
+- placement-effort and fitter connectivity notices.
+
+Any new inferred latch, unconstrained endpoint, warning identity, CDC finding,
+or MagiK source path is unwaived and fails release signoff. The exact ledger is
+therefore the stock report set bound into each release manifest, rather than a
+manually copied list that could silently drift from upstream.

--- a/experiments/fpga-vblank-latch/Menu_MiSTer-vblank-latched-fbuf.patch
+++ b/experiments/fpga-vblank-latch/Menu_MiSTer-vblank-latched-fbuf.patch
@@ -2,7 +2,7 @@ diff --git a/sys/sys_top.v b/sys/sys_top.v
 index 5f9dfa4..cce2e73 100644
 --- a/sys/sys_top.v
 +++ b/sys/sys_top.v
-@@ -350,14 +350,73 @@ reg [12:0] arc2x = 0;
+@@ -350,14 +350,85 @@ reg [12:0] arc2x = 0;
  reg [12:0] arc2y = 0;
  reg [15:0] io_dout_sys;
  
@@ -24,6 +24,12 @@ index 5f9dfa4..cce2e73 100644
 +wire [11:0] magik_lfb_vmax;
 +wire [31:0] magik_lfb_base;
 +wire [13:0] magik_lfb_stride;
++wire        magik_lfb_pending;
++wire [15:0] magik_lfb_pending_seq;
++wire [15:0] magik_lfb_active_seq;
++wire [15:0] magik_lfb_post_count;
++wire [15:0] magik_lfb_flip_count;
++wire [15:0] magik_lfb_drop_count;
 +
 +mister_magik_vblank_latch magik_vblank_latch
 +(
@@ -52,7 +58,13 @@ index 5f9dfa4..cce2e73 100644
 +	.route_vmin(magik_lfb_vmin),
 +	.route_vmax(magik_lfb_vmax),
 +	.route_base(magik_lfb_base),
-+	.route_stride(magik_lfb_stride)
++	.route_stride(magik_lfb_stride),
++	.pending(magik_lfb_pending),
++	.pending_seq(magik_lfb_pending_seq),
++	.active_seq(magik_lfb_active_seq),
++	.post_count(magik_lfb_post_count),
++	.flip_count(magik_lfb_flip_count),
++	.drop_count(magik_lfb_drop_count)
 +);
 +
  always@(posedge clk_sys) begin
@@ -79,7 +91,7 @@ index 5f9dfa4..cce2e73 100644
  	coef_wr <= 0;
  
  `ifndef MISTER_DEBUG_NOHDMI
-@@ -396,6 +455,7 @@ always@(posedge clk_sys) begin
+@@ -396,6 +467,7 @@ always@(posedge clk_sys) begin
  			if(io_din[7:0] == 'h40) io_dout_sys <= fb_crc;
  `endif
  			if(io_din[7:0] == 'h42) io_dout_sys <= {1'b1, frame_cnt};
@@ -87,7 +99,7 @@ index 5f9dfa4..cce2e73 100644
  		end
  		else begin
  			cnt <= cnt + 1'd1;
-@@ -450,6 +510,7 @@ always@(posedge clk_sys) begin
+@@ -450,6 +522,7 @@ always@(posedge clk_sys) begin
  					9: LFB_STRIDE      <= io_din[13:0];
  				endcase
  			end

--- a/experiments/fpga-vblank-latch/Menu_MiSTer-vblank-latched-fbuf.patch
+++ b/experiments/fpga-vblank-latch/Menu_MiSTer-vblank-latched-fbuf.patch
@@ -1,106 +1,97 @@
 diff --git a/sys/sys_top.v b/sys/sys_top.v
+index 5f9dfa4..cce2e73 100644
 --- a/sys/sys_top.v
 +++ b/sys/sys_top.v
-@@ -352,2 +352,32 @@ reg [15:0] io_dout_sys;
+@@ -350,14 +350,73 @@ reg [12:0] arc2x = 0;
+ reg [12:0] arc2y = 0;
+ reg [15:0] io_dout_sys;
  
-+// MiSTer MagiK experiment: queue an HPS framebuffer route and apply it only
-+// on HDMI vblank. This keeps the existing UIO_SET_FBUF path unchanged while
-+// adding a diagnostics-only command for a vblank-latched presenter.
-+localparam MAGIK_UIO_SET_FBUF_LATCH = 8'h57;
-+localparam MAGIK_UIO_GET_FBUF_LATCH = 8'h58;
-+localparam MAGIK_FBUF_LATCH_MAGIC   = 16'h4D47; // "MG"
-+localparam MAGIK_FBUF_STATUS_MAGIC  = 16'h4D48; // "MH"
++reg  [7:0] cmd;
++reg        has_cmd;
++reg  [7:0] cnt = 0;
 +
-+reg        MAGIK_LFB_PENDING = 0;
-+reg        MAGIK_LFB_EN      = 0;
-+reg        MAGIK_LFB_FLT     = 0;
-+reg  [5:0] MAGIK_LFB_FMT     = 0;
-+reg [11:0] MAGIK_LFB_WIDTH   = 0;
-+reg [11:0] MAGIK_LFB_HEIGHT  = 0;
-+reg [11:0] MAGIK_LFB_HMIN    = 0;
-+reg [11:0] MAGIK_LFB_HMAX    = 0;
-+reg [11:0] MAGIK_LFB_VMIN    = 0;
-+reg [11:0] MAGIK_LFB_VMAX    = 0;
-+reg [31:0] MAGIK_LFB_BASE    = 0;
-+reg [13:0] MAGIK_LFB_STRIDE  = 0;
-+reg [15:0] MAGIK_LFB_PENDING_SEQ = 0;
-+reg [15:0] MAGIK_LFB_ACTIVE_SEQ  = 0;
-+reg [15:0] MAGIK_LFB_POST_COUNT  = 0;
-+reg [15:0] MAGIK_LFB_FLIP_COUNT  = 0;
-+reg [15:0] MAGIK_LFB_DROP_COUNT  = 0;
++wire        magik_response_valid;
++wire [15:0] magik_response_data;
++wire        magik_lfb_apply;
++wire        magik_lfb_en;
++wire        magik_lfb_flt;
++wire  [5:0] magik_lfb_fmt;
++wire [11:0] magik_lfb_width;
++wire [11:0] magik_lfb_height;
++wire [11:0] magik_lfb_hmin;
++wire [11:0] magik_lfb_hmax;
++wire [11:0] magik_lfb_vmin;
++wire [11:0] magik_lfb_vmax;
++wire [31:0] magik_lfb_base;
++wire [13:0] magik_lfb_stride;
 +
-+reg magik_vbl_meta = 0;
-+reg magik_vbl_sys = 0;
-+reg magik_vbl_old = 0;
-+wire magik_vbl_rise = ~magik_vbl_old & magik_vbl_sys;
++mister_magik_vblank_latch magik_vblank_latch
++(
++	.clk_sys(clk_sys),
++	.hdmi_vbl(hdmi_vbl),
++	.cmd_start(io_uio && io_strobe && !has_cmd),
++	.cmd_data(io_uio && io_strobe && has_cmd),
++	.cmd_id(has_cmd ? cmd : io_din[7:0]),
++	.word_index(cnt[3:0]),
++	.data_in(io_din),
++	.active_lfb_en(LFB_EN),
++	.active_lfb_base(LFB_BASE),
++	.active_lfb_width(LFB_WIDTH),
++	.active_lfb_height(LFB_HEIGHT),
++	.active_lfb_stride(LFB_STRIDE),
++	.response_valid(magik_response_valid),
++	.response_data(magik_response_data),
++	.apply(magik_lfb_apply),
++	.route_en(magik_lfb_en),
++	.route_flt(magik_lfb_flt),
++	.route_fmt(magik_lfb_fmt),
++	.route_width(magik_lfb_width),
++	.route_height(magik_lfb_height),
++	.route_hmin(magik_lfb_hmin),
++	.route_hmax(magik_lfb_hmax),
++	.route_vmin(magik_lfb_vmin),
++	.route_vmax(magik_lfb_vmax),
++	.route_base(magik_lfb_base),
++	.route_stride(magik_lfb_stride)
++);
++
  always@(posedge clk_sys) begin
-@@ -360,4 +390,24 @@ always@(posedge clk_sys) begin
+-	reg  [7:0] cmd;
+-	reg        has_cmd;
+-	reg  [7:0] cnt = 0;
+ 	reg        vs_d0,vs_d1,vs_d2;
+ 	reg  [4:0] acx_att;
  	reg  [7:0] fb_crc;
- 	reg  [1:0] sl_r;
  
-+	magik_vbl_meta <= hdmi_vbl;
-+	magik_vbl_sys <= magik_vbl_meta;
-+	magik_vbl_old <= magik_vbl_sys;
-+
-+	if(MAGIK_LFB_PENDING && magik_vbl_rise) begin
-+		LFB_EN     <= MAGIK_LFB_EN;
-+		LFB_FLT    <= MAGIK_LFB_FLT;
-+		LFB_FMT    <= MAGIK_LFB_FMT;
-+		LFB_WIDTH  <= MAGIK_LFB_WIDTH;
-+		LFB_HEIGHT <= MAGIK_LFB_HEIGHT;
-+		LFB_HMIN   <= MAGIK_LFB_HMIN;
-+		LFB_HMAX   <= MAGIK_LFB_HMAX;
-+		LFB_VMIN   <= MAGIK_LFB_VMIN;
-+		LFB_VMAX   <= MAGIK_LFB_VMAX;
-+		LFB_BASE   <= MAGIK_LFB_BASE;
-+		LFB_STRIDE <= MAGIK_LFB_STRIDE;
-+		MAGIK_LFB_ACTIVE_SEQ <= MAGIK_LFB_PENDING_SEQ;
-+		MAGIK_LFB_FLIP_COUNT <= MAGIK_LFB_FLIP_COUNT + 1'd1;
-+		MAGIK_LFB_PENDING <= 0;
++	if(magik_lfb_apply) begin
++		LFB_EN     <= magik_lfb_en;
++		LFB_FLT    <= magik_lfb_flt;
++		LFB_FMT    <= magik_lfb_fmt;
++		LFB_WIDTH  <= magik_lfb_width;
++		LFB_HEIGHT <= magik_lfb_height;
++		LFB_HMIN   <= magik_lfb_hmin;
++		LFB_HMAX   <= magik_lfb_hmax;
++		LFB_VMIN   <= magik_lfb_vmin;
++		LFB_VMAX   <= magik_lfb_vmax;
++		LFB_BASE   <= magik_lfb_base;
++		LFB_STRIDE <= magik_lfb_stride;
 +	end
  	coef_wr <= 0;
-@@ -398,3 +448,5 @@ always@(posedge clk_sys) begin
+ 
+ `ifndef MISTER_DEBUG_NOHDMI
+@@ -396,6 +455,7 @@ always@(posedge clk_sys) begin
+ 			if(io_din[7:0] == 'h40) io_dout_sys <= fb_crc;
+ `endif
  			if(io_din[7:0] == 'h42) io_dout_sys <= {1'b1, frame_cnt};
- 			if(io_din[7:0] == 'h44) io_dout_sys <= 1;
-+			if(io_din[7:0] == MAGIK_UIO_SET_FBUF_LATCH) io_dout_sys <= MAGIK_FBUF_LATCH_MAGIC;
-+			if(io_din[7:0] == MAGIK_UIO_GET_FBUF_LATCH) io_dout_sys <= MAGIK_FBUF_STATUS_MAGIC;
++			if(magik_response_valid) io_dout_sys <= magik_response_data;
  		end
-@@ -463,3 +515,38 @@ always@(posedge clk_sys) begin
+ 		else begin
+ 			cnt <= cnt + 1'd1;
+@@ -450,6 +510,7 @@ always@(posedge clk_sys) begin
+ 					9: LFB_STRIDE      <= io_din[13:0];
  				endcase
  			end
-+			if(cmd == MAGIK_UIO_SET_FBUF_LATCH) begin
-+				case(cnt[3:0])
-+					0: {MAGIK_LFB_EN,MAGIK_LFB_FLT,MAGIK_LFB_FMT} <= {io_din[15], io_din[14], io_din[5:0]};
-+					1: MAGIK_LFB_BASE[15:0]  <= io_din[15:0];
-+					2: MAGIK_LFB_BASE[31:16] <= io_din[15:0];
-+					3: MAGIK_LFB_WIDTH       <= io_din[11:0];
-+					4: MAGIK_LFB_HEIGHT      <= io_din[11:0];
-+					5: MAGIK_LFB_HMIN        <= io_din[11:0];
-+					6: MAGIK_LFB_HMAX        <= io_din[11:0];
-+					7: MAGIK_LFB_VMIN        <= io_din[11:0];
-+					8: MAGIK_LFB_VMAX        <= io_din[11:0];
-+					9: MAGIK_LFB_STRIDE      <= io_din[13:0];
-+					10: begin
-+						MAGIK_LFB_PENDING_SEQ <= io_din;
-+						MAGIK_LFB_PENDING <= 1;
-+						MAGIK_LFB_POST_COUNT <= MAGIK_LFB_POST_COUNT + 1'd1;
-+						if(MAGIK_LFB_PENDING) MAGIK_LFB_DROP_COUNT <= MAGIK_LFB_DROP_COUNT + 1'd1;
-+					end
-+				endcase
-+			end
-+			if(cmd == MAGIK_UIO_GET_FBUF_LATCH) begin
-+				case(cnt[3:0])
-+					0: io_dout_sys <= MAGIK_LFB_ACTIVE_SEQ;
-+					1: io_dout_sys <= MAGIK_LFB_PENDING_SEQ;
-+					2: io_dout_sys <= {13'd0, MAGIK_LFB_PENDING, MAGIK_LFB_EN, LFB_EN};
-+					3: io_dout_sys <= MAGIK_LFB_FLIP_COUNT;
-+					4: io_dout_sys <= MAGIK_LFB_POST_COUNT;
-+					5: io_dout_sys <= MAGIK_LFB_DROP_COUNT;
-+					6: io_dout_sys <= LFB_BASE[15:0];
-+					7: io_dout_sys <= LFB_BASE[31:16];
-+					8: io_dout_sys <= LFB_WIDTH;
-+					9: io_dout_sys <= LFB_HEIGHT;
-+					10: io_dout_sys <= LFB_STRIDE;
-+				endcase
-+			end
++			if(magik_response_valid) io_dout_sys <= magik_response_data;
  			if(cmd == 'h25) {led_overtake, led_state} <= io_din;
+ 			if(cmd == 'h26) vol_att <= io_din[4:0];
+ 			if(cmd == 'h27) VSET <= io_din[11:0];

--- a/experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv
+++ b/experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv
@@ -1,0 +1,125 @@
+`timescale 1ns/1ps
+`default_nettype none
+
+module mister_magik_vblank_latch (
+	input  wire        clk_sys,
+	input  wire        hdmi_vbl,
+	input  wire        cmd_start,
+	input  wire        cmd_data,
+	input  wire [7:0]  cmd_id,
+	input  wire [3:0]  word_index,
+	input  wire [15:0] data_in,
+
+	input  wire        active_lfb_en,
+	input  wire [31:0] active_lfb_base,
+	input  wire [11:0] active_lfb_width,
+	input  wire [11:0] active_lfb_height,
+	input  wire [13:0] active_lfb_stride,
+
+	output wire        response_valid,
+	output reg  [15:0] response_data,
+	output wire        apply,
+
+	output reg         route_en = 1'b0,
+	output reg         route_flt = 1'b0,
+	output reg  [5:0]  route_fmt = 6'd0,
+	output reg  [11:0] route_width = 12'd0,
+	output reg  [11:0] route_height = 12'd0,
+	output reg  [11:0] route_hmin = 12'd0,
+	output reg  [11:0] route_hmax = 12'd0,
+	output reg  [11:0] route_vmin = 12'd0,
+	output reg  [11:0] route_vmax = 12'd0,
+	output reg  [31:0] route_base = 32'd0,
+	output reg  [13:0] route_stride = 14'd0,
+
+	output reg         pending = 1'b0,
+	output reg  [15:0] pending_seq = 16'd0,
+	output reg  [15:0] active_seq = 16'd0,
+	output reg  [15:0] post_count = 16'd0,
+	output reg  [15:0] flip_count = 16'd0,
+	output reg  [15:0] drop_count = 16'd0
+);
+
+	localparam [7:0]  MAGIK_UIO_SET_FBUF_LATCH = 8'h57;
+	localparam [7:0]  MAGIK_UIO_GET_FBUF_LATCH = 8'h58;
+	localparam [15:0] MAGIK_FBUF_LATCH_MAGIC = 16'h4D47;
+	localparam [15:0] MAGIK_FBUF_STATUS_MAGIC = 16'h4D48;
+
+	(* altera_attribute = "-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS" *)
+	reg vbl_meta = 1'b0;
+	(* altera_attribute = "-name SYNCHRONIZER_IDENTIFICATION FORCED_IF_ASYNCHRONOUS" *)
+	reg vbl_sys = 1'b0;
+	reg vbl_old = 1'b0;
+
+	wire vbl_rise = ~vbl_old & vbl_sys;
+	assign apply = pending && vbl_rise;
+	assign response_valid =
+		(cmd_start && ((cmd_id == MAGIK_UIO_SET_FBUF_LATCH) ||
+		               (cmd_id == MAGIK_UIO_GET_FBUF_LATCH))) ||
+		(cmd_data && (cmd_id == MAGIK_UIO_GET_FBUF_LATCH));
+
+	always @(*) begin
+		response_data = 16'd0;
+		if(cmd_start) begin
+			case(cmd_id)
+				MAGIK_UIO_SET_FBUF_LATCH: response_data = MAGIK_FBUF_LATCH_MAGIC;
+				MAGIK_UIO_GET_FBUF_LATCH: response_data = MAGIK_FBUF_STATUS_MAGIC;
+				default: response_data = 16'd0;
+			endcase
+		end
+		else if(cmd_data && (cmd_id == MAGIK_UIO_GET_FBUF_LATCH)) begin
+			case(word_index)
+				4'd0:  response_data = active_seq;
+				4'd1:  response_data = pending_seq;
+				4'd2:  response_data = {13'd0, pending, route_en, active_lfb_en};
+				4'd3:  response_data = flip_count;
+				4'd4:  response_data = post_count;
+				4'd5:  response_data = drop_count;
+				4'd6:  response_data = active_lfb_base[15:0];
+				4'd7:  response_data = active_lfb_base[31:16];
+				4'd8:  response_data = {4'd0, active_lfb_width};
+				4'd9:  response_data = {4'd0, active_lfb_height};
+				4'd10: response_data = {2'd0, active_lfb_stride};
+				default: response_data = 16'd0;
+			endcase
+		end
+	end
+
+	always @(posedge clk_sys) begin
+		vbl_meta <= hdmi_vbl;
+		vbl_sys <= vbl_meta;
+		vbl_old <= vbl_sys;
+
+		if(apply) begin
+			active_seq <= pending_seq;
+			flip_count <= flip_count + 1'd1;
+			pending <= 1'b0;
+		end
+
+		if(cmd_data && (cmd_id == MAGIK_UIO_SET_FBUF_LATCH)) begin
+			case(word_index)
+				4'd0:  {route_en, route_flt, route_fmt} <=
+					{data_in[15], data_in[14], data_in[5:0]};
+				4'd1:  route_base[15:0] <= data_in;
+				4'd2:  route_base[31:16] <= data_in;
+				4'd3:  route_width <= data_in[11:0];
+				4'd4:  route_height <= data_in[11:0];
+				4'd5:  route_hmin <= data_in[11:0];
+				4'd6:  route_hmax <= data_in[11:0];
+				4'd7:  route_vmin <= data_in[11:0];
+				4'd8:  route_vmax <= data_in[11:0];
+				4'd9:  route_stride <= data_in[13:0];
+				4'd10: begin
+					pending_seq <= data_in;
+					pending <= 1'b1;
+					post_count <= post_count + 1'd1;
+					if(pending) drop_count <= drop_count + 1'd1;
+				end
+				default: begin end
+			endcase
+		end
+	end
+
+endmodule
+
+`default_nettype wire

--- a/experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
+++ b/experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
@@ -40,6 +40,7 @@ module tb_mister_magik_vblank_latch;
 	wire [15:0] drop_count;
 
 	integer apply_count = 0;
+	reg [7:0] requirement_coverage = 8'd0;
 	reg [15:0] captured_seq = 16'd0;
 	reg [31:0] captured_base = 32'd0;
 	reg [11:0] captured_width = 12'd0;
@@ -267,6 +268,7 @@ module tb_mister_magik_vblank_latch;
 
 		check_ack(SET_LATCH, 16'h4D47);
 		check_ack(GET_LATCH, 16'h4D48);
+		requirement_coverage[0] = 1'b1; // LATCH-001
 		check_unrelated_ack();
 
 		// Partial and unrelated payloads can stage data but cannot post a route.
@@ -276,6 +278,7 @@ module tb_mister_magik_vblank_latch;
 		idle_cycles(4);
 		if(pending || (post_count != 0) || (flip_count != 0) || (apply_count != 0))
 			fail("partial or unrelated command posted a route");
+		requirement_coverage[2] = 1'b1; // LATCH-003
 
 		// Exercise every payload word and prove no edge means no application.
 		send_route(16'hC02A, 32'h12345678, 12'd960, 12'd540,
@@ -290,6 +293,7 @@ module tb_mister_magik_vblank_latch;
 		   route_hmax !== 12'd970 || route_vmin !== 12'd22 ||
 		   route_vmax !== 12'd561 || route_stride !== 14'd1920)
 			fail("staged route fields mismatch");
+		requirement_coverage[1] = 1'b1; // LATCH-002
 		idle_cycles(6);
 		if((flip_count != 0) || (apply_count != 0)) fail("route applied without vblank edge");
 
@@ -302,10 +306,12 @@ module tb_mister_magik_vblank_latch;
 		   captured_hmax !== 12'd970 || captured_vmin !== 12'd22 ||
 		   captured_vmax !== 12'd561 || captured_stride !== 14'd1920)
 			fail("route was not captured atomically on apply");
+		requirement_coverage[3] = 1'b1; // LATCH-004
 
 		// Keeping vblank high must not create another apply.
 		idle_cycles(5);
 		if((flip_count != 1) || (apply_count != 1)) fail("level or falling vblank applied route");
+		requirement_coverage[7] = 1'b1; // LATCH-008
 
 		// A complete replacement while pending wins and accounts one dropped post.
 		// Stage it while vblank remains high, then prove the falling edge is inert.
@@ -326,6 +332,7 @@ module tb_mister_magik_vblank_latch;
 		   captured_base !== 32'h30002000 || captured_width !== 12'd640 ||
 		   captured_height !== 12'd480 || captured_stride !== 14'd1280)
 			fail("replacement route did not win atomically");
+		requirement_coverage[4] = 1'b1; // LATCH-005
 		lower_vblank();
 
 		// Exact status layout, including externally-owned active route fields.
@@ -346,6 +353,7 @@ module tb_mister_magik_vblank_latch;
 		expect_status(4'd9, 16'd720);
 		expect_status(4'd10, 16'd2560);
 		expect_status(4'd15, 16'd0);
+		requirement_coverage[5] = 1'b1; // LATCH-006
 
 		// Force the natural 16-bit wrap boundaries, then exercise them normally.
 		@(negedge clk_sys);
@@ -368,6 +376,10 @@ module tb_mister_magik_vblank_latch;
 		expect16(pending_seq, 16'h0000, "sequence wrap to zero");
 		raise_vblank_and_wait_for_flip(16'h0001, 4);
 		expect16(active_seq, 16'h0000, "active sequence wrap");
+		requirement_coverage[6] = 1'b1; // LATCH-007
+
+		if(requirement_coverage !== 8'hFF) fail("not all RTL requirement coverpoints hit");
+		$display("COVER LATCH-001..LATCH-008 all RTL requirements hit");
 
 		$display("PASS: mister_magik_vblank_latch protocol and vblank semantics");
 		$finish;

--- a/experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
+++ b/experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
@@ -274,10 +274,11 @@ module tb_mister_magik_vblank_latch;
 		// Partial and unrelated payloads can stage data but cannot post a route.
 		send_word(SET_LATCH, 4'd0, 16'hC02A);
 		send_word(SET_LATCH, 4'd1, 16'h5678);
+		send_word(SET_LATCH, 4'd15, 16'hFFFF);
 		send_word(8'h56, 4'd10, 16'h9999);
 		idle_cycles(4);
 		if(pending || (post_count != 0) || (flip_count != 0) || (apply_count != 0))
-			fail("partial or unrelated command posted a route");
+			fail("partial, out-of-range, or unrelated word posted a route");
 		requirement_coverage[2] = 1'b1; // LATCH-003
 
 		// Exercise every payload word and prove no edge means no application.

--- a/experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
+++ b/experiments/fpga-vblank-latch/tb_mister_magik_vblank_latch.sv
@@ -1,0 +1,383 @@
+`timescale 1ns/1ps
+`default_nettype none
+
+module tb_mister_magik_vblank_latch;
+	localparam [7:0] SET_LATCH = 8'h57;
+	localparam [7:0] GET_LATCH = 8'h58;
+
+	reg clk_sys = 1'b0;
+	reg hdmi_vbl = 1'b0;
+	reg cmd_start = 1'b0;
+	reg cmd_data = 1'b0;
+	reg [7:0] cmd_id = 8'd0;
+	reg [3:0] word_index = 4'd0;
+	reg [15:0] data_in = 16'd0;
+	reg active_lfb_en = 1'b0;
+	reg [31:0] active_lfb_base = 32'd0;
+	reg [11:0] active_lfb_width = 12'd0;
+	reg [11:0] active_lfb_height = 12'd0;
+	reg [13:0] active_lfb_stride = 14'd0;
+
+	wire response_valid;
+	wire [15:0] response_data;
+	wire apply;
+	wire route_en;
+	wire route_flt;
+	wire [5:0] route_fmt;
+	wire [11:0] route_width;
+	wire [11:0] route_height;
+	wire [11:0] route_hmin;
+	wire [11:0] route_hmax;
+	wire [11:0] route_vmin;
+	wire [11:0] route_vmax;
+	wire [31:0] route_base;
+	wire [13:0] route_stride;
+	wire pending;
+	wire [15:0] pending_seq;
+	wire [15:0] active_seq;
+	wire [15:0] post_count;
+	wire [15:0] flip_count;
+	wire [15:0] drop_count;
+
+	integer apply_count = 0;
+	reg [15:0] captured_seq = 16'd0;
+	reg [31:0] captured_base = 32'd0;
+	reg [11:0] captured_width = 12'd0;
+	reg [11:0] captured_height = 12'd0;
+	reg [11:0] captured_hmin = 12'd0;
+	reg [11:0] captured_hmax = 12'd0;
+	reg [11:0] captured_vmin = 12'd0;
+	reg [11:0] captured_vmax = 12'd0;
+	reg [13:0] captured_stride = 14'd0;
+	reg [7:0] captured_mode = 8'd0;
+
+	mister_magik_vblank_latch dut (
+		.clk_sys(clk_sys),
+		.hdmi_vbl(hdmi_vbl),
+		.cmd_start(cmd_start),
+		.cmd_data(cmd_data),
+		.cmd_id(cmd_id),
+		.word_index(word_index),
+		.data_in(data_in),
+		.active_lfb_en(active_lfb_en),
+		.active_lfb_base(active_lfb_base),
+		.active_lfb_width(active_lfb_width),
+		.active_lfb_height(active_lfb_height),
+		.active_lfb_stride(active_lfb_stride),
+		.response_valid(response_valid),
+		.response_data(response_data),
+		.apply(apply),
+		.route_en(route_en),
+		.route_flt(route_flt),
+		.route_fmt(route_fmt),
+		.route_width(route_width),
+		.route_height(route_height),
+		.route_hmin(route_hmin),
+		.route_hmax(route_hmax),
+		.route_vmin(route_vmin),
+		.route_vmax(route_vmax),
+		.route_base(route_base),
+		.route_stride(route_stride),
+		.pending(pending),
+		.pending_seq(pending_seq),
+		.active_seq(active_seq),
+		.post_count(post_count),
+		.flip_count(flip_count),
+		.drop_count(drop_count)
+	);
+
+	always #5 clk_sys = ~clk_sys;
+
+	always @(posedge clk_sys) begin
+		if(apply) begin
+			apply_count = apply_count + 1;
+			captured_seq = pending_seq;
+			captured_base = route_base;
+			captured_width = route_width;
+			captured_height = route_height;
+			captured_hmin = route_hmin;
+			captured_hmax = route_hmax;
+			captured_vmin = route_vmin;
+			captured_vmax = route_vmax;
+			captured_stride = route_stride;
+			captured_mode = {route_en, route_flt, route_fmt};
+		end
+	end
+
+	task automatic fail(input [8*96-1:0] message);
+		begin
+			$display("FAIL: %0s", message);
+			$fatal(1);
+		end
+	endtask
+
+	task automatic expect16(
+		input [15:0] actual,
+		input [15:0] expected,
+		input [8*96-1:0] message
+	);
+		begin
+			if(actual !== expected) begin
+				$display("FAIL: %0s: got %04x expected %04x", message, actual, expected);
+				$fatal(1);
+			end
+		end
+	endtask
+
+	task automatic expect_true(input condition, input [8*96-1:0] message);
+		begin
+			if(condition !== 1'b1) fail(message);
+		end
+	endtask
+
+	task automatic idle_cycles(input integer count);
+		integer i;
+		begin
+			for(i = 0; i < count; i = i + 1) @(posedge clk_sys);
+			#1;
+		end
+	endtask
+
+	task automatic check_ack(input [7:0] command, input [15:0] expected);
+		begin
+			@(negedge clk_sys);
+			cmd_id = command;
+			cmd_start = 1'b1;
+			#1;
+			expect_true(response_valid, "recognized command must acknowledge");
+			expect16(response_data, expected, "command acknowledgement magic");
+			@(negedge clk_sys);
+			cmd_start = 1'b0;
+		end
+	endtask
+
+	task automatic check_unrelated_ack;
+		begin
+			@(negedge clk_sys);
+			cmd_id = 8'h56;
+			cmd_start = 1'b1;
+			#1;
+			if(response_valid !== 1'b0) fail("unrelated command acknowledged");
+			@(negedge clk_sys);
+			cmd_start = 1'b0;
+		end
+	endtask
+
+	task automatic send_word(
+		input [7:0] command,
+		input [3:0] index,
+		input [15:0] value
+	);
+		begin
+			@(negedge clk_sys);
+			cmd_id = command;
+			word_index = index;
+			data_in = value;
+			cmd_data = 1'b1;
+			@(posedge clk_sys);
+			#1;
+			cmd_data = 1'b0;
+		end
+	endtask
+
+	task automatic expect_status(input [3:0] index, input [15:0] expected);
+		begin
+			@(negedge clk_sys);
+			cmd_id = GET_LATCH;
+			word_index = index;
+			cmd_data = 1'b1;
+			#1;
+			expect_true(response_valid, "status word must be valid");
+			expect16(response_data, expected, "status word mismatch");
+			cmd_data = 1'b0;
+		end
+	endtask
+
+	task automatic send_route(
+		input [15:0] mode_value,
+		input [31:0] base,
+		input [11:0] width,
+		input [11:0] height,
+		input [11:0] hmin,
+		input [11:0] hmax,
+		input [11:0] vmin,
+		input [11:0] vmax,
+		input [13:0] stride,
+		input [15:0] seq_value
+	);
+		begin
+			send_word(SET_LATCH, 4'd0, mode_value);
+			send_word(SET_LATCH, 4'd1, base[15:0]);
+			send_word(SET_LATCH, 4'd2, base[31:16]);
+			send_word(SET_LATCH, 4'd3, {4'd0, width});
+			send_word(SET_LATCH, 4'd4, {4'd0, height});
+			send_word(SET_LATCH, 4'd5, {4'd0, hmin});
+			send_word(SET_LATCH, 4'd6, {4'd0, hmax});
+			send_word(SET_LATCH, 4'd7, {4'd0, vmin});
+			send_word(SET_LATCH, 4'd8, {4'd0, vmax});
+			send_word(SET_LATCH, 4'd9, {2'd0, stride});
+			send_word(SET_LATCH, 4'd10, seq_value);
+		end
+	endtask
+
+	task automatic raise_vblank_and_wait_for_flip(
+		input [15:0] expected_flip,
+		input integer expected_apply_count
+	);
+		integer i;
+		reg found;
+		begin
+			@(negedge clk_sys);
+			hdmi_vbl = 1'b1;
+			found = 1'b0;
+			for(i = 0; i < 8; i = i + 1) begin
+				@(posedge clk_sys);
+				#1;
+				if(flip_count == expected_flip) begin
+					found = 1'b1;
+					i = 8;
+				end
+			end
+			if(!found) fail("bounded wait for vblank flip expired");
+			if(apply_count != expected_apply_count) fail("apply pulse count mismatch");
+		end
+	endtask
+
+	task automatic lower_vblank;
+		begin
+			@(negedge clk_sys);
+			hdmi_vbl = 1'b0;
+			idle_cycles(4);
+		end
+	endtask
+
+	initial begin
+		idle_cycles(2);
+
+		expect16(active_seq, 16'd0, "power-up active sequence");
+		expect16(pending_seq, 16'd0, "power-up pending sequence");
+		expect16(post_count, 16'd0, "power-up post count");
+		expect16(flip_count, 16'd0, "power-up flip count");
+		expect16(drop_count, 16'd0, "power-up drop count");
+		if(pending || route_en || route_flt || (route_fmt != 0) ||
+		   (route_base != 0) || (route_width != 0) || (route_height != 0) ||
+		   (route_hmin != 0) || (route_hmax != 0) || (route_vmin != 0) ||
+		   (route_vmax != 0) || (route_stride != 0))
+			fail("power-up route state is not zero");
+
+		check_ack(SET_LATCH, 16'h4D47);
+		check_ack(GET_LATCH, 16'h4D48);
+		check_unrelated_ack();
+
+		// Partial and unrelated payloads can stage data but cannot post a route.
+		send_word(SET_LATCH, 4'd0, 16'hC02A);
+		send_word(SET_LATCH, 4'd1, 16'h5678);
+		send_word(8'h56, 4'd10, 16'h9999);
+		idle_cycles(4);
+		if(pending || (post_count != 0) || (flip_count != 0) || (apply_count != 0))
+			fail("partial or unrelated command posted a route");
+
+		// Exercise every payload word and prove no edge means no application.
+		send_route(16'hC02A, 32'h12345678, 12'd960, 12'd540,
+		           12'd11, 12'd970, 12'd22, 12'd561, 14'd1920, 16'h0010);
+		expect_true(pending, "sequence word must set pending");
+		expect16(pending_seq, 16'h0010, "pending sequence after post");
+		expect16(post_count, 16'd1, "post count after first post");
+		expect16(drop_count, 16'd0, "first post must not drop");
+		if({route_en, route_flt, route_fmt} !== 8'hEA ||
+		   route_base !== 32'h12345678 || route_width !== 12'd960 ||
+		   route_height !== 12'd540 || route_hmin !== 12'd11 ||
+		   route_hmax !== 12'd970 || route_vmin !== 12'd22 ||
+		   route_vmax !== 12'd561 || route_stride !== 14'd1920)
+			fail("staged route fields mismatch");
+		idle_cycles(6);
+		if((flip_count != 0) || (apply_count != 0)) fail("route applied without vblank edge");
+
+		raise_vblank_and_wait_for_flip(16'd1, 1);
+		expect16(active_seq, 16'h0010, "active sequence after first flip");
+		if(pending) fail("pending did not clear after flip");
+		if(captured_seq !== 16'h0010 || captured_mode !== 8'hEA ||
+		   captured_base !== 32'h12345678 || captured_width !== 12'd960 ||
+		   captured_height !== 12'd540 || captured_hmin !== 12'd11 ||
+		   captured_hmax !== 12'd970 || captured_vmin !== 12'd22 ||
+		   captured_vmax !== 12'd561 || captured_stride !== 14'd1920)
+			fail("route was not captured atomically on apply");
+
+		// Keeping vblank high must not create another apply.
+		idle_cycles(5);
+		if((flip_count != 1) || (apply_count != 1)) fail("level or falling vblank applied route");
+
+		// A complete replacement while pending wins and accounts one dropped post.
+		// Stage it while vblank remains high, then prove the falling edge is inert.
+		send_route(16'h8021, 32'h20001000, 12'd1280, 12'd720,
+		           12'd1, 12'd1280, 12'd2, 12'd721, 14'd2560, 16'h0020);
+		send_route(16'h4022, 32'h30002000, 12'd640, 12'd480,
+		           12'd3, 12'd642, 12'd4, 12'd483, 14'd1280, 16'h0021);
+		expect16(post_count, 16'd3, "post count after replacement");
+		expect16(drop_count, 16'd1, "replacement drop count");
+		expect16(pending_seq, 16'h0021, "replacement pending sequence");
+		if((flip_count != 1) || (apply_count != 1)) fail("high vblank level applied replacement");
+		lower_vblank();
+		if(!pending || (flip_count != 1) || (apply_count != 1))
+			fail("falling vblank edge applied replacement");
+		raise_vblank_and_wait_for_flip(16'd2, 2);
+		expect16(active_seq, 16'h0021, "replacement active sequence");
+		if(captured_seq !== 16'h0021 || captured_mode !== 8'h62 ||
+		   captured_base !== 32'h30002000 || captured_width !== 12'd640 ||
+		   captured_height !== 12'd480 || captured_stride !== 14'd1280)
+			fail("replacement route did not win atomically");
+		lower_vblank();
+
+		// Exact status layout, including externally-owned active route fields.
+		active_lfb_en = 1'b1;
+		active_lfb_base = 32'h89ABCDEF;
+		active_lfb_width = 12'd1280;
+		active_lfb_height = 12'd720;
+		active_lfb_stride = 14'd2560;
+		expect_status(4'd0, 16'h0021);
+		expect_status(4'd1, 16'h0021);
+		expect_status(4'd2, 16'h0001);
+		expect_status(4'd3, 16'd2);
+		expect_status(4'd4, 16'd3);
+		expect_status(4'd5, 16'd1);
+		expect_status(4'd6, 16'hCDEF);
+		expect_status(4'd7, 16'h89AB);
+		expect_status(4'd8, 16'd1280);
+		expect_status(4'd9, 16'd720);
+		expect_status(4'd10, 16'd2560);
+		expect_status(4'd15, 16'd0);
+
+		// Force the natural 16-bit wrap boundaries, then exercise them normally.
+		@(negedge clk_sys);
+		dut.post_count = 16'hFFFF;
+		dut.flip_count = 16'hFFFF;
+		dut.drop_count = 16'hFFFF;
+		send_route(16'h8001, 32'h40000000, 12'd320, 12'd240,
+		           12'd0, 12'd319, 12'd0, 12'd239, 14'd640, 16'hFFFF);
+		expect16(post_count, 16'h0000, "post counter wrap");
+		send_word(SET_LATCH, 4'd10, 16'hFFFF);
+		expect16(post_count, 16'h0001, "post count after wrapped replacement");
+		expect16(drop_count, 16'h0000, "drop counter wrap");
+		expect16(pending_seq, 16'hFFFF, "maximum pending sequence");
+		raise_vblank_and_wait_for_flip(16'h0000, 3);
+		expect16(flip_count, 16'h0000, "flip counter wrap");
+		expect16(active_seq, 16'hFFFF, "maximum active sequence");
+		lower_vblank();
+		send_route(16'h0000, 32'h00000000, 12'd0, 12'd0,
+		           12'd0, 12'd0, 12'd0, 12'd0, 14'd0, 16'h0000);
+		expect16(pending_seq, 16'h0000, "sequence wrap to zero");
+		raise_vblank_and_wait_for_flip(16'h0001, 4);
+		expect16(active_seq, 16'h0000, "active sequence wrap");
+
+		$display("PASS: mister_magik_vblank_latch protocol and vblank semantics");
+		$finish;
+	end
+
+	initial begin
+		#20000;
+		fail("global simulation timeout");
+	end
+
+endmodule
+
+`default_nettype wire

--- a/experiments/fpga-vblank-latch/verilator_coverage_main.cpp
+++ b/experiments/fpga-vblank-latch/verilator_coverage_main.cpp
@@ -1,0 +1,17 @@
+#include "Vtb_mister_magik_vblank_latch.h"
+#include "verilated.h"
+#include "verilated_cov.h"
+
+int main(int argc, char** argv) {
+    VerilatedContext context;
+    context.commandArgs(argc, argv);
+    Vtb_mister_magik_vblank_latch model{&context};
+    while (!context.gotFinish()) {
+        model.eval();
+        if (!model.eventsPending()) break;
+        context.time(model.nextTimeSlot());
+    }
+    model.final();
+    context.coveragep()->write("coverage.dat");
+    return context.gotFinish() ? 0 : 1;
+}

--- a/history/2026-07-11-fpga-latch-release-candidate.md
+++ b/history/2026-07-11-fpga-latch-release-candidate.md
@@ -1,0 +1,28 @@
+# FPGA latch release candidate evidence - 2026-07-11
+
+The extracted `0x57`/`0x58` vblank latch candidate has SHA-256
+`69e0e312b226c004bfe7fced2cc1145954efa1110cee7a0f58de1528d52627a1`.
+GitHub Actions run `29158797784` produced the matched stock/patched Quartus
+evidence and returned `quartus_delta_signoff_tsv valid=1`. Fast RTL run
+`29159218946` passed simulation, lint, integration/opcode checks, functional
+points, and complete reachable custom-module line coverage.
+
+The first performance comparison reused pre-visual-change baseline samples and
+correctly failed the 3% Arcade comparison. Repeating the baseline with the same
+current binary isolated the RBF variable. The corrected matched comparison
+returned `valid=1`: Home baseline/candidate median p99 work was 6799.5/6788.0 us
+and Arcade was 5282.0/5374.5 us. All candidate rows had zero latch deadline,
+visual, alternation, flip-gap, and unexpected-drop failures.
+
+The exact candidate accepted `0x57` and `0x58`, advanced post/flip counters,
+incremented drops under deliberate over-posting, and recovered at normal
+cadence. A 1920x1080 USB HDMI capture and contact strips are retained under the
+ignored `build/launcher-home-pan-captures/` directory; large raw evidence is not
+committed.
+
+Commercial signoff was not reached. The 1280x720 hidden route falls back because
+the 1,040,384-byte slots cannot hold a 1,843,200-byte RGB565 frame. The existing
+game-return smoke failed to write its return-state marker twice, the two-hour
+soak was deferred, and second-unit plus independent review remain outstanding.
+The qualification and lifecycle runners were hardened to clear persistent
+launcher/fault arming files on failure. No such files remained after testing.

--- a/magik-gui/src/main.rs
+++ b/magik-gui/src/main.rs
@@ -1377,11 +1377,15 @@ fn run_fpga_latch_pattern(fpga: &mut Fpga) {
     let mut post_samples = Vec::with_capacity(frames);
     let mut status_samples = Vec::with_capacity(frames);
     let mut unsupported_posts = 0usize;
-    let period = std::time::Duration::from_micros(16_667);
+    let period_us = std::env::var("MISTER_FPGA_LATCH_PATTERN_PERIOD_US")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(16_667);
+    let period = std::time::Duration::from_micros(period_us);
     let mut next_deadline = std::time::Instant::now();
 
     crate::ui_logln!(
-        "fpga_latch_pattern_header_tsv\tframes={frames}\twidth={width}\theight={height}\tstride_bytes={stride_bytes}\tbytes_per_frame={}\tbuffer1_phys=0x{base1:08x}\tbuffer2_phys=0x{base2:08x}",
+        "fpga_latch_pattern_header_tsv\tframes={frames}\tperiod_us={period_us}\twidth={width}\theight={height}\tstride_bytes={stride_bytes}\tbytes_per_frame={}\tbuffer1_phys=0x{base1:08x}\tbuffer2_phys=0x{base2:08x}",
         stride_bytes * height
     );
     crate::ui_logln!(

--- a/magik-gui/ui/components/launcher_chrome.slint
+++ b/magik-gui/ui/components/launcher_chrome.slint
@@ -26,12 +26,15 @@ export component LauncherTile inherits Rectangle {
 
         if subtitle != "" : Text {
             text: subtitle;
-            color: #9080a8;
-            opacity: flat-focus-style ? (focused ? 1.0 : 0.0) : 1.0;
+            color: flat-focus-style
+                ? (focused ? #9080a8ff : #9080a800)
+                : #9080a8ff;
             font-size: 8px;
             horizontal-alignment: center;
 
-            animate opacity { duration: 100ms; easing: Easing.ease-in-out; }
+            // In the RGB565 software-renderer launcher mock, animating color alpha
+            // was slightly faster than animating Text opacity for this subtitle fade.
+            animate color { duration: 100ms; easing: Easing.ease-in-out; }
         }
     }
 }

--- a/scripts/analyze-max-scroll-drops.py
+++ b/scripts/analyze-max-scroll-drops.py
@@ -334,7 +334,7 @@ def print_summary(
     )
     visual_latch_misses = len(latch_misses) + buffer_failures + flip_failures
     scheduler_wake_jitter_misses = len(cadence_misses)
-    latch_valid = not latch_rows or (
+    latch_valid = bool(latch_rows) and (
         len(latch_misses) == 0
         and buffer_failures == 0
         and flip_failures == 0
@@ -536,6 +536,14 @@ def run_self_test() -> int:
         return 1
     if print_summary("self-latch-pass", [base, next_frame], [], 1, LATCH_BACKEND, report_before, report_after) != 0:
         print("self-test expected latch pass", file=sys.stderr)
+        return 1
+    fallback = dict(base)
+    fallback["main_present_backend"] = "fb0-dirty"
+    fallback["main_present_status"] = "none"
+    fallback_next = dict(fallback)
+    fallback_next["frame"] = "32"
+    if print_summary("self-latch-backend-fail", [fallback, fallback_next], [], 1, LATCH_BACKEND, report_before, report_after) == 0:
+        print("self-test expected latch backend failure", file=sys.stderr)
         return 1
     if print_summary("self-latch-fail", [missed, next_frame], [], 1, LATCH_BACKEND, report_before, report_after) == 0:
         print("self-test expected latch failure", file=sys.stderr)

--- a/scripts/build-fpga-vblank-latch-core.sh
+++ b/scripts/build-fpga-vblank-latch-core.sh
@@ -118,6 +118,9 @@ case "$APPLY_PATCH" in
 esac
 
 {
+  echo "format=mister-magik-fpga-release-v1"
+  git -C "$ROOT" rev-parse HEAD 2>/dev/null | sed 's/^/magik_commit=/'
+  git -C "$ROOT" status --short --untracked-files=no 2>/dev/null | sed 's/^/magik_status=/'
   echo "source_dir=$MENU_ABS"
   git -C "$MENU_ABS" rev-parse HEAD 2>/dev/null | sed 's/^/source_commit=/'
   git -C "$MENU_ABS" status --short 2>/dev/null | sed 's/^/source_status=/'
@@ -130,6 +133,12 @@ esac
   echo "quartus_strace=${QUARTUS_STRACE:-0}"
   echo "quartus_docker_privileged=${QUARTUS_DOCKER_PRIVILEGED:-0}"
   echo "quartus_docker_empty_sys=${QUARTUS_DOCKER_EMPTY_SYS:-0}"
+  awk '/^-?set_global_assignment -name SEED / {print "quartus_seed="$NF}' "$WORK_DIR/menu.qsf" | tail -1
+  if [[ -n "${GITHUB_SERVER_URL:-}" && -n "${GITHUB_REPOSITORY:-}" && -n "${GITHUB_RUN_ID:-}" ]]; then
+    echo "workflow_url=$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+  else
+    echo "workflow_url=local"
+  fi
 } > "$META_OUT"
 
 build_status=0
@@ -194,5 +203,15 @@ fi
 
 cp "$RBF_CANDIDATE" "$RBF_OUT"
 shasum -a 256 "$RBF_OUT" | awk '{print "rbf_sha256="$1}' >> "$META_OUT"
-echo "rbf=$RBF_OUT" >> "$META_OUT"
+echo "rbf_file=$(basename "$RBF_OUT")" >> "$META_OUT"
+quartus_version="$(sed -n 's/.*Version \([0-9][^ ]* Build [0-9][^ ]*\).*/\1/p' "$LOG_OUT" | head -1)"
+echo "quartus_version=${quartus_version:-17.0.0 Build 595}" >> "$META_OUT"
+rm -rf "$OUT_DIR/reports"
+mkdir -p "$OUT_DIR/reports"
+find "$WORK_DIR/output_files" -maxdepth 1 -type f \( -name '*.rpt' -o -name '*.summary' \) -exec cp {} "$OUT_DIR/reports/" \;
+find "$OUT_DIR/reports" -type f -print0 | sort -z | while IFS= read -r -d '' report; do
+  relative="reports/$(basename "$report")"
+  hash="$(shasum -a 256 "$report" | awk '{print $1}')"
+  echo "report_sha256.$relative=$hash" >> "$META_OUT"
+done
 echo "$RBF_OUT"

--- a/scripts/build-fpga-vblank-latch-core.sh
+++ b/scripts/build-fpga-vblank-latch-core.sh
@@ -205,7 +205,11 @@ cp "$RBF_CANDIDATE" "$RBF_OUT"
 shasum -a 256 "$RBF_OUT" | awk '{print "rbf_sha256="$1}' >> "$META_OUT"
 echo "rbf_file=$(basename "$RBF_OUT")" >> "$META_OUT"
 quartus_version="$(sed -n 's/.*Version \([0-9][^ ]* Build [0-9][^ ]*\).*/\1/p' "$LOG_OUT" | head -1)"
-echo "quartus_version=${quartus_version:-17.0.0 Build 595}" >> "$META_OUT"
+if [[ -z "$quartus_version" ]]; then
+  echo "Quartus version was not found in $LOG_OUT" >&2
+  exit 1
+fi
+echo "quartus_version=$quartus_version" >> "$META_OUT"
 rm -rf "$OUT_DIR/reports"
 mkdir -p "$OUT_DIR/reports"
 find "$WORK_DIR/output_files" -maxdepth 1 -type f \( -name '*.rpt' -o -name '*.summary' \) -exec cp {} "$OUT_DIR/reports/" \;

--- a/scripts/build-fpga-vblank-latch-core.sh
+++ b/scripts/build-fpga-vblank-latch-core.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PATCH="$ROOT/experiments/fpga-vblank-latch/Menu_MiSTer-vblank-latched-fbuf.patch"
+LATCH_RTL="$ROOT/experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv"
 OUT_DIR="$ROOT/build/fpga-vblank-latch"
 WORK_DIR="${MISTER_MENU_BUILD_DIR:-$OUT_DIR/Menu_MiSTer-vblank-latch-work}"
 if [[ -n "${MISTER_MENU_DIR:-}" ]]; then
@@ -111,6 +112,8 @@ case "$APPLY_PATCH" in
       echo "patch does not apply cleanly to $MENU_ABS" >&2
       git -C "$WORK_DIR" apply --recount --check "$PATCH"
     fi
+    cp "$LATCH_RTL" "$WORK_DIR/sys/mister_magik_vblank_latch.sv"
+    printf '\nset_global_assignment -name SYSTEMVERILOG_FILE sys/mister_magik_vblank_latch.sv\n' >> "$WORK_DIR/menu.qsf"
     ;;
 esac
 
@@ -119,6 +122,7 @@ esac
   git -C "$MENU_ABS" rev-parse HEAD 2>/dev/null | sed 's/^/source_commit=/'
   git -C "$MENU_ABS" status --short 2>/dev/null | sed 's/^/source_status=/'
   shasum -a 256 "$PATCH" | awk '{print "patch_sha256="$1}'
+  shasum -a 256 "$LATCH_RTL" | awk '{print "latch_rtl_sha256="$1}'
   echo "apply_patch=$APPLY_PATCH"
   echo "work_dir=$WORK_DIR"
   echo "quartus_mode=$QUARTUS_MODE"

--- a/scripts/build-fpga-vblank-latch-core.sh
+++ b/scripts/build-fpga-vblank-latch-core.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PATCH="$ROOT/experiments/fpga-vblank-latch/Menu_MiSTer-vblank-latched-fbuf.patch"
 LATCH_RTL="$ROOT/experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv"
-OUT_DIR="$ROOT/build/fpga-vblank-latch"
+OUT_DIR="${MISTER_FPGA_OUT_DIR:-$ROOT/build/fpga-vblank-latch}"
 WORK_DIR="${MISTER_MENU_BUILD_DIR:-$OUT_DIR/Menu_MiSTer-vblank-latch-work}"
 if [[ -n "${MISTER_MENU_DIR:-}" ]]; then
   MENU_DIR="$MISTER_MENU_DIR"

--- a/scripts/check-fpga-device-qualification.py
+++ b/scripts/check-fpga-device-qualification.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Compare matched baseline/candidate latch gate summaries."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+from pathlib import Path
+
+ZERO_FIELDS = (
+    "latch_deadline_misses",
+    "visual_latch_misses",
+    "buffer_alternation_failures",
+    "flip_counter_gaps",
+    "fpga_drop_count_max",
+)
+
+
+def summary(path: Path) -> dict[str, str]:
+    for line in path.read_text().splitlines():
+        if line.startswith("max_scroll_gate_tsv"):
+            fields: dict[str, str] = {}
+            for token in line.replace("\t", " ").split()[1:]:
+                if "=" in token:
+                    key, value = token.split("=", 1)
+                    fields[key] = value
+            return fields
+    raise ValueError(f"no max_scroll_gate_tsv row: {path}")
+
+
+def check_family(name: str, baseline_paths: list[Path], candidate_paths: list[Path]) -> tuple[list[str], dict[str, float]]:
+    reasons: list[str] = []
+    if len(baseline_paths) != 2 or len(candidate_paths) != 2:
+        return [f"{name}_requires_two_baseline_and_candidate_samples"], {}
+    baseline = [summary(path) for path in baseline_paths]
+    candidate = [summary(path) for path in candidate_paths]
+    for index, row in enumerate(candidate, 1):
+        if row.get("valid") != "1":
+            reasons.append(f"{name}_candidate_{index}_gate_invalid")
+        for field in ZERO_FIELDS:
+            if row.get(field) != "0":
+                reasons.append(f"{name}_candidate_{index}_{field}")
+        if row.get("fpga_counters_advanced") != "1":
+            reasons.append(f"{name}_candidate_{index}_counter_stall")
+    baseline_median = statistics.median(int(row["work_p99"]) for row in baseline)
+    candidate_median = statistics.median(int(row["work_p99"]) for row in candidate)
+    limit = baseline_median * 1.03
+    if candidate_median > limit:
+        reasons.append(f"{name}_p99_regression")
+    return reasons, {
+        f"{name}_baseline_median_p99_work_us": baseline_median,
+        f"{name}_candidate_median_p99_work_us": candidate_median,
+        f"{name}_candidate_limit_p99_work_us": limit,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    for family in ("home", "arcade"):
+        parser.add_argument(f"--baseline-{family}", action="append", type=Path, required=True)
+        parser.add_argument(f"--candidate-{family}", action="append", type=Path, required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+    reasons: list[str] = []
+    details: dict[str, float] = {}
+    for family in ("home", "arcade"):
+        family_reasons, family_details = check_family(
+            family,
+            getattr(args, f"baseline_{family}"),
+            getattr(args, f"candidate_{family}"),
+        )
+        reasons.extend(family_reasons)
+        details.update(family_details)
+    payload = {"valid": int(not reasons), "invalid_reason": ",".join(reasons) or "ok", **details}
+    if args.json:
+        print(json.dumps(payload, sort_keys=True, separators=(",", ":")))
+    else:
+        print("fpga_device_qualification_tsv\t" + "\t".join(f"{key}={value}" for key, value in payload.items()))
+    return 0 if not reasons else 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except (OSError, ValueError, KeyError) as error:
+        print(f"qualification summary failed: {error}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/check-fpga-latch-coverage.py
+++ b/scripts/check-fpga-latch-coverage.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Require every Verilator flow/branch point in the custom RTL to be hit."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("annotation_dir", type=Path)
+    parser.add_argument("--source", default="mister_magik_vblank_latch.sv")
+    args = parser.parse_args()
+
+    matches = list(args.annotation_dir.rglob(args.source))
+    if len(matches) != 1:
+        print(f"expected one annotated {args.source}, found {len(matches)}", file=sys.stderr)
+        raise SystemExit(1)
+    annotations = matches[0].read_text().splitlines()
+    incomplete = [line for line in annotations if line.startswith(("%", "~"))]
+    covered = [line for line in annotations if re.match(r"^[ +]?\d+", line)]
+    if not covered:
+        print(f"no coverage points found for {args.source}", file=sys.stderr)
+        raise SystemExit(1)
+    if incomplete:
+        print("incomplete custom RTL line/branch coverage:", file=sys.stderr)
+        for line in incomplete:
+            print(line, file=sys.stderr)
+        raise SystemExit(1)
+    print(f"custom RTL line/branch coverage complete: {len(covered)} annotated points")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-fpga-latch-integration.py
+++ b/scripts/check-fpga-latch-integration.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Apply and structurally verify the latch-only Menu integration patch."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+PINNED_MENU_COMMIT = "cf4dfdee516fcaa6952bdd9fb47154e96c28567e"
+COMMAND_PATTERNS = {
+    "0x57": re.compile(r"(?:cmd|io_din\s*\[\s*7\s*:\s*0\s*\])\s*==\s*(?:8\s*'h|')57", re.I),
+    "0x58": re.compile(r"(?:cmd|io_din\s*\[\s*7\s*:\s*0\s*\])\s*==\s*(?:8\s*'h|')58", re.I),
+}
+
+
+def fail(message: str) -> None:
+    print(f"FPGA integration check failed: {message}", file=sys.stderr)
+    raise SystemExit(1)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("menu_dir", type=Path)
+    parser.add_argument("--allow-unpinned", action="store_true")
+    args = parser.parse_args()
+
+    root = Path(__file__).resolve().parents[1]
+    menu = args.menu_dir.resolve()
+    sys_top = menu / "sys/sys_top.v"
+    qsf = menu / "menu.qsf"
+    if not sys_top.is_file() or not qsf.is_file():
+        fail(f"not a Menu_MiSTer checkout: {menu}")
+
+    commit = subprocess.run(
+        ["git", "-C", str(menu), "rev-parse", "HEAD"],
+        check=True,
+        text=True,
+        capture_output=True,
+    ).stdout.strip()
+    if not args.allow_unpinned and commit != PINNED_MENU_COMMIT:
+        fail(f"Menu commit {commit} is not pinned {PINNED_MENU_COMMIT}")
+
+    conflicts: list[str] = []
+    for path in sorted((menu / "sys").rglob("*")):
+        if path.suffix.lower() not in {".v", ".sv", ".vh"}:
+            continue
+        text = path.read_text(errors="replace")
+        for command, pattern in COMMAND_PATTERNS.items():
+            if pattern.search(text):
+                conflicts.append(f"{path.relative_to(menu)} uses {command}")
+    if conflicts:
+        fail("upstream opcode conflict: " + "; ".join(conflicts))
+
+    patch = root / "experiments/fpga-vblank-latch/Menu_MiSTer-vblank-latched-fbuf.patch"
+    rtl = root / "experiments/fpga-vblank-latch/mister_magik_vblank_latch.sv"
+    with tempfile.TemporaryDirectory(prefix="mister-magik-fpga-integration-") as temporary:
+        work = Path(temporary) / "Menu_MiSTer"
+        shutil.copytree(menu, work, ignore=shutil.ignore_patterns(".git", "db", "output_files"))
+        subprocess.run(["git", "apply", "--check", str(patch)], cwd=work, check=True)
+        subprocess.run(["git", "apply", str(patch)], cwd=work, check=True)
+        shutil.copy2(rtl, work / "sys/mister_magik_vblank_latch.sv")
+        with (work / "menu.qsf").open("a") as output:
+            output.write("\nset_global_assignment -name SYSTEMVERILOG_FILE sys/mister_magik_vblank_latch.sv\n")
+
+        patched = (work / "sys/sys_top.v").read_text()
+        required = (
+            "mister_magik_vblank_latch magik_vblank_latch",
+            ".cmd_start(io_uio && io_strobe && !has_cmd)",
+            ".cmd_data(io_uio && io_strobe && has_cmd)",
+            "if(magik_lfb_apply)",
+            "if(magik_response_valid) io_dout_sys <= magik_response_data;",
+        )
+        missing = [fragment for fragment in required if fragment not in patched]
+        if missing:
+            fail("patched integration is missing: " + ", ".join(missing))
+        qsf_text = (work / "menu.qsf").read_text()
+        assignment = "SYSTEMVERILOG_FILE sys/mister_magik_vblank_latch.sv"
+        if qsf_text.count(assignment) != 1:
+            fail("generated QSF must contain exactly one latch RTL assignment")
+
+    print(f"COVER LATCH-009 pinned Menu integration and opcode ownership ({commit})")
+    print("FPGA latch integration check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/check-fpga-quartus-delta.py
+++ b/scripts/check-fpga-quartus-delta.py
@@ -23,6 +23,9 @@ TABLE_ROW_RE = re.compile(rf"^\s*(?:Info \(\d+\):\s*)?({NUMBER})\s+({NUMBER})\s+
 CHAIN_COUNT_RE = re.compile(r"(?:Found|Found:)\s+(\d+)\s+synchronizer chains", re.IGNORECASE)
 MTBF_VALUE_RE = re.compile(rf"(?:MTBF|Mean Time Between Failures).*?({NUMBER})\s*(years?|seconds?|s)\b", re.IGNORECASE)
 UNCONSTRAINED_RE = re.compile(r"\bunconstrained\b|not fully constrained", re.IGNORECASE)
+UNCONSTRAINED_OUTPUT_RE = re.compile(r"Unconstrained Output Port Paths\s*;\s*(\d+)\s*;", re.IGNORECASE)
+UNCALCULATED_FRACTION_RE = re.compile(r"Fraction of Chains for which MTBFs Could Not be Calculated:\s*([0-9.]+)", re.IGNORECASE)
+SYNC_ASSIGN_RE = re.compile(r"SYNCHRONIZER_IDENTIFICATION\s*;\s*FORCED_IF_ASYNCHRONOUS.*;\s*(vbl_meta|vbl_sys)\s*;", re.IGNORECASE)
 RESOURCE_RE = re.compile(
     r"^\s*(Total (?:logic elements|registers|block memory bits|DSP Blocks))\s*[:;]\s*([\d,]+)",
     re.IGNORECASE,
@@ -31,6 +34,7 @@ RESOURCE_RE = re.compile(
 
 def normalize_space(value: str) -> str:
     value = re.sub(r"\s+File:\s+\S+\s+Line:\s+\d+\s*$", "", value, flags=re.IGNORECASE)
+    value = re.sub(r'Node "emu\|random\|lc0\|data[a-f]"', 'Node "emu|random|lc0|data*"', value, flags=re.IGNORECASE)
     return " ".join(value.split())
 
 
@@ -67,6 +71,9 @@ def parse_report(text: str, synchronizer_re: re.Pattern[str]) -> dict[str, objec
     custom_sync_lines: list[int] = []
     custom_sync_mtbf = False
     resources: dict[str, int] = {}
+    sync_assignments: set[str] = set()
+    uncalculated_fractions: list[float] = []
+    unconstrained_output_paths: list[int] = []
     timing_section: str | None = None
     in_tns_table = False
 
@@ -102,7 +109,10 @@ def parse_report(text: str, synchronizer_re: re.Pattern[str]) -> dict[str, objec
             if value is not None:
                 tns.append(value)
 
-        if UNCONSTRAINED_RE.search(line):
+        unconstrained_output = UNCONSTRAINED_OUTPUT_RE.search(line)
+        if unconstrained_output:
+            unconstrained_output_paths.append(int(unconstrained_output.group(1)))
+        elif UNCONSTRAINED_RE.search(line):
             unconstrained[normalize_space(line)] += 1
 
         chains = CHAIN_COUNT_RE.search(line)
@@ -111,6 +121,16 @@ def parse_report(text: str, synchronizer_re: re.Pattern[str]) -> dict[str, objec
 
         if synchronizer_re.search(line):
             custom_sync_lines.append(index)
+
+        sync_assignment = SYNC_ASSIGN_RE.search(line)
+        if sync_assignment:
+            sync_assignments.add(sync_assignment.group(1).lower())
+
+        fraction = UNCALCULATED_FRACTION_RE.search(line)
+        if fraction:
+            value = finite_number(fraction.group(1))
+            if value is not None:
+                uncalculated_fractions.append(value)
 
         resource = RESOURCE_RE.search(line)
         if resource:
@@ -134,6 +154,9 @@ def parse_report(text: str, synchronizer_re: re.Pattern[str]) -> dict[str, objec
         "custom_sync_seen": bool(custom_sync_lines),
         "custom_sync_mtbf": custom_sync_mtbf,
         "resources": resources,
+        "sync_assignments": sync_assignments,
+        "uncalculated_fractions": uncalculated_fractions,
+        "unconstrained_output_paths": unconstrained_output_paths,
     }
 
 
@@ -162,6 +185,13 @@ def compare(stock: dict[str, object], patched: dict[str, object]) -> tuple[list[
     added_unconstrained = counter_delta(stock_unconstrained, patched_unconstrained)
     if added_unconstrained:
         reasons.append("unconstrained_added")
+    stock_output_paths = stock["unconstrained_output_paths"]
+    patched_output_paths = patched["unconstrained_output_paths"]
+    assert isinstance(stock_output_paths, list) and isinstance(patched_output_paths, list)
+    if not stock_output_paths or not patched_output_paths:
+        reasons.append("unconstrained_output_summary_missing")
+    elif max(patched_output_paths) > max(stock_output_paths):
+        reasons.append("unconstrained_output_paths_added")
 
     slacks = patched["slacks"]
     assert isinstance(slacks, dict)
@@ -183,9 +213,25 @@ def compare(stock: dict[str, object], patched: dict[str, object]) -> tuple[list[
     assert isinstance(chain_counts, list)
     if not chain_counts or max(chain_counts) <= 0:
         reasons.append("synchronizer_report_missing")
-    if not patched["custom_sync_seen"]:
+    stock_chain_counts = stock["chain_counts"]
+    assert isinstance(stock_chain_counts, list)
+    sync_assignments = patched["sync_assignments"]
+    assert isinstance(sync_assignments, set)
+    custom_assignment_seen = sync_assignments == {"vbl_meta", "vbl_sys"}
+    stock_fractions = stock["uncalculated_fractions"]
+    patched_fractions = patched["uncalculated_fractions"]
+    assert isinstance(stock_fractions, list) and isinstance(patched_fractions, list)
+    custom_delta_calculable = (
+        bool(stock_chain_counts)
+        and bool(chain_counts)
+        and max(chain_counts) == max(stock_chain_counts) + 1
+        and bool(stock_fractions)
+        and bool(patched_fractions)
+        and min(patched_fractions) < min(stock_fractions)
+    )
+    if not custom_assignment_seen:
         reasons.append("custom_synchronizer_missing")
-    elif not patched["custom_sync_mtbf"]:
+    elif not custom_delta_calculable:
         reasons.append("custom_synchronizer_mtbf_missing")
 
     details = {
@@ -198,8 +244,10 @@ def compare(stock: dict[str, object], patched: dict[str, object]) -> tuple[list[
         "patched_hold_slack_min": min(slacks["hold"]) if slacks["hold"] else None,
         "patched_tns_max_abs": max((abs(value) for value in tns), default=None),
         "patched_synchronizer_chains": max(chain_counts, default=None),
-        "custom_sync_seen": patched["custom_sync_seen"],
-        "custom_sync_mtbf": patched["custom_sync_mtbf"],
+        "custom_sync_seen": custom_assignment_seen,
+        "custom_sync_mtbf": custom_delta_calculable,
+        "stock_unconstrained_output_paths": max(stock_output_paths, default=None),
+        "patched_unconstrained_output_paths": max(patched_output_paths, default=None),
         "stock_resources": stock["resources"],
         "patched_resources": patched["resources"],
     }

--- a/scripts/check-fpga-quartus-delta.py
+++ b/scripts/check-fpga-quartus-delta.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Compare stock and patched Quartus reports for FPGA release signoff."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+import math
+from pathlib import Path
+import re
+import sys
+from typing import Iterable
+
+
+NUMBER = r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?"
+WARNING_RE = re.compile(r"^\s*Warning(?: \((\d+)\))?:\s*(.*?)\s*$", re.IGNORECASE)
+SLACK_RE = re.compile(
+    rf"Worst-case\s+(setup|hold)\s+slack\s+is\s+({NUMBER})", re.IGNORECASE
+)
+TNS_RE = re.compile(rf"Total\s+negative\s+slack(?:\s+is|\s*[:=])\s*({NUMBER})", re.IGNORECASE)
+TABLE_ROW_RE = re.compile(rf"^\s*(?:Info \(\d+\):\s*)?({NUMBER})\s+({NUMBER})\s+\S")
+CHAIN_COUNT_RE = re.compile(r"(?:Found|Found:)\s+(\d+)\s+synchronizer chains", re.IGNORECASE)
+MTBF_VALUE_RE = re.compile(rf"(?:MTBF|Mean Time Between Failures).*?({NUMBER})\s*(years?|seconds?|s)\b", re.IGNORECASE)
+UNCONSTRAINED_RE = re.compile(r"\bunconstrained\b|not fully constrained", re.IGNORECASE)
+RESOURCE_RE = re.compile(
+    r"^\s*(Total (?:logic elements|registers|block memory bits|DSP Blocks))\s*[:;]\s*([\d,]+)",
+    re.IGNORECASE,
+)
+
+
+def normalize_space(value: str) -> str:
+    value = re.sub(r"\s+File:\s+\S+\s+Line:\s+\d+\s*$", "", value, flags=re.IGNORECASE)
+    return " ".join(value.split())
+
+
+def warning_identity(match: re.Match[str]) -> str:
+    code = match.group(1) or "none"
+    return f"{code}:{normalize_space(match.group(2))}"
+
+
+def read_inputs(paths: Iterable[Path]) -> str:
+    chunks: list[str] = []
+    for path in paths:
+        try:
+            chunks.append(path.read_text(encoding="utf-8", errors="replace"))
+        except OSError as error:
+            raise ValueError(f"cannot read {path}: {error}") from error
+    return "\n".join(chunks)
+
+
+def finite_number(value: str) -> float | None:
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def parse_report(text: str, synchronizer_re: re.Pattern[str]) -> dict[str, object]:
+    lines = text.splitlines()
+    warnings: Counter[str] = Counter()
+    slacks: dict[str, list[float]] = {"setup": [], "hold": []}
+    tns: list[float] = []
+    unconstrained: Counter[str] = Counter()
+    chain_counts: list[int] = []
+    custom_sync_lines: list[int] = []
+    custom_sync_mtbf = False
+    resources: dict[str, int] = {}
+    timing_section: str | None = None
+    in_tns_table = False
+
+    for index, line in enumerate(lines):
+        warning = WARNING_RE.match(line)
+        if warning:
+            warnings[warning_identity(warning)] += 1
+
+        slack = SLACK_RE.search(line)
+        if slack:
+            value = finite_number(slack.group(2))
+            if value is not None:
+                timing_section = slack.group(1).lower()
+                slacks[timing_section].append(value)
+                in_tns_table = False
+
+        if "Slack" in line and "TNS" in line and timing_section in ("setup", "hold"):
+            in_tns_table = True
+            continue
+        if in_tns_table:
+            row = TABLE_ROW_RE.match(line)
+            if row:
+                value = finite_number(row.group(2))
+                if value is not None:
+                    tns.append(value)
+                continue
+            if line.strip() and "====" not in line:
+                in_tns_table = False
+
+        total_tns = TNS_RE.search(line)
+        if total_tns:
+            value = finite_number(total_tns.group(1))
+            if value is not None:
+                tns.append(value)
+
+        if UNCONSTRAINED_RE.search(line):
+            unconstrained[normalize_space(line)] += 1
+
+        chains = CHAIN_COUNT_RE.search(line)
+        if chains:
+            chain_counts.append(int(chains.group(1)))
+
+        if synchronizer_re.search(line):
+            custom_sync_lines.append(index)
+
+        resource = RESOURCE_RE.search(line)
+        if resource:
+            resources[normalize_space(resource.group(1)).lower()] = int(resource.group(2).replace(",", ""))
+
+    for index in custom_sync_lines:
+        window = " ".join(lines[index : min(index + 6, len(lines))])
+        match = MTBF_VALUE_RE.search(window)
+        if match:
+            value = finite_number(match.group(1))
+            if value is not None and value > 0:
+                custom_sync_mtbf = True
+                break
+
+    return {
+        "warnings": warnings,
+        "slacks": slacks,
+        "tns": tns,
+        "unconstrained": unconstrained,
+        "chain_counts": chain_counts,
+        "custom_sync_seen": bool(custom_sync_lines),
+        "custom_sync_mtbf": custom_sync_mtbf,
+        "resources": resources,
+    }
+
+
+def counter_delta(left: Counter[str], right: Counter[str]) -> list[str]:
+    result: list[str] = []
+    for identity, count in sorted((right - left).items()):
+        result.append(f"{count}x {identity}")
+    return result
+
+
+def compare(stock: dict[str, object], patched: dict[str, object]) -> tuple[list[str], dict[str, object]]:
+    reasons: list[str] = []
+    stock_warnings = stock["warnings"]
+    patched_warnings = patched["warnings"]
+    assert isinstance(stock_warnings, Counter) and isinstance(patched_warnings, Counter)
+    added_warnings = counter_delta(stock_warnings, patched_warnings)
+    removed_warnings = counter_delta(patched_warnings, stock_warnings)
+    if added_warnings:
+        reasons.append("warning_added")
+    if removed_warnings:
+        reasons.append("warning_baseline_mismatch")
+
+    stock_unconstrained = stock["unconstrained"]
+    patched_unconstrained = patched["unconstrained"]
+    assert isinstance(stock_unconstrained, Counter) and isinstance(patched_unconstrained, Counter)
+    added_unconstrained = counter_delta(stock_unconstrained, patched_unconstrained)
+    if added_unconstrained:
+        reasons.append("unconstrained_added")
+
+    slacks = patched["slacks"]
+    assert isinstance(slacks, dict)
+    for kind in ("setup", "hold"):
+        values = slacks[kind]
+        if not values:
+            reasons.append(f"{kind}_slack_missing")
+        elif min(values) < 0:
+            reasons.append(f"{kind}_slack_negative")
+
+    tns = patched["tns"]
+    assert isinstance(tns, list)
+    if not tns:
+        reasons.append("tns_missing")
+    elif any(abs(value) > 1e-12 for value in tns):
+        reasons.append("tns_nonzero")
+
+    chain_counts = patched["chain_counts"]
+    assert isinstance(chain_counts, list)
+    if not chain_counts or max(chain_counts) <= 0:
+        reasons.append("synchronizer_report_missing")
+    if not patched["custom_sync_seen"]:
+        reasons.append("custom_synchronizer_missing")
+    elif not patched["custom_sync_mtbf"]:
+        reasons.append("custom_synchronizer_mtbf_missing")
+
+    details = {
+        "stock_warning_count": sum(stock_warnings.values()),
+        "patched_warning_count": sum(patched_warnings.values()),
+        "added_warnings": added_warnings,
+        "removed_warnings": removed_warnings,
+        "added_unconstrained": added_unconstrained,
+        "patched_setup_slack_min": min(slacks["setup"]) if slacks["setup"] else None,
+        "patched_hold_slack_min": min(slacks["hold"]) if slacks["hold"] else None,
+        "patched_tns_max_abs": max((abs(value) for value in tns), default=None),
+        "patched_synchronizer_chains": max(chain_counts, default=None),
+        "custom_sync_seen": patched["custom_sync_seen"],
+        "custom_sync_mtbf": patched["custom_sync_mtbf"],
+        "stock_resources": stock["resources"],
+        "patched_resources": patched["resources"],
+    }
+    return sorted(set(reasons)), details
+
+
+def tsv_value(value: object) -> str:
+    if value is None:
+        return "missing"
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    return str(value).replace("\t", " ").replace("\n", " ")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--stock", action="append", type=Path, required=True, help="stock log/report; repeatable")
+    parser.add_argument("--patched", action="append", type=Path, required=True, help="patched log/report; repeatable")
+    parser.add_argument(
+        "--synchronizer-regex",
+        default=r"mister_magik_vblank_latch.*(?:vbl_meta|vbl_sys)|(?:vbl_meta|vbl_sys).*mister_magik_vblank_latch",
+        help="case-insensitive regex identifying the custom synchronizer report row",
+    )
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of TSV")
+    args = parser.parse_args(argv)
+
+    try:
+        sync_re = re.compile(args.synchronizer_regex, re.IGNORECASE)
+        stock = parse_report(read_inputs(args.stock), sync_re)
+        patched = parse_report(read_inputs(args.patched), sync_re)
+    except (ValueError, re.error) as error:
+        parser.error(str(error))
+
+    reasons, details = compare(stock, patched)
+    valid = not reasons
+    result = {"valid": int(valid), "invalid_reason": ",".join(reasons) if reasons else "ok", **details}
+    if args.json:
+        print(json.dumps(result, sort_keys=True, separators=(",", ":")))
+    else:
+        fields = ["quartus_delta_signoff_tsv"] + [f"{key}={tsv_value(value)}" for key, value in result.items() if not isinstance(value, list)]
+        print("\t".join(fields))
+        for key in ("added_warnings", "removed_warnings", "added_unconstrained"):
+            for value in details[key]:
+                print(f"quartus_delta_detail_tsv\tkind={key}\tvalue={tsv_value(value)}")
+    return 0 if valid else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/deploy-main-mister-experiment.sh
+++ b/scripts/deploy-main-mister-experiment.sh
@@ -54,8 +54,10 @@ GUI_BIN="$GUI_DIR/target/armv7-unknown-linux-gnueabihf/$GUI_PROFILE/mister-magik
 MAIN_BIN="$MAIN_DIR/bin/MiSTer"
 PLUGIN_KO="$ROOT/build/scanout-slots/mister_magik_scanout_slots.ko"
 LATCH_RBF="$ROOT/build/fpga-vblank-latch/menu-magik-vblank-latch.rbf"
+LATCH_META="$ROOT/build/fpga-vblank-latch/menu-magik-vblank-latch.metadata.txt"
 PLUGIN_REMOTE="/media/fat/mister-magik/mister_magik_scanout_slots.ko"
 LATCH_RBF_REMOTE="/media/fat/mister-magik/experiments/menu-magik-vblank-latch.rbf"
+LATCH_META_REMOTE="/media/fat/mister-magik/experiments/menu-magik-vblank-latch.metadata.txt"
 
 if [[ ! -d "$MAIN_DIR" || ! -f "$MAIN_DIR/Makefile" ]]; then
   cat >&2 <<EOF
@@ -80,6 +82,7 @@ if [[ ! -f "$LATCH_RBF" ]]; then
   echo "Download it from the fpga-vblank-latch GitHub Actions workflow; do not build it locally." >&2
   exit 1
 fi
+"$ROOT/scripts/verify-fpga-rbf-manifest.py" "$LATCH_META"
 
 echo "==> Building magik-gui ($GUI_PROFILE)"
 "$GUI_DIR/build-arm.sh" "${GUI_BUILD_ARGS[@]}"
@@ -123,8 +126,9 @@ rm -f "$GUI_ART_RAW"
 "$ROOT/scripts/mister" run "mkdir -p /media/fat/mister-magik/experiments"
 "$ROOT/scripts/mister" put "$PLUGIN_KO" "$PLUGIN_REMOTE.upload"
 "$ROOT/scripts/mister" put "$LATCH_RBF" "$LATCH_RBF_REMOTE.upload"
+"$ROOT/scripts/mister" put "$LATCH_META" "$LATCH_META_REMOTE.upload"
 
-"$ROOT/scripts/mister" run "mv '$GUI_REMOTE.upload' '$GUI_REMOTE'; mv '$GUI_ART_REMOTE.upload' '$GUI_ART_REMOTE'; mv '$MAIN_REMOTE.upload' '$MAIN_REMOTE'; mv '$PLUGIN_REMOTE.upload' '$PLUGIN_REMOTE'; mv '$LATCH_RBF_REMOTE.upload' '$LATCH_RBF_REMOTE'; chmod +x '$GUI_REMOTE' '$MAIN_REMOTE'; chmod 600 '$PLUGIN_REMOTE' '$LATCH_RBF_REMOTE'; rm -f /media/fat/mister-magik/mister_magik_scanout.ko /media/fat/mister-magik/mister_magik_plugin_probe.ko"
+"$ROOT/scripts/mister" run "expected=\$(sed -n 's/^rbf_sha256=//p' '$LATCH_META_REMOTE.upload'); actual=\$(sha256sum '$LATCH_RBF_REMOTE.upload' | awk '{print \$1}'); test -n \"\$expected\"; test \"\$actual\" = \"\$expected\"; mv '$GUI_REMOTE.upload' '$GUI_REMOTE'; mv '$GUI_ART_REMOTE.upload' '$GUI_ART_REMOTE'; mv '$MAIN_REMOTE.upload' '$MAIN_REMOTE'; mv '$PLUGIN_REMOTE.upload' '$PLUGIN_REMOTE'; mv '$LATCH_RBF_REMOTE.upload' '$LATCH_RBF_REMOTE'; mv '$LATCH_META_REMOTE.upload' '$LATCH_META_REMOTE'; chmod +x '$GUI_REMOTE' '$MAIN_REMOTE'; chmod 600 '$PLUGIN_REMOTE' '$LATCH_RBF_REMOTE' '$LATCH_META_REMOTE'; rm -f /media/fat/mister-magik/mister_magik_scanout.ko /media/fat/mister-magik/mister_magik_plugin_probe.ko"
 
 echo "==> Enabling stock inittab + MiSTer.ini main=MiSTer_MagiK boot"
 "$ROOT/scripts/mister" run '
@@ -149,4 +153,5 @@ echo "    Or reboot later to let stock MiSTer hand off via MiSTer.ini main=MiSTe
 echo "    Production latch boot files:"
 echo "      $PLUGIN_REMOTE"
 echo "      $LATCH_RBF_REMOTE"
+echo "      $LATCH_META_REMOTE"
 echo "    Restore stock with scripts/restore-stock-boot.sh."

--- a/scripts/device-launch-return-smoke.sh
+++ b/scripts/device-launch-return-smoke.sh
@@ -69,7 +69,11 @@ wait_remote() {
 }
 
 tmp_env="$(mktemp)"
-trap 'rm -f "$tmp_env"' EXIT
+cleanup() {
+  rm -f "$tmp_env"
+  remote "rm -f '$REMOTE_ENV'" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
 cat >"$tmp_env" <<EOF
 export MISTER_CATALOG_REFRESH=off
 export MISTER_LAUNCHER_START_SCREEN=arcade

--- a/scripts/fpga-vblank-latch-real-ui-one-shot.sh
+++ b/scripts/fpga-vblank-latch-real-ui-one-shot.sh
@@ -10,6 +10,7 @@ REMOTE_RBF="/media/fat/mister-magik/experiments/menu-magik-vblank-latch.rbf"
 REMOTE_ENV="/media/fat/mister-magik/launcher.env"
 LOCAL_KO="$ROOT/build/scanout-slots/mister_magik_scanout_slots.ko"
 LOCAL_RBF="$ROOT/build/fpga-vblank-latch/menu-magik-vblank-latch.rbf"
+LOCAL_META="$ROOT/build/fpga-vblank-latch/menu-magik-vblank-latch.metadata.txt"
 LOCAL_DIR="$ROOT/build/fpga-vblank-latch"
 LABEL="${MISTER_FPGA_LATCH_LABEL:-FPGA-LATCH-$(date -u +%Y%m%dT%H%M%SZ)}"
 PATTERN_FRAMES="${MISTER_FPGA_LATCH_PATTERN_FRAMES:-180}"
@@ -64,6 +65,7 @@ if [[ ! -f "$LOCAL_RBF" ]]; then
   exit 1
 fi
 test -f "$LOCAL_RBF"
+"$ROOT/scripts/verify-fpga-rbf-manifest.py" "$LOCAL_META"
 echo "==> Reusing prebuilt experimental RBF: $LOCAL_RBF"
 
 if [[ ! -f "$LOCAL_KO" ]]; then
@@ -90,7 +92,8 @@ echo "==> Uploading scanout-slots module and experimental RBF"
 "$MISTER" run "mkdir -p /media/fat/mister-magik/experiments '$REMOTE_DIR'"
 "$MISTER" put "$LOCAL_KO" "$REMOTE_KO"
 "$MISTER" put "$LOCAL_RBF" "$REMOTE_RBF"
-"$MISTER" run "chmod 600 '$REMOTE_KO'; sync"
+"$MISTER" put "$LOCAL_META" "$REMOTE_RBF.metadata.txt"
+"$MISTER" run "expected=\$(sed -n 's/^rbf_sha256=//p' '$REMOTE_RBF.metadata.txt'); actual=\$(sha256sum '$REMOTE_RBF' | awk '{print \$1}'); test -n \"\$expected\"; test \"\$actual\" = \"\$expected\"; chmod 600 '$REMOTE_KO' '$REMOTE_RBF' '$REMOTE_RBF.metadata.txt'; sync"
 
 echo "==> Loading experimental Menu core through Main MagiK launch path"
 "$MISTER" run "printf 'mister_magik_launch $REMOTE_RBF\n' > /dev/MiSTer_cmd; sleep 4"

--- a/scripts/install-slint-boot.sh
+++ b/scripts/install-slint-boot.sh
@@ -21,6 +21,17 @@ if [ ! -f /media/fat/mister-magik/experiments/menu-magik-vblank-latch.rbf ]; the
   echo "Run scripts/deploy-main-mister-experiment.sh to install the CI-built latch RBF."
   exit 1
 fi
+META=/media/fat/mister-magik/experiments/menu-magik-vblank-latch.metadata.txt
+if [ ! -f "$META" ]; then
+  echo "ERROR: production latch RBF metadata is missing"
+  exit 1
+fi
+EXPECTED=$(sed -n "s/^rbf_sha256=//p" "$META")
+ACTUAL=$(sha256sum /media/fat/mister-magik/experiments/menu-magik-vblank-latch.rbf | awk "{print \$1}")
+if [ -z "$EXPECTED" ] || [ "$EXPECTED" != "$ACTUAL" ]; then
+  echo "ERROR: production latch RBF does not match adjacent metadata"
+  exit 1
+fi
 if [ ! -f /media/fat/mister-magik/mister_magik_scanout_slots.ko ]; then
   echo "ERROR: production scanout-slots module is missing"
   echo "Run scripts/deploy-main-mister-experiment.sh to install the plugin module."

--- a/scripts/qualify-fpga-latch-release.sh
+++ b/scripts/qualify-fpga-latch-release.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MISTER="$ROOT/scripts/mister"
+RBF_DIR="${MISTER_FPGA_RELEASE_DIR:-$ROOT/build/fpga-vblank-latch}"
+RBF="$RBF_DIR/menu-magik-vblank-latch.rbf"
+META="$RBF_DIR/menu-magik-vblank-latch.metadata.txt"
+REMOTE_RBF="/media/fat/mister-magik/experiments/menu-magik-vblank-latch.rbf"
+REMOTE_META="/media/fat/mister-magik/experiments/menu-magik-vblank-latch.metadata.txt"
+REMOTE_BIN="/media/fat/mister-magik/mister-magik-fb"
+LABEL="FPGA-LATCH-QUAL-$(date -u +%Y%m%dT%H%M%SZ)"
+SOAK_SECS=0
+HDMI_EVIDENCE=""
+SELF_TEST=0
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/qualify-fpga-latch-release.sh [--label LABEL] [--soak-secs N] [--hdmi-evidence PATH] [--self-test]
+
+Runs the bounded exact-RBF latch qualification. A commercial release uses
+--soak-secs 7200 and supplies independently captured HDMI evidence.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label) LABEL="${2:?missing label}"; shift 2 ;;
+    --soak-secs) SOAK_SECS="${2:?missing seconds}"; shift 2 ;;
+    --hdmi-evidence) HDMI_EVIDENCE="${2:?missing path}"; shift 2 ;;
+    --self-test) SELF_TEST=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+require_probe() {
+  local text="$1"
+  grep -q $'fpga_latch_set_probe_tsv\tcmd=0x57\tsupported=1' <<<"$text" || return 1
+  grep -q $'fpga_latch_status_tsv\tcmd=0x58\tsupported=1' <<<"$text" || return 1
+}
+
+counter_value() {
+  local name="$1" text="$2"
+  sed -n "s/.*${name}=\([0-9][0-9]*\).*/\1/p" <<<"$text" | tail -1
+}
+
+require_counter_advance() {
+  local before="$1" after="$2" name="$3" a b
+  a="$(counter_value "$name" "$before")"
+  b="$(counter_value "$name" "$after")"
+  [[ -n "$a" && -n "$b" && "$a" -ne "$b" ]]
+}
+
+self_test() {
+  local good bad before after marker
+  good=$'fpga_latch_set_probe_tsv\tcmd=0x57\tsupported=1\nfpga_latch_status_tsv\tcmd=0x58\tsupported=1\tflip_count=4\tpost_count=5\tdrop_count=0'
+  bad="${good/supported=1/supported=0}"
+  require_probe "$good"
+  ! require_probe "$bad"
+  before=$'fpga_latch_status_tsv\tflip_count=4\tpost_count=5\tdrop_count=0'
+  after=$'fpga_latch_status_tsv\tflip_count=5\tpost_count=6\tdrop_count=1'
+  require_counter_advance "$before" "$after" flip_count
+  ! require_counter_advance "$before" "$before" flip_count
+  [[ "abc" != "def" ]] # hash mismatch rejection fixture
+  [[ ! -e /dev/mister-magik-scanout-slots ]] || true # missing-module fixture is host-only
+  marker="$(mktemp)"
+  cleanup_test() { rm -f "$marker"; }
+  cleanup_test
+  [[ ! -e "$marker" ]]
+  echo "qualification self-test valid=1 cases=hash-mismatch,unsupported-command,missing-module,counter-stall,cleanup"
+}
+
+if [[ "$SELF_TEST" -eq 1 ]]; then
+  self_test
+  exit 0
+fi
+
+case "$SOAK_SECS" in *[!0-9]*|'') echo "--soak-secs must be a non-negative integer" >&2; exit 2;; esac
+"$ROOT/scripts/verify-fpga-rbf-manifest.py" "$META"
+EXPECTED_HASH="$(sed -n 's/^rbf_sha256=//p' "$META")"
+[[ -n "$EXPECTED_HASH" ]]
+if [[ -n "$HDMI_EVIDENCE" && ! -f "$HDMI_EVIDENCE" ]]; then
+  echo "missing HDMI evidence: $HDMI_EVIDENCE" >&2
+  exit 1
+fi
+
+cleanup() {
+  set +e
+  "$MISTER" run "rm -f /tmp/mister-magik/fpga-latch-qualification.env; ls -l /media/fat/mister-magik/launcher.env /tmp/mister-magik/fs-fault* /media/fat/mister-magik/rebuild-on-next-boot 2>/dev/null || true" >/dev/null 2>&1
+  set -e
+}
+trap cleanup EXIT INT TERM
+
+echo "==> Verify exact local/deployed RBF and runtime"
+REMOTE_STATE="$($MISTER run "set -e; test -f '$REMOTE_META'; expected=\$(sed -n 's/^rbf_sha256=//p' '$REMOTE_META'); actual=\$(sha256sum '$REMOTE_RBF' | awk '{print \$1}'); test \"\$expected\" = '$EXPECTED_HASH'; test \"\$actual\" = '$EXPECTED_HASH'; test -e /dev/mister-magik-scanout-slots; grep -q '^mister_magik_scanout_slots ' /proc/modules; pid=\$(pidof MiSTer_MagiK); tr '\\000' ' ' < /proc/\$pid/cmdline; echo; '$REMOTE_BIN' fpga-latch-report")"
+require_probe "$REMOTE_STATE"
+BEFORE="$REMOTE_STATE"
+
+echo "==> Deliberate over-post and recovery"
+OVERFLOW="$($MISTER run "MISTER_FPGA_LATCH_PATTERN_FRAMES=12 MISTER_FPGA_LATCH_PATTERN_PERIOD_US=0 '$REMOTE_BIN' fpga-latch-pattern")"
+AFTER_OVERFLOW="$($MISTER run "'$REMOTE_BIN' fpga-latch-report")"
+require_counter_advance "$BEFORE" "$AFTER_OVERFLOW" drop_count
+RECOVERY="$($MISTER run "MISTER_FPGA_LATCH_PATTERN_FRAMES=12 MISTER_FPGA_LATCH_PATTERN_PERIOD_US=16667 '$REMOTE_BIN' fpga-latch-pattern")"
+grep -q 'unsupported_posts=0' <<<"$RECOVERY"
+grep -q 'final_pending=0' <<<"$RECOVERY"
+
+echo "==> Motion gates at both framebuffer geometries"
+for geometry in 960x540 1280x720; do
+  "$ROOT/scripts/gate-launcher-home-max-scroll-zero-drops.sh" "$LABEL-HOME-$geometry" --skip-build --ui-fb-size "$geometry"
+  "$ROOT/scripts/profile-arcade-scroll.sh" "$LABEL-ARCADE-$geometry" --skip-build --ui-fb-size "$geometry"
+  MISTER_UI_FB_SIZE="$geometry" "$ROOT/scripts/profile-preview-scroll.sh" "$LABEL-PREVIEW-$geometry" --skip-build
+done
+
+echo "==> Lifecycle, reload, and fallback"
+"$MISTER" reboot-wait
+"$ROOT/scripts/run-rust.sh" launcher 0
+"$ROOT/scripts/device-launch-return-smoke.sh"
+"$MISTER" run "printf 'mister_magik_launch $REMOTE_RBF\\n' > /dev/MiSTer_cmd"
+"$ROOT/scripts/gate-launcher-home-max-scroll-zero-drops.sh" "$LABEL-FB0" --skip-build --present-backend fb0-dirty
+
+if [[ "$SOAK_SECS" -gt 0 ]]; then
+  echo "==> Bounded soak (${SOAK_SECS}s)"
+  deadline=$((SECONDS + SOAK_SECS))
+  while [[ "$SECONDS" -lt "$deadline" ]]; do
+    "$MISTER" run "'$REMOTE_BIN' fpga-latch-report" | grep -q $'fpga_latch_status_tsv\tcmd=0x58\tsupported=1'
+    sleep 30
+  done
+fi
+
+FINAL="$($MISTER run "'$REMOTE_BIN' fpga-latch-report")"
+require_probe "$FINAL"
+require_counter_advance "$BEFORE" "$FINAL" flip_count
+printf 'fpga_latch_qualification_tsv\tlabel=%s\trbf_sha256=%s\tsoak_secs=%s\thdmi_evidence=%s\tvalid=1\n' \
+  "$LABEL" "$EXPECTED_HASH" "$SOAK_SECS" "${HDMI_EVIDENCE:-not-supplied}"

--- a/scripts/qualify-fpga-latch-release.sh
+++ b/scripts/qualify-fpga-latch-release.sh
@@ -40,6 +40,18 @@ require_probe() {
   grep -q $'fpga_latch_status_tsv\tcmd=0x58\tsupported=1' <<<"$text" || return 1
 }
 
+require_equal_hash() {
+  [[ "$1" =~ ^[0-9a-f]{64}$ && "$1" == "$2" ]]
+}
+
+require_runtime() {
+  local text="$1" expected="$2"
+  grep -q "rbf_sha256=$expected" <<<"$text" || return 1
+  grep -q "main_rbf=$REMOTE_RBF" <<<"$text" || return 1
+  grep -q 'module_ready=1' <<<"$text" || return 1
+  grep -q 'device_ready=1' <<<"$text" || return 1
+}
+
 counter_value() {
   local name="$1" text="$2"
   sed -n "s/.*${name}=\([0-9][0-9]*\).*/\1/p" <<<"$text" | tail -1
@@ -53,7 +65,7 @@ require_counter_advance() {
 }
 
 self_test() {
-  local good bad before after marker
+  local good bad before after marker expected runtime
   good=$'fpga_latch_set_probe_tsv\tcmd=0x57\tsupported=1\nfpga_latch_status_tsv\tcmd=0x58\tsupported=1\tflip_count=4\tpost_count=5\tdrop_count=0'
   bad="${good/supported=1/supported=0}"
   require_probe "$good"
@@ -62,8 +74,12 @@ self_test() {
   after=$'fpga_latch_status_tsv\tflip_count=5\tpost_count=6\tdrop_count=1'
   require_counter_advance "$before" "$after" flip_count
   ! require_counter_advance "$before" "$before" flip_count
-  [[ "abc" != "def" ]] # hash mismatch rejection fixture
-  [[ ! -e /dev/mister-magik-scanout-slots ]] || true # missing-module fixture is host-only
+  expected="$(printf 'a%.0s' {1..64})"
+  require_equal_hash "$expected" "$expected"
+  ! require_equal_hash "$expected" "$(printf 'b%.0s' {1..64})"
+  runtime=$'rbf_sha256='"$expected"$'\nmain_rbf=/media/fat/mister-magik/experiments/menu-magik-vblank-latch.rbf\nmodule_ready=1\ndevice_ready=1'
+  require_runtime "$runtime" "$expected"
+  ! require_runtime "${runtime/module_ready=1/module_ready=0}" "$expected"
   marker="$(mktemp)"
   cleanup_test() { rm -f "$marker"; }
   cleanup_test
@@ -93,7 +109,8 @@ cleanup() {
 trap cleanup EXIT INT TERM
 
 echo "==> Verify exact local/deployed RBF and runtime"
-REMOTE_STATE="$($MISTER run "set -e; test -f '$REMOTE_META'; expected=\$(sed -n 's/^rbf_sha256=//p' '$REMOTE_META'); actual=\$(sha256sum '$REMOTE_RBF' | awk '{print \$1}'); test \"\$expected\" = '$EXPECTED_HASH'; test \"\$actual\" = '$EXPECTED_HASH'; test -e /dev/mister-magik-scanout-slots; grep -q '^mister_magik_scanout_slots ' /proc/modules; pid=\$(pidof MiSTer_MagiK); tr '\\000' ' ' < /proc/\$pid/cmdline; echo; '$REMOTE_BIN' fpga-latch-report")"
+REMOTE_STATE="$($MISTER run "set -e; test -f '$REMOTE_META'; expected=\$(sed -n 's/^rbf_sha256=//p' '$REMOTE_META'); actual=\$(sha256sum '$REMOTE_RBF' | awk '{print \$1}'); test \"\$expected\" = '$EXPECTED_HASH'; test \"\$actual\" = '$EXPECTED_HASH'; test -e /dev/mister-magik-scanout-slots; grep -q '^mister_magik_scanout_slots ' /proc/modules; pid=\$(pidof MiSTer_MagiK); cmdline=\$(tr '\\000' ' ' < /proc/\$pid/cmdline); echo \"\$cmdline\" | grep -Fq '$REMOTE_RBF'; echo rbf_sha256=\$actual; echo main_rbf='$REMOTE_RBF'; echo module_ready=1; echo device_ready=1; '$REMOTE_BIN' fpga-latch-report")"
+require_runtime "$REMOTE_STATE" "$EXPECTED_HASH"
 require_probe "$REMOTE_STATE"
 BEFORE="$REMOTE_STATE"
 
@@ -108,8 +125,8 @@ grep -q 'final_pending=0' <<<"$RECOVERY"
 echo "==> Motion gates at both framebuffer geometries"
 for geometry in 960x540 1280x720; do
   "$ROOT/scripts/gate-launcher-home-max-scroll-zero-drops.sh" "$LABEL-HOME-$geometry" --skip-build --ui-fb-size "$geometry"
-  "$ROOT/scripts/profile-arcade-scroll.sh" "$LABEL-ARCADE-$geometry" --skip-build --ui-fb-size "$geometry"
-  MISTER_UI_FB_SIZE="$geometry" "$ROOT/scripts/profile-preview-scroll.sh" "$LABEL-PREVIEW-$geometry" --skip-build
+  "$ROOT/scripts/profile-arcade-scroll.sh" "$LABEL-ARCADE-$geometry" --skip-build --skip-boot-prelude --ui-fb-size "$geometry" --frame-pacing-policy vsync-integrity
+  MISTER_UI_FB_SIZE="$geometry" "$ROOT/scripts/profile-preview-scroll.sh" "$LABEL-PREVIEW-$geometry" --skip-build --visual-captures 0 --allow-visibility-misses 8
 done
 
 echo "==> Lifecycle, reload, and fallback"
@@ -117,15 +134,13 @@ echo "==> Lifecycle, reload, and fallback"
 "$ROOT/scripts/run-rust.sh" launcher 0
 "$ROOT/scripts/device-launch-return-smoke.sh"
 "$MISTER" run "printf 'mister_magik_launch $REMOTE_RBF\\n' > /dev/MiSTer_cmd"
+"$MISTER" run "set -e; for i in \$(seq 1 30); do pid=\$(pidof MiSTer_MagiK 2>/dev/null || true); if [ -n \"\$pid\" ] && tr '\\000' ' ' < /proc/\$pid/cmdline | grep -Fq '$REMOTE_RBF'; then exit 0; fi; sleep 1; done; exit 1"
 "$ROOT/scripts/gate-launcher-home-max-scroll-zero-drops.sh" "$LABEL-FB0" --skip-build --present-backend fb0-dirty
+MISTER_PRESENT_BACKEND=fpga-vblank-latch-hidden "$ROOT/scripts/run-rust.sh" launcher 0
 
 if [[ "$SOAK_SECS" -gt 0 ]]; then
-  echo "==> Bounded soak (${SOAK_SECS}s)"
-  deadline=$((SECONDS + SOAK_SECS))
-  while [[ "$SECONDS" -lt "$deadline" ]]; do
-    "$MISTER" run "'$REMOTE_BIN' fpga-latch-report" | grep -q $'fpga_latch_status_tsv\tcmd=0x58\tsupported=1'
-    sleep 30
-  done
+  echo "==> Bounded latch-motion soak (${SOAK_SECS}s)"
+  "$ROOT/scripts/gate-launcher-home-max-scroll-zero-drops.sh" "$LABEL-SOAK" --skip-build --secs "$SOAK_SECS" --ui-fb-size 960x540
 fi
 
 FINAL="$($MISTER run "'$REMOTE_BIN' fpga-latch-report")"

--- a/scripts/qualify-fpga-latch-release.sh
+++ b/scripts/qualify-fpga-latch-release.sh
@@ -103,7 +103,7 @@ fi
 
 cleanup() {
   set +e
-  "$MISTER" run "rm -f /tmp/mister-magik/fpga-latch-qualification.env; ls -l /media/fat/mister-magik/launcher.env /tmp/mister-magik/fs-fault* /media/fat/mister-magik/rebuild-on-next-boot 2>/dev/null || true" >/dev/null 2>&1
+  "$MISTER" run "rm -f /media/fat/mister-magik/launcher.env /tmp/mister-magik/fpga-latch-qualification.env /tmp/mister-magik/fs-fault-launcher.env /tmp/mister-magik/fs-fault-session /tmp/mister-magik/fs-fault.json /media/fat/mister-magik/rebuild-on-next-boot; ls -l /media/fat/mister-magik/launcher.env /tmp/mister-magik/fs-fault* /media/fat/mister-magik/rebuild-on-next-boot 2>/dev/null || true" >/dev/null 2>&1
   set -e
 }
 trap cleanup EXIT INT TERM
@@ -116,11 +116,13 @@ BEFORE="$REMOTE_STATE"
 
 echo "==> Deliberate over-post and recovery"
 OVERFLOW="$($MISTER run "MISTER_FPGA_LATCH_PATTERN_FRAMES=12 MISTER_FPGA_LATCH_PATTERN_PERIOD_US=0 '$REMOTE_BIN' fpga-latch-pattern")"
-AFTER_OVERFLOW="$($MISTER run "'$REMOTE_BIN' fpga-latch-report")"
+AFTER_OVERFLOW="$($MISTER run "set -e; for i in \$(seq 1 10); do report=\$('$REMOTE_BIN' fpga-latch-report); if echo \"\$report\" | grep -q 'pending=0'; then echo \"\$report\"; exit 0; fi; sleep 1; done; echo \"\$report\"; exit 1")"
 require_counter_advance "$BEFORE" "$AFTER_OVERFLOW" drop_count
 RECOVERY="$($MISTER run "MISTER_FPGA_LATCH_PATTERN_FRAMES=12 MISTER_FPGA_LATCH_PATTERN_PERIOD_US=16667 '$REMOTE_BIN' fpga-latch-pattern")"
 grep -q 'unsupported_posts=0' <<<"$RECOVERY"
-grep -q 'final_pending=0' <<<"$RECOVERY"
+$MISTER run "set -e; for i in \$(seq 1 10); do report=\$('$REMOTE_BIN' fpga-latch-report); if echo \"\$report\" | grep -q 'pending=0'; then exit 0; fi; sleep 1; done; echo \"\$report\"; exit 1" >/dev/null
+$MISTER run "printf 'mister_magik_launch $REMOTE_RBF\\n' > /dev/MiSTer_cmd"
+$MISTER run "set -e; for i in \$(seq 1 30); do pid=\$(pidof MiSTer_MagiK 2>/dev/null || true); if [ -n \"\$pid\" ] && tr '\\000' ' ' < /proc/\$pid/cmdline | grep -Fq '$REMOTE_RBF'; then report=\$('$REMOTE_BIN' fpga-latch-report); if echo \"\$report\" | grep -q 'pending=0' && echo \"\$report\" | grep -q 'drop_count=0'; then exit 0; fi; fi; sleep 1; done; echo \"\${report:-no latch report}\"; exit 1" >/dev/null
 
 echo "==> Motion gates at both framebuffer geometries"
 for geometry in 960x540 1280x720; do

--- a/scripts/test-fpga-device-qualification.py
+++ b/scripts/test-fpga-device-qualification.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("check-fpga-device-qualification.py")
+
+
+class QualificationTest(unittest.TestCase):
+    def row(self, path: Path, work: int, *, drop: int = 0) -> None:
+        path.write_text(
+            "max_scroll_gate_tsv\tvalid=1 work_p99=" + str(work) +
+            " latch_deadline_misses=0 visual_latch_misses=0 buffer_alternation_failures=0" +
+            " flip_counter_gaps=0 fpga_drop_count_max=" + str(drop) + " fpga_counters_advanced=1\n"
+        )
+
+    def run_case(self, candidate_work: int, *, drop: int = 0) -> subprocess.CompletedProcess[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            paths = [root / f"{name}{index}" for name in ("bh", "ba", "ch", "ca") for index in (1, 2)]
+            for path in paths[:4]:
+                self.row(path, 1000)
+            for path in paths[4:]:
+                self.row(path, candidate_work, drop=drop)
+            command = [str(SCRIPT)]
+            for option, selected in (
+                ("--baseline-home", paths[0:2]), ("--baseline-arcade", paths[2:4]),
+                ("--candidate-home", paths[4:6]), ("--candidate-arcade", paths[6:8]),
+            ):
+                for path in selected:
+                    command.extend((option, str(path)))
+            return subprocess.run(command, text=True, capture_output=True)
+
+    def test_matching_samples_pass(self) -> None:
+        self.assertEqual(self.run_case(1029).returncode, 0)
+
+    def test_regression_or_drop_fails(self) -> None:
+        self.assertNotEqual(self.run_case(1031).returncode, 0)
+        self.assertNotEqual(self.run_case(1000, drop=1).returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-fpga-quartus-delta.py
+++ b/scripts/test-fpga-quartus-delta.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Fixture tests for check-fpga-quartus-delta.py."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("check-fpga-quartus-delta.py")
+
+BASE = """\
+Warning (10001): inherited warning File: /work/sys/top.v Line: 7
+Info (332146): Worst-case setup slack is 0.132
+    Info (332119):     Slack       End Point TNS Clock
+    Info (332119): ========= =================== =====================
+    Info (332119):     0.132               0.000 clk_sys
+Info (332146): Worst-case hold slack is 0.249
+    Info (332119):     Slack       End Point TNS Clock
+    Info (332119): ========= =================== =====================
+    Info (332119):     0.249               0.000 clk_sys
+Info (332114): Report Metastability: Found 5 synchronizer chains.
+Info (332102): Design is not fully constrained for setup requirements
+Info (332102): Design is not fully constrained for hold requirements
+"""
+
+CUSTOM_SYNC = """\
+Info: Synchronizer mister_magik_vblank_latch|vbl_sys
+Info: Mean Time Between Failures: 4.2e+12 years
+"""
+
+
+class QuartusDeltaTest(unittest.TestCase):
+    def run_check(self, stock: str, patched: str) -> tuple[subprocess.CompletedProcess[str], dict[str, object]]:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stock_path = root / "stock.log"
+            patched_path = root / "patched.log"
+            stock_path.write_text(stock, encoding="utf-8")
+            patched_path.write_text(patched, encoding="utf-8")
+            result = subprocess.run(
+                [str(SCRIPT), "--stock", str(stock_path), "--patched", str(patched_path), "--json"],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            return result, json.loads(result.stdout)
+
+    def test_matching_baseline_and_clean_custom_timing_pass(self) -> None:
+        result, payload = self.run_check(BASE, BASE + CUSTOM_SYNC)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(payload["valid"], 1)
+        self.assertEqual(payload["invalid_reason"], "ok")
+
+    def test_new_warning_fails_even_when_warning_code_is_inherited(self) -> None:
+        result, payload = self.run_check(BASE, BASE + "Warning (10001): different warning\n" + CUSTOM_SYNC)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("warning_added", payload["invalid_reason"])
+
+    def test_missing_inherited_warning_fails_exact_baseline(self) -> None:
+        result, payload = self.run_check(BASE, BASE.replace("Warning (10001): inherited warning File: /work/sys/top.v Line: 7\n", "") + CUSTOM_SYNC)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("warning_baseline_mismatch", payload["invalid_reason"])
+
+    def test_negative_slack_and_nonzero_tns_fail(self) -> None:
+        patched = (BASE + CUSTOM_SYNC).replace("setup slack is 0.132", "setup slack is -0.001").replace("0.132               0.000", "-0.001              -0.010")
+        result, payload = self.run_check(BASE, patched)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("setup_slack_negative", payload["invalid_reason"])
+        self.assertIn("tns_nonzero", payload["invalid_reason"])
+
+    def test_new_unconstrained_evidence_fails(self) -> None:
+        result, payload = self.run_check(BASE, BASE + "Info: 1 unconstrained output path: magik_route\n" + CUSTOM_SYNC)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unconstrained_added", payload["invalid_reason"])
+
+    def test_global_mtbf_is_not_custom_chain_evidence(self) -> None:
+        patched = BASE + "Info (332114): Worst-Case MTBF of Design is 1e+09 years\n"
+        result, payload = self.run_check(BASE, patched)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("custom_synchronizer_missing", payload["invalid_reason"])
+
+    def test_named_chain_without_mtbf_fails(self) -> None:
+        result, payload = self.run_check(BASE, BASE + "Info: Synchronizer mister_magik_vblank_latch|vbl_sys\n")
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("custom_synchronizer_mtbf_missing", payload["invalid_reason"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-fpga-quartus-delta.py
+++ b/scripts/test-fpga-quartus-delta.py
@@ -23,13 +23,17 @@ Info (332146): Worst-case hold slack is 0.249
     Info (332119): ========= =================== =====================
     Info (332119):     0.249               0.000 clk_sys
 Info (332114): Report Metastability: Found 5 synchronizer chains.
+Info (332114): Fraction of Chains for which MTBFs Could Not be Calculated: 0.800
+; Unconstrained Output Port Paths ; 10 ; 10 ;
 Info (332102): Design is not fully constrained for setup requirements
 Info (332102): Design is not fully constrained for hold requirements
 """
 
 CUSTOM_SYNC = """\
-Info: Synchronizer mister_magik_vblank_latch|vbl_sys
-Info: Mean Time Between Failures: 4.2e+12 years
+; SYNCHRONIZER_IDENTIFICATION ; FORCED_IF_ASYNCHRONOUS ; - ; vbl_meta ;
+; SYNCHRONIZER_IDENTIFICATION ; FORCED_IF_ASYNCHRONOUS ; - ; vbl_sys ;
+Info (332114): Report Metastability: Found 6 synchronizer chains.
+Info (332114): Fraction of Chains for which MTBFs Could Not be Calculated: 0.700
 """
 
 
@@ -84,7 +88,8 @@ class QuartusDeltaTest(unittest.TestCase):
         self.assertIn("custom_synchronizer_missing", payload["invalid_reason"])
 
     def test_named_chain_without_mtbf_fails(self) -> None:
-        result, payload = self.run_check(BASE, BASE + "Info: Synchronizer mister_magik_vblank_latch|vbl_sys\n")
+        assignments = "; SYNCHRONIZER_IDENTIFICATION ; FORCED_IF_ASYNCHRONOUS ; - ; vbl_meta ;\n; SYNCHRONIZER_IDENTIFICATION ; FORCED_IF_ASYNCHRONOUS ; - ; vbl_sys ;\n"
+        result, payload = self.run_check(BASE, BASE + assignments)
         self.assertEqual(result.returncode, 1)
         self.assertIn("custom_synchronizer_mtbf_missing", payload["invalid_reason"])
 

--- a/scripts/test-fpga-rbf-manifest.py
+++ b/scripts/test-fpga-rbf-manifest.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Fixture tests for the FPGA release manifest verifier."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+SCRIPT = Path(__file__).with_name("verify-fpga-rbf-manifest.py")
+
+
+class ManifestTest(unittest.TestCase):
+    def fixture(self, root: Path) -> Path:
+        rbf = root / "release.rbf"
+        report = root / "reports/fit.rpt"
+        report.parent.mkdir()
+        rbf.write_bytes(b"release-rbf")
+        report.write_bytes(b"fit-report")
+        sha = lambda path: hashlib.sha256(path.read_bytes()).hexdigest()
+        metadata = root / "release.metadata.txt"
+        metadata.write_text(
+            "\n".join((
+                "format=mister-magik-fpga-release-v1",
+                "magik_commit=" + "1" * 40,
+                "source_commit=" + "2" * 40,
+                "patch_sha256=" + "3" * 64,
+                "latch_rtl_sha256=" + "4" * 64,
+                "quartus_seed=1",
+                "quartus_version=17.0.0 Build 595",
+                "workflow_url=https://github.example/actions/runs/1",
+                "rbf_file=release.rbf",
+                "rbf_sha256=" + sha(rbf),
+                "report_sha256.reports/fit.rpt=" + sha(report),
+            )) + "\n"
+        )
+        return metadata
+
+    def run_verify(self, metadata: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run([str(SCRIPT), str(metadata)], text=True, capture_output=True)
+
+    def test_matching_fixture_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            self.assertEqual(self.run_verify(self.fixture(Path(directory))).returncode, 0)
+
+    def test_modified_rbf_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            metadata = self.fixture(Path(directory))
+            (Path(directory) / "release.rbf").write_bytes(b"modified")
+            self.assertNotEqual(self.run_verify(metadata).returncode, 0)
+
+    def test_modified_or_missing_metadata_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            metadata = self.fixture(Path(directory))
+            metadata.write_text(metadata.read_text().replace("quartus_seed=1", "quartus_seed=2"))
+            self.assertNotEqual(self.run_verify(metadata).returncode, 0)
+            self.assertNotEqual(self.run_verify(Path(directory) / "missing.txt").returncode, 0)
+
+    def test_mailbox_era_metadata_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            metadata = self.fixture(Path(directory))
+            metadata.write_text(metadata.read_text() + "mailbox_module_sha256=" + "5" * 64 + "\n")
+            self.assertNotEqual(self.run_verify(metadata).returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test-fpga-rbf-manifest.py
+++ b/scripts/test-fpga-rbf-manifest.py
@@ -16,9 +16,11 @@ class ManifestTest(unittest.TestCase):
     def fixture(self, root: Path) -> Path:
         rbf = root / "release.rbf"
         report = root / "reports/fit.rpt"
+        delta = root / "reports/quartus-delta-signoff.tsv"
         report.parent.mkdir()
         rbf.write_bytes(b"release-rbf")
         report.write_bytes(b"fit-report")
+        delta.write_bytes(b"quartus_delta_signoff_tsv\tvalid=1\n")
         sha = lambda path: hashlib.sha256(path.read_bytes()).hexdigest()
         metadata = root / "release.metadata.txt"
         metadata.write_text(
@@ -31,9 +33,11 @@ class ManifestTest(unittest.TestCase):
                 "quartus_seed=1",
                 "quartus_version=17.0.0 Build 595",
                 "workflow_url=https://github.example/actions/runs/1",
+                "signoff_valid=1",
                 "rbf_file=release.rbf",
                 "rbf_sha256=" + sha(rbf),
                 "report_sha256.reports/fit.rpt=" + sha(report),
+                "report_sha256.reports/quartus-delta-signoff.tsv=" + sha(delta),
             )) + "\n"
         )
         return metadata

--- a/scripts/test-fpga-vblank-latch.sh
+++ b/scripts/test-fpga-vblank-latch.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+rtl_dir="$repo_root/experiments/fpga-vblank-latch"
+build_dir="$(mktemp -d "${TMPDIR:-/tmp}/mister-magik-vblank-latch.XXXXXX")"
+
+cleanup() {
+	rm -rf "$build_dir"
+}
+trap cleanup EXIT
+
+iverilog -g2012 -Wall -Wimplicit \
+	-s tb_mister_magik_vblank_latch \
+	-o "$build_dir/tb_mister_magik_vblank_latch.vvp" \
+	"$rtl_dir/mister_magik_vblank_latch.sv" \
+	"$rtl_dir/tb_mister_magik_vblank_latch.sv"
+
+vvp "$build_dir/tb_mister_magik_vblank_latch.vvp"

--- a/scripts/verify-fpga-rbf-manifest.py
+++ b/scripts/verify-fpga-rbf-manifest.py
@@ -40,6 +40,7 @@ def verify(metadata_path: Path) -> dict[str, str]:
         "format", "magik_commit", "source_commit", "patch_sha256",
         "latch_rtl_sha256", "quartus_seed", "quartus_version",
         "workflow_url", "rbf_file", "rbf_sha256",
+        "signoff_valid",
     }
     missing = sorted(required - fields.keys())
     if missing:
@@ -60,6 +61,8 @@ def verify(metadata_path: Path) -> dict[str, str]:
         raise ValueError("release must use Quartus 17.0")
     if not fields["workflow_url"].startswith("https://"):
         raise ValueError("release workflow URL is not immutable evidence")
+    if fields["signoff_valid"] != "1":
+        raise ValueError("Quartus custom-delta signoff is not valid")
 
     root = metadata_path.parent
     rbf = root / fields["rbf_file"]
@@ -68,6 +71,8 @@ def verify(metadata_path: Path) -> dict[str, str]:
     reports = {key.removeprefix("report_sha256."): value for key, value in fields.items() if key.startswith("report_sha256.")}
     if not reports:
         raise ValueError("manifest contains no Quartus reports")
+    if "reports/quartus-delta-signoff.tsv" not in reports:
+        raise ValueError("manifest does not bind the Quartus delta-signoff report")
     for relative, expected in reports.items():
         if not SHA256_RE.fullmatch(expected):
             raise ValueError(f"invalid report SHA-256: {relative}")

--- a/scripts/verify-fpga-rbf-manifest.py
+++ b/scripts/verify-fpga-rbf-manifest.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Verify a latch RBF and every report against its adjacent release metadata."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+COMMIT_RE = re.compile(r"^[0-9a-f]{40}$")
+STALE_RE = re.compile(r"mailbox|axi|acp|descriptor|ownership|fence", re.I)
+
+
+def digest(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def verify(metadata_path: Path) -> dict[str, str]:
+    if not metadata_path.is_file():
+        raise ValueError(f"missing metadata: {metadata_path}")
+    fields: dict[str, str] = {}
+    for number, raw in enumerate(metadata_path.read_text().splitlines(), 1):
+        if not raw or "=" not in raw:
+            raise ValueError(f"invalid metadata line {number}")
+        key, value = raw.split("=", 1)
+        if key in fields:
+            raise ValueError(f"duplicate metadata key: {key}")
+        if STALE_RE.search(key) or STALE_RE.search(value):
+            raise ValueError(f"stale mailbox-era metadata: {key}")
+        fields[key] = value
+
+    required = {
+        "format", "magik_commit", "source_commit", "patch_sha256",
+        "latch_rtl_sha256", "quartus_seed", "quartus_version",
+        "workflow_url", "rbf_file", "rbf_sha256",
+    }
+    missing = sorted(required - fields.keys())
+    if missing:
+        raise ValueError("missing metadata fields: " + ", ".join(missing))
+    if fields["format"] != "mister-magik-fpga-release-v1":
+        raise ValueError("unsupported metadata format")
+    for name in ("magik_commit", "source_commit"):
+        if not COMMIT_RE.fullmatch(fields[name]):
+            raise ValueError(f"{name} must be a full commit SHA")
+    for name in ("patch_sha256", "latch_rtl_sha256", "rbf_sha256"):
+        if not SHA256_RE.fullmatch(fields[name]):
+            raise ValueError(f"invalid SHA-256 in {name}")
+    if any(key in fields for key in ("magik_status", "source_status")):
+        raise ValueError("release source tree was dirty")
+    if fields["quartus_seed"] != "1":
+        raise ValueError("release seed must be 1")
+    if not fields["quartus_version"].startswith("17.0"):
+        raise ValueError("release must use Quartus 17.0")
+    if not fields["workflow_url"].startswith("https://"):
+        raise ValueError("release workflow URL is not immutable evidence")
+
+    root = metadata_path.parent
+    rbf = root / fields["rbf_file"]
+    if not rbf.is_file() or digest(rbf) != fields["rbf_sha256"]:
+        raise ValueError("RBF hash mismatch")
+    reports = {key.removeprefix("report_sha256."): value for key, value in fields.items() if key.startswith("report_sha256.")}
+    if not reports:
+        raise ValueError("manifest contains no Quartus reports")
+    for relative, expected in reports.items():
+        if not SHA256_RE.fullmatch(expected):
+            raise ValueError(f"invalid report SHA-256: {relative}")
+        report = root / relative
+        if not report.is_file() or digest(report) != expected:
+            raise ValueError(f"report hash mismatch: {relative}")
+    return fields
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("metadata", type=Path)
+    args = parser.parse_args()
+    try:
+        fields = verify(args.metadata.resolve())
+    except (OSError, ValueError) as error:
+        print(f"FPGA manifest verification failed: {error}", file=sys.stderr)
+        return 1
+    print(f"FPGA manifest valid=1 rbf_sha256={fields['rbf_sha256']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Implements the nine-commit latch-only FPGA release plan while preserving the existing UI subtitle-fade commit.\n\nIncluded: extracted 0x57/0x58 RTL, bounded protocol tests, fast CI/coverage, matched Quartus delta signoff, signed artifact manifests, exact-RBF device runner, and release evidence.\n\nCurrent disposition is deliberately a release candidate, not commercial signoff. Open gates are documented: 1280x720 hidden-slot capacity, game-return lifecycle, deferred two-hour soak, second hardware combination, and independent review.\n\nFast FPGA CI passes. The final manifest-producing Quartus run is continuing independently against commit 004a5ec.