### PR TITLE
Add Amiga game screenshots and filters

### DIFF
--- a/docs/console-media-identity.md
+++ b/docs/console-media-identity.md
@@ -94,6 +94,7 @@ Console screenshot packs live under:
 /media/fat/mister-magik/assets/sms-screenshots-320x320.mmlz4b
 /media/fat/mister-magik/assets/megadrive-screenshots-320x320.mmlz4b
 /media/fat/mister-magik/assets/saturn-screenshots-320x320.mmlz4b
+/media/fat/mister-magik/assets/amiga-screenshots-320x320.mmlz4b
 ```
 
 The current public pack size is `320x320`. Legacy fixed-name packs such as

--- a/magik-gui/catalog/src/catalog_config.rs
+++ b/magik-gui/catalog/src/catalog_config.rs
@@ -17,7 +17,7 @@ pub const DEFAULT_MAME_SQLITE_PATH: &str = "/media/fat/mister-magik/mame.sqlite3
 pub const DEFAULT_HBMAME_SQLITE_PATH: &str = "/media/fat/mister-magik/hbmame.sqlite3";
 pub const DEFAULT_SQLITE_BUILD_DIR: &str = "/tmp/mister-magik/sqlite-build";
 
-pub const SCHEMA_VERSION: u32 = 62;
+pub const SCHEMA_VERSION: u32 = 63;
 pub const CATALOG_BUILD_VERSION: u32 = 9;
 
 pub fn default_sqlite_path() -> PathBuf {

--- a/magik-gui/catalog/src/library_db.rs
+++ b/magik-gui/catalog/src/library_db.rs
@@ -1136,16 +1136,17 @@ impl CatalogProjectionBuildContext<'_> {
                 metadata,
             )
         } else {
-            let preview = software_identity
-                .as_ref()
-                .and_then(|identity| console_preview_asset(identity, self.preview_paths));
-            let preview = preview
-                .as_ref()
-                .map(|asset| {
-                    LauncherPreviewAsset::new(
-                        preview_worker::preview_archive_path_for_system(&system_id),
-                        asset.asset_key.to_string(),
-                    )
+            let preview = amigavision_preview_asset(discovery, &system_id, self.preview_paths)
+                .or_else(|| {
+                    software_identity
+                        .as_ref()
+                        .and_then(|identity| console_preview_asset(identity, self.preview_paths))
+                        .map(|asset| {
+                            LauncherPreviewAsset::new(
+                                preview_worker::preview_archive_path_for_system(&system_id),
+                                asset.asset_key.to_string(),
+                            )
+                        })
                 })
                 .unwrap_or_else(LauncherPreviewAsset::none);
             let family_key = software_identity
@@ -1159,7 +1160,7 @@ impl CatalogProjectionBuildContext<'_> {
                 ArcadeGameMetadataKey {
                     year: discovery.year,
                     manufacturer: discovery.manufacturer.clone().unwrap_or_default(),
-                    category: discovery.genre.clone().unwrap_or_default(),
+                    category: launcher_category_for_discovery(discovery),
                 },
             )
         };
@@ -1190,6 +1191,30 @@ impl CatalogProjectionBuildContext<'_> {
             is_arcade,
             launch_plan,
         })
+    }
+}
+
+fn amigavision_preview_asset(
+    discovery: &GameDiscovery,
+    system_id: &str,
+    preview_paths: &PreviewArchivePaths,
+) -> Option<LauncherPreviewAsset> {
+    if system_id != "amiga" || discovery.genre.as_deref() != Some("AmigaVision") {
+        return None;
+    }
+    preview_paths.archive_for_platform("amiga")?;
+    Some(LauncherPreviewAsset::new(
+        preview_worker::preview_archive_path_for_system("amiga"),
+        crate::media_identity::ScreenshotAssetId::from_amigavision_title(&discovery.title)
+            .into_string(),
+    ))
+}
+
+fn launcher_category_for_discovery(discovery: &GameDiscovery) -> String {
+    match discovery.genre.as_deref() {
+        Some("AmigaVision") if discovery.platform_id == "amiga" => "Games".to_string(),
+        Some("AmigaVision demos") if discovery.platform_id == "amiga" => "Demos".to_string(),
+        _ => discovery.genre.clone().unwrap_or_default(),
     }
 }
 
@@ -1562,6 +1587,28 @@ mod tests {
                 is_new: game.is_new,
             })
             .collect()
+    }
+
+    #[test]
+    fn amigavision_games_use_amiga_pack_identity_but_demos_do_not() {
+        let mut discovery = payload("/media/fat/games/Amiga/AmigaVision.hdf");
+        discovery.title = "Alien Breed (OCS)[en]".to_string();
+        discovery.platform_id = "amiga".to_string();
+        discovery.genre = Some("AmigaVision".to_string());
+        let paths = PreviewArchivePaths::from_paths(vec![
+            "/media/fat/mister-magik/assets/amiga-screenshots.mmlz4b".to_string(),
+        ]);
+
+        let preview = amigavision_preview_asset(&discovery, "amiga", &paths)
+            .expect("AmigaVision game preview");
+        assert_eq!(
+            preview.archive_path,
+            "/media/fat/mister-magik/assets/amiga-screenshots.mmlz4b"
+        );
+        assert_eq!(preview.asset_key, "amigavision__667cdd86c04e1709");
+
+        discovery.genre = Some("AmigaVision demos".to_string());
+        assert!(amigavision_preview_asset(&discovery, "amiga", &paths).is_none());
     }
 
     #[test]
@@ -1991,6 +2038,27 @@ mod tests {
             prepared: None,
             confidence: DiscoveryConfidence::CatalogMetadata,
         };
+        let amigavision_demo = GameDiscovery {
+            source_path: "/media/fat/games/Amiga/AmigaVision.hdf::State of the Art".to_string(),
+            launch_ref: media_metadata::amigavision_game_launch_ref(
+                "listings/demos.txt",
+                "State of the Art",
+            ),
+            source_kind: DiscoverySourceKind::CatalogEntry,
+            title: "State of the Art".to_string(),
+            category: "Computer".to_string(),
+            platform_id: "amiga".to_string(),
+            core_id: "Minimig".to_string(),
+            hardware_id: "amiga".to_string(),
+            manufacturer: None,
+            genre: Some("AmigaVision demos".to_string()),
+            year: None,
+            setname: None,
+            parent: None,
+            covered_payload_path: None,
+            prepared: None,
+            confidence: DiscoveryConfidence::CatalogMetadata,
+        };
 
         let scan = sqlite_scan_with_discoveries(vec![
             arcade_parent,
@@ -2002,6 +2070,7 @@ mod tests {
             neogeo_without_setname,
             archive_entry,
             amigavision_game,
+            amigavision_demo,
         ]);
         let ram_catalog = build_catalog_from_scan_with_sources(
             "/media/fat/_Arcade",
@@ -2040,6 +2109,26 @@ mod tests {
             .games
             .iter()
             .any(|game| game.mra_path.starts_with("magik-amigavision:")));
+        assert_eq!(
+            ram_catalog
+                .games
+                .iter()
+                .find(|game| game.title.as_ref() == "Alien Breed")
+                .expect("AmigaVision game")
+                .category
+                .as_ref(),
+            "Games"
+        );
+        assert_eq!(
+            ram_catalog
+                .games
+                .iter()
+                .find(|game| game.title.as_ref() == "State of the Art")
+                .expect("AmigaVision demo")
+                .category
+                .as_ref(),
+            "Demos"
+        );
         let virtual_ref = ram_catalog
             .games
             .iter()

--- a/magik-gui/catalog/src/library_indexer.rs
+++ b/magik-gui/catalog/src/library_indexer.rs
@@ -34,6 +34,7 @@ const SCREENSHOT_PACK_SYSTEM_IDS: &[&str] = &[
     "sms",
     "megadrive",
     "saturn",
+    "amiga",
 ];
 
 pub(crate) struct LibraryIndexer<'a> {

--- a/magik-gui/catalog/src/media_identity.rs
+++ b/magik-gui/catalog/src/media_identity.rs
@@ -16,6 +16,7 @@ const SUPPORTED_SCREENSHOT_PACK_IDS: &[ScreenshotPackId] = &[
     ScreenshotPackId::Sms,
     ScreenshotPackId::MegaDrive,
     ScreenshotPackId::Saturn,
+    ScreenshotPackId::Amiga,
 ];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -28,6 +29,7 @@ pub enum ScreenshotPackId {
     Sms,
     MegaDrive,
     Saturn,
+    Amiga,
 }
 
 impl ScreenshotPackId {
@@ -41,6 +43,7 @@ impl ScreenshotPackId {
             "sms" => Some(Self::Sms),
             "megadrive" => Some(Self::MegaDrive),
             "saturn" => Some(Self::Saturn),
+            "amiga" => Some(Self::Amiga),
             _ => None,
         }
     }
@@ -55,6 +58,7 @@ impl ScreenshotPackId {
             Self::Sms => "sms",
             Self::MegaDrive => "megadrive",
             Self::Saturn => "saturn",
+            Self::Amiga => "amiga",
         }
     }
 
@@ -118,6 +122,15 @@ impl ScreenshotAssetId {
 
     pub fn from_mame_software(list_name: &str, software_name: &str) -> Self {
         Self(format!("mame-software__{list_name}__{software_name}"))
+    }
+
+    pub fn from_amigavision_title(title: &str) -> Self {
+        let mut hash = 0xcbf29ce484222325_u64;
+        for byte in title.as_bytes() {
+            hash ^= u64::from(*byte);
+            hash = hash.wrapping_mul(0x100000001b3);
+        }
+        Self(format!("amigavision__{hash:016x}"))
     }
 
     pub fn as_str(&self) -> &str {
@@ -323,6 +336,10 @@ mod tests {
         assert_eq!(
             ScreenshotAssetId::from_mame_software("nes", "smb").as_str(),
             "mame-software__nes__smb"
+        );
+        assert_eq!(
+            ScreenshotAssetId::from_amigavision_title("Alien Breed (OCS)[en]").as_str(),
+            "amigavision__667cdd86c04e1709"
         );
     }
 }

--- a/magik-gui/catalog/src/preview_worker.rs
+++ b/magik-gui/catalog/src/preview_worker.rs
@@ -1608,6 +1608,7 @@ fn console_preview_archive_paths_from_env() -> Vec<String> {
         "MISTER_SMS_PREVIEW_ARCHIVE",
         "MISTER_MEGADRIVE_PREVIEW_ARCHIVE",
         "MISTER_SATURN_PREVIEW_ARCHIVE",
+        "MISTER_AMIGA_PREVIEW_ARCHIVE",
     ]
     .into_iter()
     .filter_map(|name| match std::env::var(name) {

--- a/magik-gui/catalog/src/software_identity.rs
+++ b/magik-gui/catalog/src/software_identity.rs
@@ -809,6 +809,8 @@ pub(crate) fn preview_asset_pack_platform(path: &str) -> &'static str {
         "sms"
     } else if path.contains("megadrive-screenshots") {
         "megadrive"
+    } else if path.contains("amiga-screenshots") {
+        "amiga"
     } else if path.contains("saturn") {
         "saturn"
     } else {

--- a/magik-gui/catalog/src/sqlite_catalog.rs
+++ b/magik-gui/catalog/src/sqlite_catalog.rs
@@ -2175,7 +2175,11 @@ fn write_sqlite_scan_with_sources_inner(
                    games.system_id,
                    game_detail_rows.year,
                    games.manufacturer,
-                   games.genre AS category,
+                   CASE
+                       WHEN games.system_id = 'amiga' AND games.genre = 'AmigaVision' THEN 'Games'
+                       WHEN games.system_id = 'amiga' AND games.genre = 'AmigaVision demos' THEN 'Demos'
+                       ELSE games.genre
+                   END AS category,
                    game_detail_rows.discovered_at_unix
             FROM launcher_catalog_rows
             JOIN launch_target_rows ON launch_target_rows.launch_id = launcher_catalog_rows.launch_id

--- a/magik-gui/src/launcher.rs
+++ b/magik-gui/src/launcher.rs
@@ -869,11 +869,12 @@ impl LauncherNav {
         self.update_home_scroll(now, frame_now, system_count);
 
         if rising(now.btn_a, self.prev.btn_a) {
-            self.arcade_filter.active = ArcadeFilter::All;
             if let Some(system) = catalog.systems.get(self.selected) {
-                let count = catalog.system_game_count(&system.id);
+                self.arcade_filter.active = default_filter_for_system(catalog, &system.id);
+                let count = catalog.filtered_game_count(&system.id, &self.arcade_filter.active);
                 self.restore_game_list_state(&system.id, count);
             } else {
+                self.arcade_filter.active = ArcadeFilter::All;
                 self.arcade.reset();
             }
             self.screen = Screen::Arcade;
@@ -1923,6 +1924,15 @@ fn filter_memory_key(filter: &ArcadeFilter) -> String {
         ArcadeFilter::Decade(decade) => format!("decade:{decade}"),
         ArcadeFilter::Manufacturer(manufacturer) => format!("manufacturer:{manufacturer}"),
         ArcadeFilter::Category(category) => format!("category:{category}"),
+    }
+}
+
+fn default_filter_for_system(catalog: &ArcadeCatalog, system_id: &str) -> ArcadeFilter {
+    let games = ArcadeFilter::Category("Games".to_string());
+    if system_id == "amiga" && catalog.filtered_game_count(system_id, &games) > 0 {
+        games
+    } else {
+        ArcadeFilter::All
     }
 }
 
@@ -3139,6 +3149,29 @@ mod tests {
                 .system_id("amiga")
                 .build()],
             vec![arcade_system("amiga", 1)],
+        )
+    }
+
+    fn amiga_games_and_demos_catalog() -> ArcadeCatalog {
+        arcade_catalog(
+            vec![
+                arcade_game("Agony")
+                    .path("magik-amigavision:games:Agony")
+                    .system_id("amiga")
+                    .category("Games")
+                    .build(),
+                arcade_game("Alien Breed")
+                    .path("magik-amigavision:games:Alien%20Breed")
+                    .system_id("amiga")
+                    .category("Games")
+                    .build(),
+                arcade_game("State of the Art")
+                    .path("magik-amigavision:demos:State%20of%20the%20Art")
+                    .system_id("amiga")
+                    .category("Demos")
+                    .build(),
+            ],
+            vec![arcade_system("amiga", 3)],
         )
     }
 
@@ -4379,6 +4412,25 @@ mod tests {
         assert_eq!(nav.screen, Screen::Arcade);
         assert_eq!(nav.arcade.selected, 3);
         assert_eq!(nav.arcade.scroll_y, 3 * ARCADE_ROW_HEIGHT);
+    }
+
+    #[test]
+    fn amiga_opens_with_games_category_instead_of_games_and_demos() {
+        let catalog = amiga_games_and_demos_catalog();
+        let mut nav = LauncherNav::new();
+
+        assert!(nav
+            .handle_input(&pad_with(|pad| pad.btn_a = true), Instant::now(), &catalog)
+            .is_none());
+
+        assert_eq!(nav.screen, Screen::Arcade);
+        assert_eq!(
+            nav.arcade_filter.active,
+            ArcadeFilter::Category("Games".to_string())
+        );
+        let visible = nav.active_arcade_game_view(&catalog, "amiga");
+        assert_eq!(visible.len(), 2);
+        assert!(visible.iter().all(|game| game.category.as_ref() == "Games"));
     }
 
     #[test]

--- a/magik-gui/src/preview_state.rs
+++ b/magik-gui/src/preview_state.rs
@@ -1916,6 +1916,8 @@ fn preview_result_system_id(result: &PreviewResult) -> &'static str {
         "neogeo"
     } else if path.contains("saturn-screenshots") {
         "saturn"
+    } else if path.contains("amiga-screenshots") {
+        "amiga"
     } else if path.contains("arcade-screenshots") {
         "arcade"
     } else {


### PR DESCRIPTION
## What changed

- add Amiga screenshot-pack identity and preview archive discovery
- map AmigaVision categories to `Games` and `Demos` in both RAM and SQLite projections
- open Amiga on the `Games` filter by default
- bump the catalog schema for the projection change
- update the private `magik-cloud` submodule to the published Amiga pack tooling

## Why

AmigaVision games need one stable screenshot per installed title, clearer launcher category labels, and a games-only default view rather than mixing games and demos.

## Dependency

- private `magik-cloud` draft PR: https://github.com/NigelBreslaw/magik-cloud/pull/1

## Validation

The pre-commit suite passed, including:

- 255 host UI tests
- 350 catalog tests
- 79 host-tool tests
- catalog and host clippy checks
- host, host-tool, and agent checks
- `git diff --check`

The Amiga R2 archive contains 753 entries and its archive/index hashes were verified.
