### PR TITLE
Fix latch v3 Quartus timing closure

### DIFF
--- a/mister/platform/fpga/menu-vblank-latch/mister_magik_vblank_latch.sv
+++ b/mister/platform/fpga/menu-vblank-latch/mister_magik_vblank_latch.sv
@@ -98,6 +98,8 @@ module mister_magik_vblank_latch (
 	reg [15:0] rx_vmax_word = 16'd0;
 	reg [15:0] rx_stride_word = 16'd0;
 	reg [15:0] rx_seq = 16'd0;
+	reg [25:0] rx_row_span = 26'd0;
+	reg rx_address_wrap = 1'b0;
 
 	reg [3:0] last_reject_reason = MAGIK_REJECT_NONE;
 	reg magik_ownership = 1'b0;
@@ -134,10 +136,13 @@ module mister_magik_vblank_latch (
 	wire [11:0] rx_vmin = rx_vmin_word[11:0];
 	wire [11:0] rx_vmax = rx_vmax_word[11:0];
 	wire [13:0] rx_stride = rx_stride_word[13:0];
-	wire [47:0] rx_end_address =
-		{16'd0, rx_base} +
-		(({36'd0, rx_height} - 48'd1) * {34'd0, rx_stride}) +
-		({36'd0, rx_width} << 1);
+	wire [11:0] rx_height_minus_one = rx_height - 12'd1;
+	wire [25:0] rx_next_row_span =
+		rx_height_minus_one * data_in[13:0];
+	wire [32:0] rx_pipelined_end_address =
+		{1'b0, rx_base} +
+		{{7{1'b0}}, rx_row_span} +
+		{{20{1'b0}}, rx_width, 1'b0};
 
 	reg [3:0] semantic_reject;
 	always @(*) begin
@@ -166,7 +171,7 @@ module mister_magik_vblank_latch (
 			semantic_reject = MAGIK_REJECT_INVALID_STRIDE;
 		else if((rx_hmin > rx_hmax) || (rx_vmin > rx_vmax))
 			semantic_reject = MAGIK_REJECT_INVALID_BOUNDS;
-		else if(rx_end_address > 48'h000100000000)
+		else if(rx_address_wrap)
 			semantic_reject = MAGIK_REJECT_ADDRESS_WRAP;
 	end
 
@@ -283,6 +288,8 @@ module mister_magik_vblank_latch (
 				rx_expected <= 4'd0;
 				rx_mask <= 11'd0;
 				rx_crc <= crc_header(MAGIK_UIO_SET_FBUF_LATCH, 16'd11);
+				rx_row_span <= 26'd0;
+				rx_address_wrap <= 1'b0;
 			end
 			else begin
 				rx_open <= 1'b0;
@@ -336,8 +343,15 @@ module mister_magik_vblank_latch (
 					4'd6: rx_hmax_word <= data_in;
 					4'd7: rx_vmin_word <= data_in;
 					4'd8: rx_vmax_word <= data_in;
-					4'd9: rx_stride_word <= data_in;
-					4'd10: rx_seq <= data_in;
+					4'd9: begin
+						rx_stride_word <= data_in;
+						rx_row_span <= rx_next_row_span;
+					end
+					4'd10: begin
+						rx_seq <= data_in;
+						rx_address_wrap <=
+							rx_pipelined_end_address > 33'h100000000;
+					end
 					// word_index < 11 and exact ordering restrict this case to 0..10.
 					/* verilator coverage_off */
 					default: begin end

--- a/mister/platform/fpga/menu-vblank-latch/report_top_timing.tcl
+++ b/mister/platform/fpga/menu-vblank-latch/report_top_timing.tcl
@@ -1,0 +1,26 @@
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+package require ::quartus::project
+package require ::quartus::sta
+
+project_open menu
+create_timing_netlist
+read_sdc
+update_timing_netlist
+
+report_timing \
+	-setup \
+	-npaths 25 \
+	-nworst 1 \
+	-detail full_path \
+	-file output_files/menu.top-setup-paths.rpt
+report_timing \
+	-hold \
+	-npaths 25 \
+	-nworst 1 \
+	-detail full_path \
+	-file output_files/menu.top-hold-paths.rpt
+
+delete_timing_netlist
+project_close

--- a/mister/platform/fpga/menu-vblank-latch/tb_mister_magik_vblank_latch.sv
+++ b/mister/platform/fpga/menu-vblank-latch/tb_mister_magik_vblank_latch.sv
@@ -585,12 +585,20 @@ module tb_mister_magik_vblank_latch;
 		send_route(16'h8014, 32'hfffffe00, 16'd320, 16'd2,
 		           16'd0, 16'd319, 16'd0, 16'd1, 16'd640, 16'h1006);
 		expect_reject(reject_before, MAGIK_REJECT_ADDRESS_WRAP, "address wrap");
+		expect16(pending_seq, pending_before, "semantic rejects preserve pending");
+		// The next transaction must replace the pipelined wrap result. An
+		// exclusive end address exactly at 2^32 is valid.
+		send_route(16'h8014, 32'hfffffd80, 16'd320, 16'd1,
+		           16'd0, 16'd319, 16'd0, 16'd0, 16'd640, 16'h1007);
+		expect16(pending_seq, 16'h1007, "valid route after address wrap commits");
+		expect32(route_base, 32'hfffffd80, "boundary route base commits");
+		pending_before = pending_seq;
 		reject_before = reject_count;
 		send_route(16'h0000, 32'h00000002, 16'd0, 16'd0,
-		           16'd0, 16'd0, 16'd0, 16'd0, 16'd0, 16'h1007);
+		           16'd0, 16'd0, 16'd0, 16'd0, 16'd0, 16'h1008);
 		expect_reject(reject_before, MAGIK_REJECT_INVALID_MODE,
 		              "disabled route must be canonical");
-		expect16(pending_seq, pending_before, "semantic rejects preserve pending");
+		expect16(pending_seq, pending_before, "later semantic reject preserves pending");
 		requirement_coverage[8] = 1'b1;
 
 		// Applying old pending and committing new on one edge keeps the new pending.

--- a/scripts/build-fpga-vblank-latch-core.sh
+++ b/scripts/build-fpga-vblank-latch-core.sh
@@ -9,6 +9,7 @@ PATCH="$ROOT/mister/platform/fpga/menu-vblank-latch/Menu_MiSTer-vblank-latched-f
 LATCH_RTL="$ROOT/mister/platform/fpga/menu-vblank-latch/mister_magik_vblank_latch.sv"
 LATCH_BRIDGE="$ROOT/mister/platform/fpga/menu-vblank-latch/mister_magik_latch_sys_top_bridge.sv"
 LATCH_PROTOCOL="$ROOT/mister/platform/fpga/menu-vblank-latch/mister_magik_latch_protocol.svh"
+TIMING_REPORT_TCL="$ROOT/mister/platform/fpga/menu-vblank-latch/report_top_timing.tcl"
 OUT_DIR="${MISTER_FPGA_OUT_DIR:-$ROOT/build/fpga-vblank-latch}"
 WORK_DIR="${MISTER_MENU_BUILD_DIR:-$OUT_DIR/Menu_MiSTer-vblank-latch-work}"
 if [[ -n "${MISTER_MENU_DIR:-}" ]]; then
@@ -21,6 +22,7 @@ fi
 RBF_OUT="$OUT_DIR/menu-magik-vblank-latch.rbf"
 META_OUT="$OUT_DIR/menu-magik-vblank-latch.metadata.txt"
 LOG_OUT="$OUT_DIR/menu-magik-vblank-latch.build.log"
+TIMING_LOG_OUT="$OUT_DIR/menu-magik-vblank-latch.top-timing.log"
 STRACE_PREFIX="quartus-flow.strace"
 QUARTUS_DOCKER_IMAGE="${QUARTUS_DOCKER_IMAGE:-mister-magik-quartus-runtime:ubuntu20-amd64}"
 QUARTUS_DOCKER_CPUS="${QUARTUS_DOCKER_CPUS:-8}"
@@ -85,6 +87,10 @@ if [[ ! -f "$LATCH_BRIDGE" ]]; then
   echo "missing latch sys_top bridge: $LATCH_BRIDGE" >&2
   exit 1
 fi
+if [[ ! -f "$TIMING_REPORT_TCL" ]]; then
+  echo "missing top timing report script: $TIMING_REPORT_TCL" >&2
+  exit 1
+fi
 MENU_ABS="$(abs_path "$MENU_DIR")"
 
 if [[ ! -f "$MENU_ABS/menu.qsf" || ! -f "$MENU_ABS/sys/sys_top.v" ]]; then
@@ -110,7 +116,7 @@ else
 fi
 
 mkdir -p "$OUT_DIR"
-rm -f "$RBF_OUT" "$META_OUT" "$LOG_OUT" "$OUT_DIR"/"$STRACE_PREFIX"*.log
+rm -f "$RBF_OUT" "$META_OUT" "$LOG_OUT" "$TIMING_LOG_OUT" "$OUT_DIR"/"$STRACE_PREFIX"*.log
 rm -rf "$WORK_DIR"
 mkdir -p "$WORK_DIR"
 rsync -a --delete \
@@ -120,6 +126,7 @@ rsync -a --delete \
   --exclude incremental_db \
   "$MENU_ABS"/ "$WORK_DIR"/
 git -C "$WORK_DIR" init -q
+cp "$TIMING_REPORT_TCL" "$WORK_DIR/mister_magik_report_top_timing.tcl"
 
 case "$APPLY_PATCH" in
   0|false|False|FALSE|no|No|NO)
@@ -280,6 +287,23 @@ find "$WORK_DIR" -maxdepth 1 -name "$STRACE_PREFIX*" -print0 |
 
 if [[ "$build_status" -ne 0 ]]; then
   exit "$build_status"
+fi
+
+if [[ "$QUARTUS_MODE" = "docker" ]]; then
+  docker run --platform linux/amd64 --rm \
+    "${docker_security_args[@]}" \
+    "${docker_mount_args[@]}" \
+    --cpus "$QUARTUS_DOCKER_CPUS" \
+    --memory "$QUARTUS_DOCKER_MEMORY" \
+    "${docker_quartus_mount_args[@]}" \
+    --workdir /work \
+    "$QUARTUS_DOCKER_IMAGE" \
+    quartus_sta -t mister_magik_report_top_timing.tcl 2>&1 | tee "$TIMING_LOG_OUT"
+else
+  (
+    cd "$WORK_DIR"
+    quartus_sta -t mister_magik_report_top_timing.tcl
+  ) 2>&1 | tee "$TIMING_LOG_OUT"
 fi
 
 RBF_CANDIDATE="$WORK_DIR/output_files/menu.rbf"


### PR DESCRIPTION
## Summary
- pipeline SET address-wrap validation across stride and sequence words
- preserve CRC word 11 as the sole commit point
- retain detailed Quartus setup and hold path reports for matched stock/patched builds

## Failure addressed
The protocol-v3 platform candidate built its RBF but failed signoff at -0.874 ns setup slack and -14.012 ns TNS on clk_sys. This removes the multiplier-plus-wide-adder chain from CRC commit validation.

## Validation
- pre-commit fast gates passed for both logical commits
- pre-push full local assurance passed
- Quartus/RBF validation intentionally deferred to the platform workflow