### PR TITLE
config: evolve the runtime setting schema

### DIFF
--- a/agent-cli/src/checks.rs
+++ b/agent-cli/src/checks.rs
@@ -765,12 +765,37 @@ struct RuntimeEnvironmentControl {
     value_shape: String,
     default_behavior: String,
     visibility: String,
+    #[serde(default)]
+    parser: Option<String>,
+    #[serde(default)]
+    typed_default: Option<toml::Value>,
+    #[serde(default)]
+    scope: Option<String>,
+    #[serde(default)]
+    conflicts: Vec<String>,
+    #[serde(default)]
+    sensitivity: Option<String>,
+    #[serde(default)]
+    aliases: Vec<String>,
+    #[serde(default)]
+    documentation: Option<RuntimeEnvironmentDocumentation>,
+}
+
+#[derive(Clone, serde::Deserialize)]
+struct RuntimeEnvironmentDocumentation {
+    summary: String,
+    #[serde(default)]
+    accepted_values: Vec<String>,
+    value_policy: String,
 }
 
 fn check_runtime_environment(repository: &Path) -> Result<(), String> {
     const REGISTRY_PATH: &str = "apps/mister/config/runtime-environment.toml";
     const REFERENCE_PATH: &str = "docs/reference/mister-runtime-environment.md";
-    const FORMAT: &str = "mister-magik-runtime-environment-v1";
+    const FORMATS: &[&str] = &[
+        "mister-magik-runtime-environment-v1",
+        "mister-magik-runtime-environment-v2",
+    ];
     const SOURCE_ROOTS: &[&str] = &[
         "apps/mister/src",
         "mister/platform/runtime/src",
@@ -781,9 +806,10 @@ fn check_runtime_environment(repository: &Path) -> Result<(), String> {
     let text = read(repository, REGISTRY_PATH)?;
     let mut registry: RuntimeEnvironmentRegistry = toml::from_str(&text)
         .map_err(|error| format!("runtime_environment_registry_invalid: {error}"))?;
-    if registry.format != FORMAT {
+    if !FORMATS.contains(&registry.format.as_str()) {
         return Err(format!(
-            "runtime_environment_format_invalid: expected {FORMAT}"
+            "runtime_environment_format_invalid: expected {}",
+            FORMATS.join(" or ")
         ));
     }
     if registry.source_roots != SOURCE_ROOTS {
@@ -825,9 +851,33 @@ fn check_runtime_environment(repository: &Path) -> Result<(), String> {
             || control.value_shape.is_empty()
             || control.default_behavior.is_empty()
             || control.visibility.is_empty()
+            || validate_runtime_environment_metadata(control).is_err()
         {
             return Err(format!(
                 "runtime_environment_control_invalid: {}",
+                control.name
+            ));
+        }
+    }
+    let mut accepted_names = registered.clone();
+    for control in &registry.control {
+        for alias in &control.aliases {
+            if !valid_environment_name(alias) || !accepted_names.insert(alias.clone()) {
+                return Err(format!(
+                    "runtime_environment_alias_invalid: {} alias {}",
+                    control.name, alias
+                ));
+            }
+        }
+    }
+    for control in &registry.control {
+        if control
+            .conflicts
+            .iter()
+            .any(|conflict| conflict == &control.name || !accepted_names.contains(conflict))
+        {
+            return Err(format!(
+                "runtime_environment_conflict_invalid: {}",
                 control.name
             ));
         }
@@ -846,7 +896,8 @@ fn check_runtime_environment(repository: &Path) -> Result<(), String> {
         }
     }
     let unregistered: Vec<_> = actual
-        .difference(&registered)
+        .iter()
+        .filter(|name| !accepted_names.contains(*name))
         .filter(|name| !registered_by_prefix(name, &registry.dynamic_prefix))
         .cloned()
         .collect();
@@ -888,6 +939,72 @@ fn check_runtime_environment(repository: &Path) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+fn validate_runtime_environment_metadata(control: &RuntimeEnvironmentControl) -> Result<(), ()> {
+    const PARSERS: &[&str] = &[
+        "bool",
+        "i64",
+        "u64",
+        "f64",
+        "string",
+        "path",
+        "path-list",
+        "enum",
+    ];
+    const SCOPES: &[&str] = &["process", "command", "instrumentation", "external", "build"];
+    const SENSITIVITY: &[&str] = &["public", "path", "secret", "volatile-token"];
+    if control
+        .parser
+        .as_deref()
+        .is_some_and(|parser| !PARSERS.contains(&parser))
+        || control
+            .scope
+            .as_deref()
+            .is_some_and(|scope| !SCOPES.contains(&scope))
+        || control
+            .sensitivity
+            .as_deref()
+            .is_some_and(|value| !SENSITIVITY.contains(&value))
+        || control
+            .typed_default
+            .as_ref()
+            .is_some_and(|value| !typed_default_matches(control.parser.as_deref(), value))
+        || control.typed_default.is_some() && control.parser.is_none()
+    {
+        return Err(());
+    }
+    if control.documentation.as_ref().is_some_and(|documentation| {
+        documentation.summary.trim().is_empty()
+            || !["document", "redact", "omit"].contains(&documentation.value_policy.as_str())
+            || documentation
+                .accepted_values
+                .iter()
+                .any(|value| value.trim().is_empty())
+            || documentation
+                .accepted_values
+                .iter()
+                .collect::<BTreeSet<_>>()
+                .len()
+                != documentation.accepted_values.len()
+    }) {
+        return Err(());
+    }
+    Ok(())
+}
+
+fn typed_default_matches(parser: Option<&str>, value: &toml::Value) -> bool {
+    match parser {
+        Some("bool") => value.is_bool(),
+        Some("i64") => value.is_integer(),
+        Some("u64") => value.as_integer().is_some_and(|value| value >= 0),
+        Some("f64") => value.is_float(),
+        Some("string" | "path" | "enum") => value.is_str(),
+        Some("path-list") => value
+            .as_array()
+            .is_some_and(|values| values.iter().all(toml::Value::is_str)),
+        _ => false,
+    }
 }
 
 fn mister_environment_names(text: &str) -> Vec<String> {
@@ -946,19 +1063,54 @@ fn render_runtime_environment_reference(registry: &RuntimeEnvironmentRegistry) -
         registry.baseline.unique_names,
         registry.baseline.external_build_names
     ));
-    output.push_str("| Name | Classification | Shape | Default behavior | Visibility | Owner |\n|---|---|---|---|---|---|\n");
+    output.push_str("| Name | Classification | Shape | Default behavior | Parser | Typed default | Scope | Conflicts | Sensitivity | Aliases | Documentation | Visibility | Owner |\n|---|---|---|---|---|---|---|---|---|---|---|---|---|\n");
     for control in &registry.control {
+        let documentation = control
+            .documentation
+            .as_ref()
+            .map(|documentation| {
+                let accepted = if documentation.accepted_values.is_empty() {
+                    String::new()
+                } else {
+                    format!("; values: {}", documentation.accepted_values.join(", "))
+                };
+                format!(
+                    "{}{}; value policy: {}",
+                    documentation.summary, accepted, documentation.value_policy
+                )
+            })
+            .unwrap_or_else(|| "—".into());
         output.push_str(&format!(
-            "| `{}` | {} | {} | {} | {} | `{}` |\n",
+            "| `{}` | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | {} | `{}` |\n",
             control.name,
             control.classification,
             control.value_shape,
             control.default_behavior.replace('|', "\\|"),
+            control.parser.as_deref().unwrap_or("—"),
+            control
+                .typed_default
+                .as_ref()
+                .map(ToString::to_string)
+                .unwrap_or_else(|| "—".into())
+                .replace('|', "\\|"),
+            control.scope.as_deref().unwrap_or("—"),
+            metadata_list(&control.conflicts),
+            control.sensitivity.as_deref().unwrap_or("—"),
+            metadata_list(&control.aliases),
+            documentation.replace('|', "\\|"),
             control.visibility,
             control.owner
         ));
     }
     output
+}
+
+fn metadata_list(values: &[String]) -> String {
+    if values.is_empty() {
+        "—".into()
+    } else {
+        values.join(", ")
+    }
 }
 
 fn check_device_crate_root_ownership(repository: &Path) -> Result<(), String> {
@@ -1832,6 +1984,58 @@ visibility = "internal runtime"
         assert!(error.contains("runtime_environment_unregistered: MISTER_TWO"));
         assert!(error.contains("owning module"));
         fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn runtime_environment_v2_accepts_every_parser_and_scope() {
+        let fixtures = [
+            ("bool", "true", "process"),
+            ("i64", "-2", "command"),
+            ("u64", "2", "instrumentation"),
+            ("f64", "1.5", "external"),
+            ("string", "\"value\"", "build"),
+            ("path", "\"/tmp/value\"", "process"),
+            ("path-list", "[\"/tmp/one\", \"/tmp/two\"]", "command"),
+            ("enum", "\"auto\"", "instrumentation"),
+        ];
+        for (parser, default, scope) in fixtures {
+            let fixture = format!(
+                r#"name = "MISTER_FIXTURE"
+owner = "apps/mister/src/config.rs"
+classification = "test"
+value_shape = "fixture"
+default_behavior = "fixture"
+visibility = "fixture"
+parser = "{parser}"
+typed_default = {default}
+scope = "{scope}"
+conflicts = ["MISTER_OTHER"]
+sensitivity = "public"
+aliases = ["MISTER_FIXTURE_ALIAS"]
+documentation = {{ summary = "Fixture metadata", accepted_values = ["one", "two"], value_policy = "document" }}
+"#
+            );
+            let control: RuntimeEnvironmentControl = toml::from_str(&fixture).unwrap();
+            assert!(
+                validate_runtime_environment_metadata(&control).is_ok(),
+                "metadata fixture rejected for parser={parser} scope={scope}"
+            );
+        }
+
+        let invalid: RuntimeEnvironmentControl = toml::from_str(
+            r#"name = "MISTER_FIXTURE"
+owner = "apps/mister/src/config.rs"
+classification = "test"
+value_shape = "fixture"
+default_behavior = "fixture"
+visibility = "fixture"
+parser = "bool"
+typed_default = "not-a-bool"
+scope = "process"
+"#,
+        )
+        .unwrap();
+        assert!(validate_runtime_environment_metadata(&invalid).is_err());
     }
 
     #[test]

--- a/apps/mister/config/runtime-environment.toml
+++ b/apps/mister/config/runtime-environment.toml
@@ -1,7 +1,7 @@
 # Copyright (C) 2026 Nigel Breslaw
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-format = "mister-magik-runtime-environment-v1"
+format = "mister-magik-runtime-environment-v2"
 source_roots = [
   "apps/mister/src",
   "mister/platform/runtime/src",

--- a/docs/reference/mister-runtime-environment.md
+++ b/docs/reference/mister-runtime-environment.md
@@ -2,281 +2,281 @@
 
 <!-- Generated from apps/mister/config/runtime-environment.toml. Do not edit. -->
 
-Registry format: `mister-magik-runtime-environment-v1`. Baseline: 395 literal occurrences, 274 owned names, 10 external/build-time names.
+Registry format: `mister-magik-runtime-environment-v2`. Baseline: 395 literal occurrences, 274 owned names, 10 external/build-time names.
 
-| Name | Classification | Shape | Default behavior | Visibility | Owner |
-|---|---|---|---|---|---|
-| `MISTER_7ZA` | external | string, enum, or boolean token | site-defined fallback; unchanged in P0 | external compatibility | `crates/catalog/src/media_metadata.rs` |
-| `MISTER_7ZA_TIMEOUT_SECS` | external | bounded integer | site-defined fallback; unchanged in P0 | external compatibility | `crates/catalog/src/media_metadata.rs` |
-| `MISTER_AMIGA_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_ANIMATION_CLOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/visual_platform.rs` |
-| `MISTER_ARCADE_BOOTSTRAP_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/pmu_profile.rs` |
-| `MISTER_ARCADE_ENTRY_RUN_ID` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_ARCADE_ENTRY_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_ARCADE_ROOT` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/effect_loop_support.rs` |
-| `MISTER_ARCADE_SCROLL_SPEED_DIV` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher.rs` |
-| `MISTER_ARCADE_SELECTED_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
-| `MISTER_ARCADE_SELECTION_INVERT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/arcade_list_renderer.rs` |
-| `MISTER_BACKGROUND_AFFINITY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/runtime_thread.rs` |
-| `MISTER_BOOT_ANALYTICS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/boot_analytics.rs` |
-| `MISTER_BOOT_BLACK_SETTLE_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/ui_boot.rs` |
-| `MISTER_BOOT_FRAME_PROFILE_FILE` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `mister/platform/runtime/src/boot_analytics.rs` |
-| `MISTER_BOOT_FRAME_PROFILE_FRAMES` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | developer diagnostic | `mister/platform/runtime/src/boot_analytics.rs` |
-| `MISTER_CAMERA_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
-| `MISTER_CAMERA_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
-| `MISTER_CAMERA_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
-| `MISTER_CAMERA_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
-| `MISTER_CAMERA_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
-| `MISTER_CAMERA_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
-| `MISTER_CATALOG_BACKGROUND_DELAY_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_CATALOG_BUILDER_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/pmu_profile.rs` |
-| `MISTER_CATALOG_CONTENTION_QUIET_PREVIEWS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_CATALOG_DIAGNOSTICS_DIR` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/catalog_progress_report.rs` |
-| `MISTER_CATALOG_DURABLE_RESUME` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/library_indexer.rs` |
-| `MISTER_CATALOG_PROTOCOL_STDOUT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/bin/catalog_builder.rs` |
-| `MISTER_CATALOG_READY_SNAPSHOT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/pmu_profile.rs` |
-| `MISTER_CATALOG_REFRESH` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
-| `MISTER_CATALOG_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `crates/catalog/src/catalog_checkpoint.rs` |
-| `MISTER_CLOUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/particles/src/intro.rs` |
-| `MISTER_CRASH_BACKTRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/crash_report.rs` |
-| `MISTER_CRT_PROBE_PATTERN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/crt_trial_loop.rs` |
-| `MISTER_CRT_TRIAL_CONTENT_BOUNDS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/crt_trial_loop.rs` |
-| `MISTER_DIRTY_RECT_BROAD_PCT` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/target.rs` |
-| `MISTER_DISPLAY_OWNER_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/ownership.rs` |
-| `MISTER_EFFECT_BENCH_LABEL` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `apps/mister/src/ui_effect_bench.rs` |
-| `MISTER_FB_DIAGNOSTIC_RECT` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `mister/platform/runtime/src/fpga.rs` |
-| `MISTER_FB_MAP_BANDWIDTH_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_FB_MAP_BANDWIDTH_H` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_FB_MAP_BANDWIDTH_W` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_FB_MAP_REPORT_H` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_FB_MAP_REPORT_W` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_FB_PRESENT_DELAY_US` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/visual_platform.rs` |
-| `MISTER_FB_RIGHT_GUARD_COLS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_present/latch.rs` |
-| `MISTER_FB_ROUTE_REASSERT_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/ownership.rs` |
-| `MISTER_FPGA_LATCH_PATTERN_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_FPGA_LATCH_PATTERN_PERIOD_US` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_FRAMEBUFFER_STREAM_SCALE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/stream.rs` |
-| `MISTER_FRAME_ORDER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/video_loop.rs` |
-| `MISTER_FS_FAULT_ACTION` | fault | string, enum, or boolean token | site-defined fallback; unchanged in P0 | destructive test only | `crates/catalog/src/fs_fault.rs` |
-| `MISTER_FS_FAULT_DELAY_MS` | fault | bounded integer | site-defined fallback; unchanged in P0 | destructive test only | `crates/catalog/src/fs_fault.rs` |
-| `MISTER_FS_FAULT_POINT` | fault | string, enum, or boolean token | site-defined fallback; unchanged in P0 | destructive test only | `crates/catalog/src/fs_fault.rs` |
-| `MISTER_FS_FAULT_SESSION` | fault | string, enum, or boolean token | site-defined fallback; unchanged in P0 | destructive test only | `crates/catalog/src/fs_fault.rs` |
-| `MISTER_GLYPH_ALPHA_THRESHOLD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/mapped.rs` |
-| `MISTER_GROUPS` | external | string, enum, or boolean token | site-defined fallback; unchanged in P0 | external compatibility | `crates/particles/src/intro.rs` |
-| `MISTER_GUI_FRAME_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_gui_profile.rs` |
-| `MISTER_GUI_FRAME_PROFILE_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_gui_profile.rs` |
-| `MISTER_GUI_FRAME_PROFILE_PMU` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_gui_profile.rs` |
-| `MISTER_HBMAME_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/catalog_config.rs` |
-| `MISTER_HOME_SELECTED_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_HUMAN_TURBO_IDLE_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_HUMAN_TURBO_NORMAL_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_HUMAN_TURBO_PAUSE_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_INI_PATH` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_display.rs` |
-| `MISTER_INPUT_INTEGRITY_STALL_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_INPUT_INTEGRITY_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_INPUT_LATENCY_LAB_ARM` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_input_latency_lab.rs` |
-| `MISTER_INPUT_LATENCY_LAB_READER_POLICY` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/input_hub.rs` |
-| `MISTER_INPUT_LATENCY_LAB_READER_SCHEDSTAT` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/input_hub.rs` |
-| `MISTER_INPUT_LATENCY_LAB_SESSION` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/input_hub.rs` |
-| `MISTER_LATCH_V5_QUALIFICATION` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/latch_v5_qualification.rs` |
-| `MISTER_LAUNCHER_AUTO_LAUNCH_SELECTED` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_BENCH_AFTER_INPUT_SCRIPT` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_LAUNCHER_BENCH_SCENARIO` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_LAUNCHER_DIRTY_OPT` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
-| `MISTER_LAUNCHER_INPUT_SCRIPT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_INPUT_SCRIPT_WAIT_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_LOCK_SCREEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_LAUNCHER_RESPONSE_COMPLETE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_EXECUTION_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_EXPECTED_CONFIRMED` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_EXPECTED_FEEDBACK_HIDDEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_FRAME_COMPLETE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_PMU` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_PMU_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_RUN_ID` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_RESPONSE_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_LAUNCHER_START_MENU` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_LAUNCHER_START_SCREEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_LAUNCHER_START_SYSTEM` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_LAUNCH_HANDOFF_DELAY_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
-| `MISTER_LAUNCH_HANDOFF_ITERATIONS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
-| `MISTER_LAUNCH_HANDOFF_LABEL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
-| `MISTER_LAUNCH_HANDOFF_MODE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
-| `MISTER_LAUNCH_HANDOFF_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
-| `MISTER_LAUNCH_PREP_AMIGAVISION_LIMIT` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launch_preparation.rs` |
-| `MISTER_LAUNCH_PREP_ITERATIONS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launch_preparation.rs` |
-| `MISTER_LAUNCH_PREP_LABEL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launch_preparation.rs` |
-| `MISTER_LAUNCH_PREP_REFS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launch_preparation.rs` |
-| `MISTER_LAUNCH_PREP_VIRTUAL_LIMIT` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launch_preparation.rs` |
-| `MISTER_LAUNCH_PREP_VIRTUAL_SYSTEMS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launch_preparation.rs` |
-| `MISTER_LAUNCH_RETURN_PMU_HANDOFF_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
-| `MISTER_LIBRARY_BENCH_FORCE_REBUILD` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `crates/catalog/src/library_cli.rs` |
-| `MISTER_LIBRARY_BENCH_ITERATIONS` | benchmark | bounded integer | site-defined fallback; unchanged in P0 | benchmark only | `crates/catalog/src/library_cli.rs` |
-| `MISTER_LIBRARY_BENCH_LABEL` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `crates/catalog/src/library_cli.rs` |
-| `MISTER_LIBRARY_BENCH_PRECOUNT` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `crates/catalog/src/library_cli.rs` |
-| `MISTER_LIBRARY_BENCH_SQLITE` | benchmark | path or path list | site-defined fallback; unchanged in P0 | benchmark only | `crates/catalog/src/device_layout.rs` |
-| `MISTER_LIBRARY_NAMESPACE_BACKEND` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/namespace_walk.rs` |
-| `MISTER_LIBRARY_PATH_MAP` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/catalog_config.rs` |
-| `MISTER_LIBRARY_REFRESH_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_LIBRARY_ROOTS` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/pmu_profile.rs` |
-| `MISTER_LIBRARY_SOFTWARE_HASH` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/software_identity.rs` |
-| `MISTER_LIBRARY_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/pmu_profile.rs` |
-| `MISTER_LIBRARY_SQLITE_BUILD_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/pmu_profile.rs` |
-| `MISTER_LOW_MEMORY_AVAILABLE_KIB` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/memory_pressure.rs` |
-| `MISTER_MAGIK_BUILD_NUMBER` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | build pipeline | `apps/mister/src/build_identity.rs` |
-| `MISTER_MAGIK_BUILD_TIME` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | build pipeline | `apps/mister/src/build_identity.rs` |
-| `MISTER_MAGIK_CRT_TRIAL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/fpga.rs` |
-| `MISTER_MAGIK_DEV_LATCH_POST_SKIP_WORD_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_present/latch.rs` |
-| `MISTER_MAGIK_DEV_LATCH_STATUS_TIMEOUT_AT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_present/latch.rs` |
-| `MISTER_MAGIK_DISPLAY_CONFIRM_UI` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_MAGIK_DOWNLOADER_INI` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/update_checker.rs` |
-| `MISTER_MAGIK_HOT_JOURNAL_DB` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/sqlite_catalog.rs` |
-| `MISTER_MAGIK_INPUT_PROXY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/input_hub.rs` |
-| `MISTER_MAGIK_INPUT_PROXY_PROTOCOL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/input_hub.rs` |
-| `MISTER_MAGIK_MAIN_GENERATION` | production | bounded integer | missing or invalid disables supervised readiness acknowledgement | internal runtime | `apps/mister/src/process_config.rs` |
-| `MISTER_MAGIK_MAIN_PID` | production | bounded integer | missing or invalid disables supervised readiness acknowledgement | internal runtime | `apps/mister/src/process_config.rs` |
-| `MISTER_MAGIK_OWNER_EPOCH` | production | bounded integer | missing or invalid disables supervised readiness acknowledgement | internal runtime | `apps/mister/src/process_config.rs` |
-| `MISTER_MAGIK_PARENT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_MAGIK_PROCESS_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/main.rs` |
-| `MISTER_MAGIK_READY_FIFO` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/process_config.rs` |
-| `MISTER_MAGIK_RELEASE_MARKER` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/update_checker.rs` |
-| `MISTER_MAGIK_RETURN_TO_LAUNCHER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_MAGIK_RUNTIME_DISPLAY_V1` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_display.rs` |
-| `MISTER_MAGIK_RUNTIME_SETTINGS_V1` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_display.rs` |
-| `MISTER_MAGIK_SOURCE_DIRTY` | build-time | path or path list | site-defined fallback; unchanged in P0 | build pipeline | `apps/mister/src/build_identity.rs` |
-| `MISTER_MAGIK_SOURCE_REVISION` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | build pipeline | `apps/mister/src/build_identity.rs` |
-| `MISTER_MAGIK_STARTUP_TOKEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/process_config.rs` |
-| `MISTER_MAGIK_TEST_AUTO_LAUNCH_GATE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | test only | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_MAGIK_TEST_CATALOG_PUBLICATION_GATE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | test only | `apps/mister/src/ui_runner/launcher_catalog_publication_test.rs` |
-| `MISTER_MAGIK_TEST_CATALOG_PUBLICATION_SESSION` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | test only | `apps/mister/src/ui_runner/launcher_catalog_publication_test.rs` |
-| `MISTER_MAGIK_TEST_CATALOG_RECOVERY_DIALOG` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | test only | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_MAGIK_TEST_FIRST_FRAME_RELEASE_GATE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | test only | `apps/mister/src/ui_runner/launcher_catalog_publication_test.rs` |
-| `MISTER_MAGIK_TEST_LIBRARY_CHANGED_DIALOG_CHOICE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | test only | `apps/mister/src/launcher.rs` |
-| `MISTER_MAGIK_VERSION` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | build pipeline | `apps/mister/src/build_identity.rs` |
-| `MISTER_MAME_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/catalog_config.rs` |
-| `MISTER_MEDIA_ASSET_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher.rs` |
-| `MISTER_MEDIA_BENCH_CONTENTION` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `apps/mister/src/launcher_runtime/media.rs` |
-| `MISTER_MEDIA_CONCURRENCY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
-| `MISTER_MEDIA_MANIFEST_URL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
-| `MISTER_MEDIA_SIZE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
-| `MISTER_MEDIA_UPDATE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
-| `MISTER_MEGADRIVE_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_MODE_FORMAT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/format.rs` |
-| `MISTER_N64_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_NAMESPACE_BACKEND` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/library_indexer.rs` |
-| `MISTER_NEOGEO_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_NES_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_ORIENTATION_PMU_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_ORIENTATION_SIMD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher_runtime/orientation_transition.rs` |
-| `MISTER_ORIENTATION_TRANSITIONS_BENCHMARK` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `apps/mister/src/ui_runner.rs` |
-| `MISTER_ORIENTATION_TRANSITIONS_EVIDENCE_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_ORIENTATION_TRANSITIONS_REQUIRE_ANALYTICS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_ORIENTATION_TRANSITION_EFFECT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_PARTICLE_COHORTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/particles/src/engine.rs` |
-| `MISTER_PARTICLE_COMMAND_ORDER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/particle_renderer.rs` |
-| `MISTER_PARTICLE_PMU` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/particle_renderer.rs` |
-| `MISTER_PARTICLE_PROJECTION` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/particles/src/engine.rs` |
-| `MISTER_PARTICLE_PROJECTION_VALIDATE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/particles/src/engine.rs` |
-| `MISTER_PARTICLE_SIMD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/particles/src/engine.rs` |
-| `MISTER_PMU_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `crates/perf-events/src/lib.rs` |
-| `MISTER_PMU_RECORD_LIMIT` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | developer diagnostic | `crates/perf-events/src/lib.rs` |
-| `MISTER_PMU_SAMPLE_EVERY` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `crates/perf-events/src/lib.rs` |
-| `MISTER_PPROF` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PPROF_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PPROF_DURATION_SECS` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PPROF_FOLDED_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PPROF_HZ` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PPROF_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PPROF_TRIGGER` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PPROF_WARMUP_SECS` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
-| `MISTER_PRESENT_BACKEND` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_ARCHIVES` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_ARCHIVE_AUTO` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_ARCHIVE_BACKGROUND_WARM` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_ARCHIVE_MEM_PRIMARY` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_ARCHIVE_MEM_WARM` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_CACHE_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/device_layout.rs` |
-| `MISTER_PREVIEW_DECODED_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_DIRECT_PRESENT` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
-| `MISTER_PREVIEW_FADE_P02` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/raw565_preview_renderer.rs` |
-| `MISTER_PREVIEW_FORCE_ARCHIVE_MEM` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_LOADING` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/preview_state.rs` |
-| `MISTER_PREVIEW_RESIZE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_RESIZE_FILTER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_RESIZE_MAX` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_PREVIEW_RUN_LABEL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
-| `MISTER_PREVIEW_SCROLL_EXIT_AFTER_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_PREVIEW_SCROLL_SKIP_ARCHIVE_WARM` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_PREVIEW_SCROLL_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_frame_accounting.rs` |
-| `MISTER_PREVIEW_SCROLL_TRACE_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_frame_accounting.rs` |
-| `MISTER_PREVIEW_SCROLL_TRACE_SECS` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_frame_accounting.rs` |
-| `MISTER_PREVIEW_STEP_HOLD_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_PREVIEW_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/preview_state.rs` |
-| `MISTER_PREVIEW_TRANSITION` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
-| `MISTER_PREVIEW_TRANSITION_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
-| `MISTER_PREVIEW_TRANSITION_PICKER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
-| `MISTER_PREVIEW_TRANSITION_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
-| `MISTER_PREVIEW_TURBO_LOOKAHEAD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/preview_state.rs` |
-| `MISTER_PREVIEW_TURBO_RUNWAY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/preview_state.rs` |
-| `MISTER_PREVIEW_VISUAL_PCT` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/preview_state.rs` |
-| `MISTER_PROCESS_NAMES` | external | string, enum, or boolean token | site-defined fallback; unchanged in P0 | external compatibility | `mister/platform/runtime/src/main_command.rs` |
-| `MISTER_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/frame_profile.rs` |
-| `MISTER_PROFILE_FILE` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/frame_profile.rs` |
-| `MISTER_PROFILE_SLOW_US` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/frame_profile.rs` |
-| `MISTER_RASTER_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
-| `MISTER_RASTER_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
-| `MISTER_RASTER_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
-| `MISTER_RASTER_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
-| `MISTER_RASTER_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
-| `MISTER_RASTER_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
-| `MISTER_ROOT` | external | path or path list | site-defined fallback; unchanged in P0 | external compatibility | `apps/mister/src/macos_preview_content.rs` |
-| `MISTER_SATURN_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_SCREENSAVER_SEED` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_screensaver.rs` |
-| `MISTER_SCREENSAVER_START_ACTIVE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_SCREENSAVER_START_IDLE_WHEN_READY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_SCREENSAVER_START_PREVIEW_AFTER_ANALYTICS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_SCREENSAVER_START_PREVIEW_WHEN_READY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_SETTINGS_NAVIGATION_BENCHMARK` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `apps/mister/src/ui_runner.rs` |
-| `MISTER_SETTINGS_NAVIGATION_EVIDENCE_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_SHARDED_CATALOG_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/pmu_profile.rs` |
-| `MISTER_SMS_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_SNES_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/preview_worker.rs` |
-| `MISTER_SPRITE_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
-| `MISTER_SPRITE_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
-| `MISTER_SPRITE_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
-| `MISTER_SPRITE_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
-| `MISTER_SPRITE_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
-| `MISTER_SPRITE_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
-| `MISTER_START_TIMEOUT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/launcher.rs` |
-| `MISTER_STREAM_SCALAR_BENCH_SAMPLES` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `mister/platform/runtime/src/framebuffer/downsample.rs` |
-| `MISTER_SYSTEM_ENTRY_BENCHMARK_SYSTEM` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | benchmark only | `apps/mister/src/ui_runner/launcher_bench.rs` |
-| `MISTER_SYSTEM_ENTRY_PROFILE_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_SYSTEM_ENTRY_RUN_ID` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_SYSTEM_ENTRY_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
-| `MISTER_TEST_EFFECTS_UNSET` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | test only | `apps/mister/src/ui_runner/experiments/effects/effect_loop_support.rs` |
-| `MISTER_TEXT_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
-| `MISTER_TEXT_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
-| `MISTER_TEXT_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
-| `MISTER_TEXT_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
-| `MISTER_TEXT_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
-| `MISTER_TEXT_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
-| `MISTER_THREAD_POLICY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/runtime_thread.rs` |
-| `MISTER_TRACE_FILE` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/frame_profile.rs` |
-| `MISTER_TRANSITION_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
-| `MISTER_TRANSITION_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
-| `MISTER_TRANSITION_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
-| `MISTER_TRANSITION_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
-| `MISTER_TRANSITION_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
-| `MISTER_TRANSITION_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
-| `MISTER_UI_FB_SIZE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_display.rs` |
-| `MISTER_USER_STATE_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `crates/catalog/src/catalog_config.rs` |
-| `MISTER_VIDEO_AUTO_TOGGLE_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/video_loop.rs` |
-| `MISTER_VIDEO_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/video_player.rs` |
-| `MISTER_VIDEO_PATH` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/video_player.rs` |
-| `MISTER_VIDEO_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | developer diagnostic | `apps/mister/src/frame_profile.rs` |
-| `MISTER_VIDEO_SCALE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `apps/mister/src/ui_runner/video_loop.rs` |
-| `MISTER_VSYNC_DEGRADED_MISSES` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |
-| `MISTER_VSYNC_DIRECT_WAIT` | production | path or path list | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |
-| `MISTER_VSYNC_FALLBACK_HZ` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |
-| `MISTER_VSYNC_FRESH_HIT_MAX_AGE_US` | production | bounded integer | site-defined fallback; unchanged in P0 | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |
+| Name | Classification | Shape | Default behavior | Parser | Typed default | Scope | Conflicts | Sensitivity | Aliases | Documentation | Visibility | Owner |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `MISTER_7ZA` | external | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | external compatibility | `crates/catalog/src/media_metadata.rs` |
+| `MISTER_7ZA_TIMEOUT_SECS` | external | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | external compatibility | `crates/catalog/src/media_metadata.rs` |
+| `MISTER_AMIGA_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_ANIMATION_CLOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/visual_platform.rs` |
+| `MISTER_ARCADE_BOOTSTRAP_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/pmu_profile.rs` |
+| `MISTER_ARCADE_ENTRY_RUN_ID` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_ARCADE_ENTRY_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_ARCADE_ROOT` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/effect_loop_support.rs` |
+| `MISTER_ARCADE_SCROLL_SPEED_DIV` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher.rs` |
+| `MISTER_ARCADE_SELECTED_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
+| `MISTER_ARCADE_SELECTION_INVERT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/arcade_list_renderer.rs` |
+| `MISTER_BACKGROUND_AFFINITY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/runtime_thread.rs` |
+| `MISTER_BOOT_ANALYTICS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/boot_analytics.rs` |
+| `MISTER_BOOT_BLACK_SETTLE_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/ui_boot.rs` |
+| `MISTER_BOOT_FRAME_PROFILE_FILE` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `mister/platform/runtime/src/boot_analytics.rs` |
+| `MISTER_BOOT_FRAME_PROFILE_FRAMES` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `mister/platform/runtime/src/boot_analytics.rs` |
+| `MISTER_CAMERA_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
+| `MISTER_CAMERA_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
+| `MISTER_CAMERA_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
+| `MISTER_CAMERA_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
+| `MISTER_CAMERA_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
+| `MISTER_CAMERA_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/camera_effects_loop.rs` |
+| `MISTER_CATALOG_BACKGROUND_DELAY_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_CATALOG_BUILDER_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/pmu_profile.rs` |
+| `MISTER_CATALOG_CONTENTION_QUIET_PREVIEWS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_CATALOG_DIAGNOSTICS_DIR` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/catalog_progress_report.rs` |
+| `MISTER_CATALOG_DURABLE_RESUME` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/library_indexer.rs` |
+| `MISTER_CATALOG_PROTOCOL_STDOUT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/bin/catalog_builder.rs` |
+| `MISTER_CATALOG_READY_SNAPSHOT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/pmu_profile.rs` |
+| `MISTER_CATALOG_REFRESH` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
+| `MISTER_CATALOG_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `crates/catalog/src/catalog_checkpoint.rs` |
+| `MISTER_CLOUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/particles/src/intro.rs` |
+| `MISTER_CRASH_BACKTRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/crash_report.rs` |
+| `MISTER_CRT_PROBE_PATTERN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/crt_trial_loop.rs` |
+| `MISTER_CRT_TRIAL_CONTENT_BOUNDS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/crt_trial_loop.rs` |
+| `MISTER_DIRTY_RECT_BROAD_PCT` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/target.rs` |
+| `MISTER_DISPLAY_OWNER_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/ownership.rs` |
+| `MISTER_EFFECT_BENCH_LABEL` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `apps/mister/src/ui_effect_bench.rs` |
+| `MISTER_FB_DIAGNOSTIC_RECT` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `mister/platform/runtime/src/fpga.rs` |
+| `MISTER_FB_MAP_BANDWIDTH_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_FB_MAP_BANDWIDTH_H` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_FB_MAP_BANDWIDTH_W` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_FB_MAP_REPORT_H` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_FB_MAP_REPORT_W` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_FB_PRESENT_DELAY_US` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/visual_platform.rs` |
+| `MISTER_FB_RIGHT_GUARD_COLS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_present/latch.rs` |
+| `MISTER_FB_ROUTE_REASSERT_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/ownership.rs` |
+| `MISTER_FPGA_LATCH_PATTERN_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_FPGA_LATCH_PATTERN_PERIOD_US` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_FRAMEBUFFER_STREAM_SCALE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/stream.rs` |
+| `MISTER_FRAME_ORDER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/video_loop.rs` |
+| `MISTER_FS_FAULT_ACTION` | fault | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | destructive test only | `crates/catalog/src/fs_fault.rs` |
+| `MISTER_FS_FAULT_DELAY_MS` | fault | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | destructive test only | `crates/catalog/src/fs_fault.rs` |
+| `MISTER_FS_FAULT_POINT` | fault | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | destructive test only | `crates/catalog/src/fs_fault.rs` |
+| `MISTER_FS_FAULT_SESSION` | fault | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | destructive test only | `crates/catalog/src/fs_fault.rs` |
+| `MISTER_GLYPH_ALPHA_THRESHOLD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/mapped.rs` |
+| `MISTER_GROUPS` | external | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | external compatibility | `crates/particles/src/intro.rs` |
+| `MISTER_GUI_FRAME_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_gui_profile.rs` |
+| `MISTER_GUI_FRAME_PROFILE_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_gui_profile.rs` |
+| `MISTER_GUI_FRAME_PROFILE_PMU` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_gui_profile.rs` |
+| `MISTER_HBMAME_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/catalog_config.rs` |
+| `MISTER_HOME_SELECTED_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_HUMAN_TURBO_IDLE_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_HUMAN_TURBO_NORMAL_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_HUMAN_TURBO_PAUSE_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_INI_PATH` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_display.rs` |
+| `MISTER_INPUT_INTEGRITY_STALL_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_INPUT_INTEGRITY_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_INPUT_LATENCY_LAB_ARM` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_input_latency_lab.rs` |
+| `MISTER_INPUT_LATENCY_LAB_READER_POLICY` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/input_hub.rs` |
+| `MISTER_INPUT_LATENCY_LAB_READER_SCHEDSTAT` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/input_hub.rs` |
+| `MISTER_INPUT_LATENCY_LAB_SESSION` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/input_hub.rs` |
+| `MISTER_LATCH_V5_QUALIFICATION` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/latch_v5_qualification.rs` |
+| `MISTER_LAUNCHER_AUTO_LAUNCH_SELECTED` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_BENCH_AFTER_INPUT_SCRIPT` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_LAUNCHER_BENCH_SCENARIO` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_LAUNCHER_DIRTY_OPT` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
+| `MISTER_LAUNCHER_INPUT_SCRIPT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_INPUT_SCRIPT_WAIT_FRAMES` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_LOCK_SCREEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_LAUNCHER_RESPONSE_COMPLETE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_EXECUTION_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_EXPECTED_CONFIRMED` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_EXPECTED_FEEDBACK_HIDDEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_FRAME_COMPLETE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_PMU` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_PMU_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_RUN_ID` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_RESPONSE_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_LAUNCHER_START_MENU` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_LAUNCHER_START_SCREEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_LAUNCHER_START_SYSTEM` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_LAUNCH_HANDOFF_DELAY_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
+| `MISTER_LAUNCH_HANDOFF_ITERATIONS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
+| `MISTER_LAUNCH_HANDOFF_LABEL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
+| `MISTER_LAUNCH_HANDOFF_MODE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
+| `MISTER_LAUNCH_HANDOFF_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
+| `MISTER_LAUNCH_PREP_AMIGAVISION_LIMIT` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launch_preparation.rs` |
+| `MISTER_LAUNCH_PREP_ITERATIONS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launch_preparation.rs` |
+| `MISTER_LAUNCH_PREP_LABEL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launch_preparation.rs` |
+| `MISTER_LAUNCH_PREP_REFS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launch_preparation.rs` |
+| `MISTER_LAUNCH_PREP_VIRTUAL_LIMIT` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launch_preparation.rs` |
+| `MISTER_LAUNCH_PREP_VIRTUAL_SYSTEMS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launch_preparation.rs` |
+| `MISTER_LAUNCH_RETURN_PMU_HANDOFF_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launch_handoff_session.rs` |
+| `MISTER_LIBRARY_BENCH_FORCE_REBUILD` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `crates/catalog/src/library_cli.rs` |
+| `MISTER_LIBRARY_BENCH_ITERATIONS` | benchmark | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `crates/catalog/src/library_cli.rs` |
+| `MISTER_LIBRARY_BENCH_LABEL` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `crates/catalog/src/library_cli.rs` |
+| `MISTER_LIBRARY_BENCH_PRECOUNT` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `crates/catalog/src/library_cli.rs` |
+| `MISTER_LIBRARY_BENCH_SQLITE` | benchmark | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `crates/catalog/src/device_layout.rs` |
+| `MISTER_LIBRARY_NAMESPACE_BACKEND` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/namespace_walk.rs` |
+| `MISTER_LIBRARY_PATH_MAP` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/catalog_config.rs` |
+| `MISTER_LIBRARY_REFRESH_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_LIBRARY_ROOTS` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/pmu_profile.rs` |
+| `MISTER_LIBRARY_SOFTWARE_HASH` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/software_identity.rs` |
+| `MISTER_LIBRARY_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/pmu_profile.rs` |
+| `MISTER_LIBRARY_SQLITE_BUILD_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/pmu_profile.rs` |
+| `MISTER_LOW_MEMORY_AVAILABLE_KIB` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/memory_pressure.rs` |
+| `MISTER_MAGIK_BUILD_NUMBER` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | build pipeline | `apps/mister/src/build_identity.rs` |
+| `MISTER_MAGIK_BUILD_TIME` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | build pipeline | `apps/mister/src/build_identity.rs` |
+| `MISTER_MAGIK_CRT_TRIAL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/fpga.rs` |
+| `MISTER_MAGIK_DEV_LATCH_POST_SKIP_WORD_INDEX` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_present/latch.rs` |
+| `MISTER_MAGIK_DEV_LATCH_STATUS_TIMEOUT_AT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_present/latch.rs` |
+| `MISTER_MAGIK_DISPLAY_CONFIRM_UI` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_MAGIK_DOWNLOADER_INI` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/update_checker.rs` |
+| `MISTER_MAGIK_HOT_JOURNAL_DB` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/sqlite_catalog.rs` |
+| `MISTER_MAGIK_INPUT_PROXY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/input_hub.rs` |
+| `MISTER_MAGIK_INPUT_PROXY_PROTOCOL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/input_hub.rs` |
+| `MISTER_MAGIK_MAIN_GENERATION` | production | bounded integer | missing or invalid disables supervised readiness acknowledgement | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/process_config.rs` |
+| `MISTER_MAGIK_MAIN_PID` | production | bounded integer | missing or invalid disables supervised readiness acknowledgement | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/process_config.rs` |
+| `MISTER_MAGIK_OWNER_EPOCH` | production | bounded integer | missing or invalid disables supervised readiness acknowledgement | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/process_config.rs` |
+| `MISTER_MAGIK_PARENT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_MAGIK_PROCESS_LOCK` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/main.rs` |
+| `MISTER_MAGIK_READY_FIFO` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/process_config.rs` |
+| `MISTER_MAGIK_RELEASE_MARKER` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/update_checker.rs` |
+| `MISTER_MAGIK_RETURN_TO_LAUNCHER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_MAGIK_RUNTIME_DISPLAY_V1` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_display.rs` |
+| `MISTER_MAGIK_RUNTIME_SETTINGS_V1` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_display.rs` |
+| `MISTER_MAGIK_SOURCE_DIRTY` | build-time | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | build pipeline | `apps/mister/src/build_identity.rs` |
+| `MISTER_MAGIK_SOURCE_REVISION` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | build pipeline | `apps/mister/src/build_identity.rs` |
+| `MISTER_MAGIK_STARTUP_TOKEN` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/process_config.rs` |
+| `MISTER_MAGIK_TEST_AUTO_LAUNCH_GATE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | test only | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_MAGIK_TEST_CATALOG_PUBLICATION_GATE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | test only | `apps/mister/src/ui_runner/launcher_catalog_publication_test.rs` |
+| `MISTER_MAGIK_TEST_CATALOG_PUBLICATION_SESSION` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | test only | `apps/mister/src/ui_runner/launcher_catalog_publication_test.rs` |
+| `MISTER_MAGIK_TEST_CATALOG_RECOVERY_DIALOG` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | test only | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_MAGIK_TEST_FIRST_FRAME_RELEASE_GATE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | test only | `apps/mister/src/ui_runner/launcher_catalog_publication_test.rs` |
+| `MISTER_MAGIK_TEST_LIBRARY_CHANGED_DIALOG_CHOICE` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | test only | `apps/mister/src/launcher.rs` |
+| `MISTER_MAGIK_VERSION` | build-time | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | build pipeline | `apps/mister/src/build_identity.rs` |
+| `MISTER_MAME_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/catalog_config.rs` |
+| `MISTER_MEDIA_ASSET_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher.rs` |
+| `MISTER_MEDIA_BENCH_CONTENTION` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `apps/mister/src/launcher_runtime/media.rs` |
+| `MISTER_MEDIA_CONCURRENCY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
+| `MISTER_MEDIA_MANIFEST_URL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
+| `MISTER_MEDIA_SIZE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
+| `MISTER_MEDIA_UPDATE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher_runtime/media.rs` |
+| `MISTER_MEGADRIVE_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_MODE_FORMAT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/format.rs` |
+| `MISTER_N64_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_NAMESPACE_BACKEND` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/library_indexer.rs` |
+| `MISTER_NEOGEO_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_NES_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_ORIENTATION_PMU_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_ORIENTATION_SIMD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher_runtime/orientation_transition.rs` |
+| `MISTER_ORIENTATION_TRANSITIONS_BENCHMARK` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `apps/mister/src/ui_runner.rs` |
+| `MISTER_ORIENTATION_TRANSITIONS_EVIDENCE_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_ORIENTATION_TRANSITIONS_REQUIRE_ANALYTICS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_ORIENTATION_TRANSITION_EFFECT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_PARTICLE_COHORTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/particles/src/engine.rs` |
+| `MISTER_PARTICLE_COMMAND_ORDER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/particle_renderer.rs` |
+| `MISTER_PARTICLE_PMU` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/particle_renderer.rs` |
+| `MISTER_PARTICLE_PROJECTION` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/particles/src/engine.rs` |
+| `MISTER_PARTICLE_PROJECTION_VALIDATE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/particles/src/engine.rs` |
+| `MISTER_PARTICLE_SIMD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/particles/src/engine.rs` |
+| `MISTER_PMU_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `crates/perf-events/src/lib.rs` |
+| `MISTER_PMU_RECORD_LIMIT` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `crates/perf-events/src/lib.rs` |
+| `MISTER_PMU_SAMPLE_EVERY` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `crates/perf-events/src/lib.rs` |
+| `MISTER_PPROF` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PPROF_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PPROF_DURATION_SECS` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PPROF_FOLDED_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PPROF_HZ` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PPROF_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PPROF_TRIGGER` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PPROF_WARMUP_SECS` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/cpu_profile.rs` |
+| `MISTER_PRESENT_BACKEND` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_ARCHIVES` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_ARCHIVE_AUTO` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_ARCHIVE_BACKGROUND_WARM` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_ARCHIVE_MEM_PRIMARY` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_ARCHIVE_MEM_WARM` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_CACHE_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/device_layout.rs` |
+| `MISTER_PREVIEW_DECODED_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_DIRECT_PRESENT` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
+| `MISTER_PREVIEW_FADE_P02` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/raw565_preview_renderer.rs` |
+| `MISTER_PREVIEW_FORCE_ARCHIVE_MEM` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_LOADING` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/preview_state.rs` |
+| `MISTER_PREVIEW_RESIZE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_RESIZE_FILTER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_RESIZE_MAX` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_PREVIEW_RUN_LABEL` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/ui_frame_target.rs` |
+| `MISTER_PREVIEW_SCROLL_EXIT_AFTER_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_PREVIEW_SCROLL_SKIP_ARCHIVE_WARM` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_PREVIEW_SCROLL_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_frame_accounting.rs` |
+| `MISTER_PREVIEW_SCROLL_TRACE_COMPLETE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_frame_accounting.rs` |
+| `MISTER_PREVIEW_SCROLL_TRACE_SECS` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_frame_accounting.rs` |
+| `MISTER_PREVIEW_STEP_HOLD_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_PREVIEW_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/preview_state.rs` |
+| `MISTER_PREVIEW_TRANSITION` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
+| `MISTER_PREVIEW_TRANSITION_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
+| `MISTER_PREVIEW_TRANSITION_PICKER` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
+| `MISTER_PREVIEW_TRANSITION_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/screenshot_transitions.rs` |
+| `MISTER_PREVIEW_TURBO_LOOKAHEAD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/preview_state.rs` |
+| `MISTER_PREVIEW_TURBO_RUNWAY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/preview_state.rs` |
+| `MISTER_PREVIEW_VISUAL_PCT` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/preview_state.rs` |
+| `MISTER_PROCESS_NAMES` | external | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | external compatibility | `mister/platform/runtime/src/main_command.rs` |
+| `MISTER_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/frame_profile.rs` |
+| `MISTER_PROFILE_FILE` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/frame_profile.rs` |
+| `MISTER_PROFILE_SLOW_US` | diagnostic | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/frame_profile.rs` |
+| `MISTER_RASTER_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
+| `MISTER_RASTER_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
+| `MISTER_RASTER_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
+| `MISTER_RASTER_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
+| `MISTER_RASTER_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
+| `MISTER_RASTER_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/raster_effects_loop.rs` |
+| `MISTER_ROOT` | external | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | external compatibility | `apps/mister/src/macos_preview_content.rs` |
+| `MISTER_SATURN_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_SCREENSAVER_SEED` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_screensaver.rs` |
+| `MISTER_SCREENSAVER_START_ACTIVE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_SCREENSAVER_START_IDLE_WHEN_READY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_SCREENSAVER_START_PREVIEW_AFTER_ANALYTICS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_SCREENSAVER_START_PREVIEW_WHEN_READY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_SETTINGS_NAVIGATION_BENCHMARK` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `apps/mister/src/ui_runner.rs` |
+| `MISTER_SETTINGS_NAVIGATION_EVIDENCE_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_SHARDED_CATALOG_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/pmu_profile.rs` |
+| `MISTER_SMS_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_SNES_PREVIEW_ARCHIVE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/preview_worker.rs` |
+| `MISTER_SPRITE_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
+| `MISTER_SPRITE_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
+| `MISTER_SPRITE_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
+| `MISTER_SPRITE_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
+| `MISTER_SPRITE_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
+| `MISTER_SPRITE_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/sprite_effects_loop.rs` |
+| `MISTER_START_TIMEOUT` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/launcher.rs` |
+| `MISTER_STREAM_SCALAR_BENCH_SAMPLES` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `mister/platform/runtime/src/framebuffer/downsample.rs` |
+| `MISTER_SYSTEM_ENTRY_BENCHMARK_SYSTEM` | benchmark | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | benchmark only | `apps/mister/src/ui_runner/launcher_bench.rs` |
+| `MISTER_SYSTEM_ENTRY_PROFILE_OUT` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_SYSTEM_ENTRY_RUN_ID` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_SYSTEM_ENTRY_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/launcher_loop.rs` |
+| `MISTER_TEST_EFFECTS_UNSET` | test | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | test only | `apps/mister/src/ui_runner/experiments/effects/effect_loop_support.rs` |
+| `MISTER_TEXT_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
+| `MISTER_TEXT_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
+| `MISTER_TEXT_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
+| `MISTER_TEXT_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
+| `MISTER_TEXT_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
+| `MISTER_TEXT_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/text_effects_loop.rs` |
+| `MISTER_THREAD_POLICY` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/runtime_thread.rs` |
+| `MISTER_TRACE_FILE` | diagnostic | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/frame_profile.rs` |
+| `MISTER_TRANSITION_EFFECTS` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
+| `MISTER_TRANSITION_EFFECTS_AUTO` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
+| `MISTER_TRANSITION_EFFECTS_CACHE_CAP` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
+| `MISTER_TRANSITION_EFFECTS_HUD` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
+| `MISTER_TRANSITION_EFFECTS_SEGMENT_SECS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
+| `MISTER_TRANSITION_EFFECTS_TRACE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/ui_runner/experiments/effects/transition_effects_loop.rs` |
+| `MISTER_UI_FB_SIZE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_display.rs` |
+| `MISTER_USER_STATE_SQLITE` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `crates/catalog/src/catalog_config.rs` |
+| `MISTER_VIDEO_AUTO_TOGGLE_MS` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/video_loop.rs` |
+| `MISTER_VIDEO_DIR` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/video_player.rs` |
+| `MISTER_VIDEO_PATH` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/video_player.rs` |
+| `MISTER_VIDEO_PROFILE` | diagnostic | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | developer diagnostic | `apps/mister/src/frame_profile.rs` |
+| `MISTER_VIDEO_SCALE` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `apps/mister/src/ui_runner/video_loop.rs` |
+| `MISTER_VSYNC_DEGRADED_MISSES` | production | string, enum, or boolean token | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |
+| `MISTER_VSYNC_DIRECT_WAIT` | production | path or path list | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |
+| `MISTER_VSYNC_FALLBACK_HZ` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |
+| `MISTER_VSYNC_FRESH_HIT_MAX_AGE_US` | production | bounded integer | site-defined fallback; unchanged in P0 | — | — | — | — | — | — | — | internal runtime | `mister/platform/runtime/src/framebuffer/vsync.rs` |

--- a/scripts/checks/generate-runtime-environment-reference.py
+++ b/scripts/checks/generate-runtime-environment-reference.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
+import json
 from pathlib import Path
 import sys
 import tomllib
@@ -11,6 +12,31 @@ import tomllib
 ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_REGISTRY = ROOT / "apps/mister/config/runtime-environment.toml"
 DEFAULT_OUTPUT = ROOT / "docs/reference/mister-runtime-environment.md"
+
+
+def typed_default(value: object) -> str:
+    if value is None:
+        return "—"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (str, list)):
+        return json.dumps(value, ensure_ascii=False)
+    return str(value)
+
+
+def metadata_list(values: list[str] | None) -> str:
+    return ", ".join(values) if values else "—"
+
+
+def documentation_text(documentation: dict | None) -> str:
+    if not documentation:
+        return "—"
+    accepted = documentation.get("accepted_values", [])
+    values = f"; values: {', '.join(accepted)}" if accepted else ""
+    return (
+        f"{documentation['summary']}{values}; "
+        f"value policy: {documentation['value_policy']}"
+    )
 
 
 def render(registry: dict) -> str:
@@ -27,14 +53,23 @@ def render(registry: dict) -> str:
             f"{baseline['external_build_names']} external/build-time names."
         ),
         "",
-        "| Name | Classification | Shape | Default behavior | Visibility | Owner |",
-        "|---|---|---|---|---|---|",
+        "| Name | Classification | Shape | Default behavior | Parser | Typed default | Scope | Conflicts | Sensitivity | Aliases | Documentation | Visibility | Owner |",
+        "|---|---|---|---|---|---|---|---|---|---|---|---|---|",
     ]
     for control in sorted(registry["control"], key=lambda value: value["name"]):
         default = control["default_behavior"].replace("|", "\\|")
+        typed = typed_default(control.get("typed_default")).replace("|", "\\|")
+        documentation = documentation_text(control.get("documentation")).replace(
+            "|", "\\|"
+        )
         lines.append(
             f"| `{control['name']}` | {control['classification']} | "
-            f"{control['value_shape']} | {default} | {control['visibility']} | "
+            f"{control['value_shape']} | {default} | {control.get('parser', '—')} | "
+            f"{typed} | {control.get('scope', '—')} | "
+            f"{metadata_list(control.get('conflicts'))} | "
+            f"{control.get('sensitivity', '—')} | "
+            f"{metadata_list(control.get('aliases'))} | {documentation} | "
+            f"{control['visibility']} | "
             f"`{control['owner']}` |"
         )
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- introduce runtime-environment registry format v2 while retaining compatible v1 parsing
- add optional parser, typed default, scope, conflicts, sensitivity, aliases, and documentation metadata
- validate a closed parser/scope/sensitivity vocabulary and typed-default compatibility
- update both deterministic reference renderers and regenerate the reference
- add fixtures covering every supported parser type and scope

## Verification
- Rust Analyzer: zero diagnostics
- generated reference check: passed
- pre-commit: 6/6 passed
- pre-push: 12/12 passed

C1 intentionally makes metadata optional; C2/C3 populate production and diagnostic controls before later commits rely on it.

Plan 03: Stage C, commit C1.