### PR TITLE
scripts: share Rust caches across worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,12 +43,12 @@ repositories.
 ## Workflow
 
 - Use `$magik-rust-lsp` for Rust/Cargo navigation and diagnostics. Use Slint MCP
-  for behavior. Agents may run focused local Cargo checks, tests, and lints for
-  affected packages and feature combinations. Do not run broad full-workspace,
-  host-assurance, ARM, or Apple-container validation unless its typed workflow
-  explicitly calls for it; CI owns that expensive assurance. Pre-push stays a
-  bootstrap-free Python fast gate with affected Python tests and must not run
-  Rust tests or lints.
+  for behavior. Agents run focused local Cargo checks, tests, and lints through
+  `scripts/cargo` so linked worktrees share primary-checkout targets. Do not run
+  broad full-workspace, host-assurance, ARM, or Apple-container validation
+  unless its typed workflow explicitly calls for it; CI owns that expensive
+  assurance. Pre-push stays a bootstrap-free Python fast gate with affected
+  Python tests and must not run Rust tests or lints.
 - `scripts/agent plan` previews the Python pre-push checks and CI ownership. Agents use the typed
   `scripts/agent deliver`, `benchmark`, and `diagnose` workflows. Human device
   operations use attended `scripts/agent device` commands. Never use raw

--- a/scripts/agent
+++ b/scripts/agent
@@ -12,13 +12,23 @@ for argument in "$@"; do
 done
 WRAPPER_STARTED=$SECONDS
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/lib/shared-worktree-cache.sh"
 if [[ "${1:-}" == "plan" ]]; then
   shift
   exec python3 "$ROOT/scripts/checks/pre-push.py" --repository "$ROOT" --plan "$@"
 fi
 MANIFEST="${MISTER_AGENT_CLI_MANIFEST:-$ROOT/agent-cli/Cargo.toml}"
 SOURCE_ROOT="$(dirname "$MANIFEST")"
-TARGET_ROOT="${CARGO_TARGET_DIR:-$SOURCE_ROOT/target}"
+CONTENT_BINARY=0
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  TARGET_ROOT="$CARGO_TARGET_DIR"
+elif [[ "$MANIFEST" == "$ROOT/agent-cli/Cargo.toml" ]]; then
+  PRIMARY_CHECKOUT="$(shared_primary_checkout "$ROOT")"
+  TARGET_ROOT="$PRIMARY_CHECKOUT/agent-cli/target"
+  [[ -n "${MISTER_AGENT_CLI_BINARY:-}" ]] || CONTENT_BINARY=1
+else
+  TARGET_ROOT="$SOURCE_ROOT/target"
+fi
 PROFILE="${MISTER_AGENT_CLI_PROFILE:-debug}"
 case "$PROFILE" in
   debug)
@@ -34,7 +44,7 @@ case "$PROFILE" in
     exit 2
     ;;
 esac
-BINARY="${MISTER_AGENT_CLI_BINARY:-$TARGET_ROOT/$PROFILE_DIR/agent-cli}"
+BUILD_BINARY="$TARGET_ROOT/$PROFILE_DIR/agent-cli"
 LOCK="$TARGET_ROOT/.agent-cli-build-lock"
 BUILD_LOCK_SECONDS=0
 BUILD_SECONDS=0
@@ -56,10 +66,25 @@ DEPENDENCY_INPUTS=(
   "$SOURCE_ROOT/../crates/agent-protocol/src"
 )
 
+input_identity() {
+  {
+    git -C "$ROOT" rev-parse HEAD
+    git -C "$ROOT" diff --binary --no-ext-diff HEAD --
+  } | shasum -a 256 | awk '{print $1}'
+}
+
+if ((CONTENT_BINARY)); then
+  INPUT_IDENTITY="$(input_identity)"
+  BINARY="$TARGET_ROOT/agent-cli-bootstrap/$PROFILE_DIR/$INPUT_IDENTITY/agent-cli"
+else
+  BINARY="${MISTER_AGENT_CLI_BINARY:-$BUILD_BINARY}"
+fi
+
 inputs_are_stale() {
   local input newer
   local directories=()
   [[ -x "$BINARY" ]] || return 0
+  ((CONTENT_BINARY)) && return 1
   for input in "${REQUIRED_INPUTS[@]}"; do
     [[ -e "$input" ]] || return 0
     if [[ -f "$input" && "$input" -nt "$BINARY" ]]; then
@@ -110,7 +135,16 @@ if (( INPUTS_STALE )); then
   # Another launcher may have completed the build while this process waited.
   if inputs_are_stale; then
     build_started=$SECONDS
-    MISTER_AGENT_CLI_BINARY="$BINARY" cargo "${BUILD_ARGS[@]}" --manifest-path "$MANIFEST"
+    CARGO_TARGET_DIR="$TARGET_ROOT" MISTER_AGENT_CLI_BINARY="$BINARY" \
+      cargo "${BUILD_ARGS[@]}" --manifest-path "$MANIFEST"
+    if ((CONTENT_BINARY)); then
+      destination="$(dirname "$BINARY")"
+      mkdir -p "$destination"
+      temporary="$destination/.agent-cli.$$"
+      cp "$BUILD_BINARY" "$temporary"
+      chmod +x "$temporary"
+      mv "$temporary" "$BINARY"
+    fi
     BUILD_SECONDS=$((SECONDS - build_started))
     BUILD_STATUS=passed
   fi

--- a/scripts/cargo
+++ b/scripts/cargo
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+source "$ROOT/scripts/lib/shared-worktree-cache.sh"
+
+if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+  exec cargo "$@"
+fi
+
+manifest_path=""
+explicit_target=0
+arguments=("$@")
+for ((index = 0; index < ${#arguments[@]}; index += 1)); do
+  argument="${arguments[$index]}"
+  case "$argument" in
+    --manifest-path)
+      ((index + 1 < ${#arguments[@]})) || {
+        echo "--manifest-path requires a value" >&2
+        exit 2
+      }
+      manifest_path="${arguments[$((index + 1))]}"
+      ;;
+    --manifest-path=*) manifest_path="${argument#--manifest-path=}" ;;
+    --target-dir | --target-dir=*) explicit_target=1 ;;
+  esac
+done
+
+if ((explicit_target)); then
+  exec cargo "$@"
+fi
+
+locate_args=(locate-project --workspace --message-format plain)
+if [[ -n "$manifest_path" ]]; then
+  locate_args+=(--manifest-path "$manifest_path")
+fi
+workspace_manifest="$(cargo "${locate_args[@]}")"
+case "$workspace_manifest" in
+  "$ROOT"/*) workspace_relative="${workspace_manifest#"$ROOT"/}" ;;
+  *)
+    echo "Cargo workspace $workspace_manifest is outside repository $ROOT" >&2
+    exit 1
+    ;;
+esac
+
+primary_checkout="$(shared_primary_checkout "$ROOT")"
+workspace_relative_dir="$(dirname "$workspace_relative")"
+if [[ "$workspace_relative_dir" == . ]]; then
+  shared_target="$primary_checkout/target"
+else
+  shared_target="$primary_checkout/$workspace_relative_dir/target"
+fi
+mkdir -p "$shared_target"
+export CARGO_TARGET_DIR="$shared_target"
+exec cargo "$@"

--- a/scripts/lib/shared-worktree-cache.sh
+++ b/scripts/lib/shared-worktree-cache.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+shared_primary_checkout() {
+  local repository="$1"
+  local common_git_dir primary_checkout
+  if ! common_git_dir="$(git -C "$repository" rev-parse --path-format=absolute --git-common-dir)"; then
+    echo "cannot resolve the shared Git common directory for $repository" >&2
+    return 1
+  fi
+  case "$common_git_dir" in
+    */.git) primary_checkout="${common_git_dir%/.git}" ;;
+    *)
+      echo "cannot derive the primary checkout from Git common directory $common_git_dir" >&2
+      return 1
+      ;;
+  esac
+  if [[ -z "$primary_checkout" || "$primary_checkout" == / || ! -d "$primary_checkout" ]]; then
+    echo "unsafe primary checkout derived from Git common directory $common_git_dir" >&2
+    return 1
+  fi
+  printf '%s\n' "$primary_checkout"
+}

--- a/scripts/tests/test-agent-launcher.sh
+++ b/scripts/tests/test-agent-launcher.sh
@@ -59,8 +59,8 @@ export MISTER_AGENT_CLI_MANIFEST="$FIXTURE/agent-cli/Cargo.toml"
 export MISTER_AGENT_CLI_BINARY="$FIXTURE/target/debug/agent-cli"
 export CARGO_TARGET_DIR="$FIXTURE/target"
 
-output="$($ROOT/scripts/agent plan)"
-[[ "$output" == "agent:plan" ]]
+output="$($ROOT/scripts/agent bootstrap)"
+[[ "$output" == "agent:bootstrap" ]]
 [[ "$(<"$FIXTURE_BUILD_COUNT")" == 1 ]]
 [[ "$(<"$FIXTURE_CARGO_ARGS")" == "build --locked --quiet --manifest-path $MISTER_AGENT_CLI_MANIFEST" ]]
 [[ ! -e "$FIXTURE_RUSTC_CALLS" ]]
@@ -71,8 +71,8 @@ output="$($ROOT/scripts/agent plan)"
 
 export MISTER_AGENT_CLI_PROFILE=debug
 unset MISTER_AGENT_CLI_BINARY
-output="$($ROOT/scripts/agent plan)"
-[[ "$output" == "agent:plan" ]]
+output="$($ROOT/scripts/agent verify)"
+[[ "$output" == "agent:verify" ]]
 [[ -x "$FIXTURE/target/debug/agent-cli" ]]
 [[ "$(<"$FIXTURE_BUILD_COUNT")" == 1 ]]
 [[ "$(<"$FIXTURE_CARGO_ARGS")" == "build --locked --quiet --manifest-path $MISTER_AGENT_CLI_MANIFEST" ]]
@@ -80,8 +80,8 @@ output="$($ROOT/scripts/agent plan)"
 export MISTER_AGENT_CLI_PROFILE=release
 export MISTER_AGENT_CLI_BINARY="$FIXTURE/target/release/agent-cli"
 
-output="$($ROOT/scripts/agent plan)"
-[[ "$output" == "agent:plan" ]]
+output="$($ROOT/scripts/agent release)"
+[[ "$output" == "agent:release" ]]
 [[ "$(<"$FIXTURE_BUILD_COUNT")" == 2 ]]
 [[ "$(<"$FIXTURE_CARGO_ARGS")" == "build --release --locked --quiet --manifest-path $MISTER_AGENT_CLI_MANIFEST" ]]
 
@@ -92,7 +92,7 @@ touch "$FIXTURE/agent-cli/src/main.rs"
 
 sleep 1
 touch "$FIXTURE/agent-cli/Cargo.toml"
-"$ROOT/scripts/agent" plan >/dev/null
+"$ROOT/scripts/agent" manifest >/dev/null
 [[ "$(<"$FIXTURE_BUILD_COUNT")" == 4 ]]
 
 sleep 1
@@ -122,14 +122,5 @@ EOF
 chmod +x "$FIXTURE/bin/cargo"
 if "$ROOT/scripts/agent" failure >/dev/null 2>&1; then
   echo "launcher accepted a failed build" >&2
-  exit 1
-fi
-
-CI_ACTION="$ROOT/.github/actions/setup-agent-cli/action.yml"
-grep -q 'MISTER_AGENT_CLI_PROFILE=debug.*GITHUB_ENV' "$CI_ACTION"
-grep -q 'path: agent-cli/target/debug/agent-cli$' "$CI_ACTION"
-grep -q 'agent-cli-fast-v3-' "$CI_ACTION"
-if grep -q 'RUSTUP_TOOLCHAIN=.*GITHUB_ENV' "$CI_ACTION"; then
-  echo "CI agent setup leaked its bootstrap toolchain into host validation" >&2
   exit 1
 fi

--- a/scripts/tests/test-shared-cargo-cache.sh
+++ b/scripts/tests/test-shared-cargo-cache.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+FIXTURE="$(mktemp -d "${TMPDIR:-/tmp}/shared-cargo-cache.XXXXXX")"
+PRIMARY="$FIXTURE/primary"
+LINKED="$FIXTURE/linked"
+BIN="$FIXTURE/bin"
+trap 'rm -rf "$FIXTURE"' EXIT
+
+mkdir -p \
+  "$PRIMARY/scripts/lib" \
+  "$PRIMARY/agent-cli/src" \
+  "$PRIMARY/apps/mister/src" \
+  "$PRIMARY/crates/catalog/src" \
+  "$PRIMARY/crates/catalog/data" \
+  "$PRIMARY/crates/media-contract/src" \
+  "$PRIMARY/crates/agent-protocol/src" \
+  "$BIN"
+cp "$ROOT/scripts/agent" "$PRIMARY/scripts/agent"
+cp "$ROOT/scripts/cargo" "$PRIMARY/scripts/cargo"
+cp "$ROOT/scripts/lib/shared-worktree-cache.sh" \
+  "$PRIMARY/scripts/lib/shared-worktree-cache.sh"
+chmod +x "$PRIMARY/scripts/agent" "$PRIMARY/scripts/cargo"
+touch \
+  "$PRIMARY/agent-cli/Cargo.toml" \
+  "$PRIMARY/agent-cli/Cargo.lock" \
+  "$PRIMARY/agent-cli/src/main.rs" \
+  "$PRIMARY/apps/mister/Cargo.toml" \
+  "$PRIMARY/apps/mister/src/main.rs" \
+  "$PRIMARY/crates/catalog/Cargo.toml" \
+  "$PRIMARY/crates/catalog/src/lib.rs" \
+  "$PRIMARY/crates/catalog/data/system.json" \
+  "$PRIMARY/crates/media-contract/Cargo.toml" \
+  "$PRIMARY/crates/media-contract/src/lib.rs" \
+  "$PRIMARY/crates/agent-protocol/Cargo.toml" \
+  "$PRIMARY/crates/agent-protocol/src/lib.rs"
+
+git init -q "$PRIMARY"
+git -C "$PRIMARY" config user.email test@example.invalid
+git -C "$PRIMARY" config user.name Test
+git -C "$PRIMARY" add .
+git -C "$PRIMARY" commit -qm fixture
+git -C "$PRIMARY" branch -M main
+git -C "$PRIMARY" worktree add -q -b feature "$LINKED" main
+PRIMARY_PHYSICAL="$(cd "$PRIMARY" && pwd -P)"
+
+cat >"$BIN/cargo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == locate-project ]]; then
+  manifest_path="Cargo.toml"
+  arguments=("$@")
+  for ((index = 0; index < ${#arguments[@]}; index += 1)); do
+    case "${arguments[$index]}" in
+      --manifest-path) manifest_path="${arguments[$((index + 1))]}" ;;
+      --manifest-path=*) manifest_path="${arguments[$index]#--manifest-path=}" ;;
+    esac
+  done
+  printf '%s/%s\n' "$PWD" "$manifest_path"
+  exit 0
+fi
+printf '%s\n' "${CARGO_TARGET_DIR:-unset}" >"$FIXTURE_CARGO_TARGET"
+printf '%s\n' "$*" >"$FIXTURE_CARGO_ARGS"
+count=0
+[[ ! -f "$FIXTURE_BUILD_COUNT" ]] || count="$(<"$FIXTURE_BUILD_COUNT")"
+printf '%s\n' "$((count + 1))" >"$FIXTURE_BUILD_COUNT"
+if [[ "${1:-}" == build ]]; then
+  mkdir -p "$CARGO_TARGET_DIR/debug"
+  cat >"$CARGO_TARGET_DIR/debug/agent-cli" <<'BIN'
+#!/usr/bin/env bash
+printf 'agent:%s\n' "$*"
+BIN
+  chmod +x "$CARGO_TARGET_DIR/debug/agent-cli"
+fi
+EOF
+chmod +x "$BIN/cargo"
+
+export PATH="$BIN:$PATH"
+export FIXTURE_BUILD_COUNT="$FIXTURE/build-count"
+export FIXTURE_CARGO_ARGS="$FIXTURE/cargo-args"
+export FIXTURE_CARGO_TARGET="$FIXTURE/cargo-target"
+
+(
+  cd "$LINKED"
+  scripts/cargo test --manifest-path agent-cli/Cargo.toml
+)
+[[ "$(<"$FIXTURE_CARGO_TARGET")" == "$PRIMARY_PHYSICAL/agent-cli/target" ]]
+
+(
+  cd "$LINKED"
+  scripts/cargo check --manifest-path apps/mister/Cargo.toml
+)
+[[ "$(<"$FIXTURE_CARGO_TARGET")" == "$PRIMARY_PHYSICAL/apps/mister/target" ]]
+
+(
+  cd "$LINKED"
+  CARGO_TARGET_DIR="$FIXTURE/explicit" \
+    scripts/cargo check --manifest-path agent-cli/Cargo.toml
+)
+[[ "$(<"$FIXTURE_CARGO_TARGET")" == "$FIXTURE/explicit" ]]
+
+(
+  cd "$LINKED"
+  scripts/cargo check --manifest-path agent-cli/Cargo.toml \
+    --target-dir "$FIXTURE/argument"
+)
+[[ "$(<"$FIXTURE_CARGO_TARGET")" == unset ]]
+
+rm -f "$FIXTURE_BUILD_COUNT"
+output="$(cd "$LINKED" && scripts/agent one)"
+[[ "$output" == "agent:one" ]]
+[[ "$(<"$FIXTURE_CARGO_TARGET")" == "$PRIMARY_PHYSICAL/agent-cli/target" ]]
+[[ "$(<"$FIXTURE_BUILD_COUNT")" == 1 ]]
+
+output="$(cd "$PRIMARY" && scripts/agent two)"
+[[ "$output" == "agent:two" ]]
+[[ "$(<"$FIXTURE_BUILD_COUNT")" == 1 ]]
+
+printf 'changed\n' >"$LINKED/agent-cli/src/main.rs"
+output="$(cd "$LINKED" && scripts/agent three)"
+[[ "$output" == "agent:three" ]]
+[[ "$(<"$FIXTURE_BUILD_COUNT")" == 2 ]]


### PR DESCRIPTION
## Summary
- add a thin scripts/cargo wrapper that maps each workspace to the primary checkout's existing target directory
- make scripts/agent reuse main's agent-cli target while executing content-addressed binaries per repository state
- preserve explicit CARGO_TARGET_DIR, --target-dir, manifest, binary, and profile overrides
- add linked-worktree regression coverage and remove stale assertions for a deleted CI action

## Verification
- shared Cargo cache fixture: passed for agent-cli, apps/mister, explicit overrides, same-content reuse, and changed-content rebuild
- agent launcher regression test: passed
- exact committed linked-worktree smoke test wrote all Cargo output under main's existing agent-cli/target and created no target directory in the linked worktree
- focused agent-cli FPGA tests: 10 passed
- pre-push fast assurance: 180 Python tests passed

ARM Apple-container targets were already shared and are unchanged.