### PR TITLE
fix(delivery): preserve attributed FPGA warnings

### DIFF
--- a/agent-cli/src/cli.rs
+++ b/agent-cli/src/cli.rs
@@ -58,12 +58,6 @@ impl Cli {
                         "--game-databases-release-dir is not valid with deliver local-main",
                     ));
                 }
-                (None, Some(_)) => {
-                    return Err(clap::Error::raw(
-                        clap::error::ErrorKind::ArgumentConflict,
-                        "use deliver runtime --game-databases-release-dir PATH for runtime-scoped delivery",
-                    ));
-                }
                 _ => {}
             }
         }
@@ -869,7 +863,7 @@ mod tests {
                 "--game-databases-release-dir",
                 "build/game-databases"
             ])
-            .is_err()
+            .is_ok()
         );
         assert!(
             Cli::try_parse_from([

--- a/agent-cli/src/host/mod.rs
+++ b/agent-cli/src/host/mod.rs
@@ -4554,11 +4554,17 @@ fn experimental_fpga_observer_fault_is_operationally_current(diagnostics: &Value
     const OBSERVER_FAULT: u64 = 1 << 3;
     const LOW_FLAG_MASK: u64 = 0x0fff;
 
+    let expected_schema = match diagnostics
+        .get("diagnostic_architecture")
+        .and_then(Value::as_str)
+    {
+        Some("scaler-off-domain-scheduler-terminal-v4") => 21,
+        Some("scaler-off-domain-scheduler-terminal-v5") => 22,
+        Some("scaler-off-domain-scheduler-terminal-v6") => 23,
+        _ => return false,
+    };
+
     experimental_fpga_transport_is_operational(diagnostics)
-        && diagnostics
-            .get("diagnostic_architecture")
-            .and_then(Value::as_str)
-            == Some("scaler-off-domain-scheduler-terminal-v4")
         && diagnostics.get("coherent").and_then(Value::as_bool) == Some(false)
         && diagnostics.get("classification").and_then(Value::as_str)
             == Some("scaler_fetch_liveness_evidence_inconclusive")
@@ -4586,7 +4592,7 @@ fn experimental_fpga_observer_fault_is_operationally_current(diagnostics: &Value
                     && samples[1..].iter().all(|sample| sample == &samples[0])
                     && samples[0].as_array().is_some_and(|words| {
                         words.len() == 4
-                            && words[0].as_u64() == Some(21)
+                            && words[0].as_u64() == Some(expected_schema)
                             && words[1].as_u64().is_some_and(|flags| {
                                 flags & LOW_FLAG_MASK & RECORD_VALID != 0
                                     && flags & LOW_FLAG_MASK & OBSERVER_FAULT != 0
@@ -40425,6 +40431,24 @@ H: Handlers=event3 js0"#
             assess_fpga_evidence(
                 "scaler-off-domain-scheduler-terminal-v4",
                 &observer_self_fault
+            ),
+            FpgaActivationAssessment::Current {
+                warning: Some(_),
+                ..
+            }
+        ));
+        let mut attributed_observer_fault = observer_self_fault.clone();
+        attributed_observer_fault["diagnostic_architecture"] =
+            json!("scaler-off-domain-scheduler-terminal-v6");
+        attributed_observer_fault["scaler_fetch_liveness_state"]["raw_samples"] =
+            json!([[23, 9, 3, 16243], [23, 9, 3, 16243], [23, 9, 3, 16243]]);
+        assert!(experimental_fpga_observer_fault_is_operationally_current(
+            &attributed_observer_fault
+        ));
+        assert!(matches!(
+            assess_fpga_evidence(
+                "scaler-off-domain-scheduler-terminal-v6",
+                &attributed_observer_fault
             ),
             FpgaActivationAssessment::Current {
                 warning: Some(_),

--- a/agent-cli/src/main.rs
+++ b/agent-cli/src/main.rs
@@ -166,11 +166,14 @@ fn dispatch(
         }
         CliCommand::Deliver {
             target: None,
-            game_databases_release_dir: Some(_),
+            game_databases_release_dir: Some(release_dir),
         } => {
-            return Err(
-                "use deliver runtime --game-databases-release-dir PATH for runtime-scoped delivery"
-                    .into(),
+            return deliver(
+                evidence,
+                repository,
+                Some(release_dir.as_path()),
+                false,
+                reporter,
             );
         }
         CliCommand::Deliver {


### PR DESCRIPTION
## Summary

- allow a verified local game-database release during a full platform delivery
- preserve operational observer-fault warnings across terminal diagnostic schemas 21, 22, and 23
- add the exact platform-v0.40 schema-23 record as a regression test

## Failure reproduced

The published database v17 still uses legacy manifest v3 while current delivery requires compact manifest v4. After supplying a locally rebuilt and verified compact v17 bundle, platform-v0.40 activated but the post-reboot smoke rolled it back. The warning predicate introduced by 4f51262c7 remained hard-coded to schema 21 / terminal-v4 after the FPGA moved through terminal-v5 to schema 23 / terminal-v6.

Observed record:

    [23, 9, 3, 16243]

It decodes as a valid, CRC-checked observer fault attributed to snapshot_timeout. The old predicate treated it as NotReady instead of Current with a warning.

## Verification

- focused CLI parser test passed
- exact FPGA activation-assessment regression test passed
- agent-cli Clippy with all targets and warnings denied passed
- rust-main diagnostics are clean for the final host change
- pre-commit and pre-push fast gates passed
- platform-v0.40 delivery completed successfully on the MiSTer
- post-reboot smoke passed in 5.987 seconds
- fresh diagnostics reported schema 23, terminal-v6, observer fault snapshot_timeout, stable ownership, zero latch drops/rejects, LauncherActive/ready, and clear arming state

No RTL or synthesis input changed.