### PR TITLE
Keep empty Arcade accessible and add screenshot diagnostics

### DIFF
--- a/agent-cli/src/host/mod.rs
+++ b/agent-cli/src/host/mod.rs
@@ -33784,6 +33784,8 @@ fn ssh_diagnostics_bundle(agent_error: String) -> Result<Value> {
         },
         "crashes": ssh_crash_reports_json(&sess),
         "catalog_failures": ssh_catalog_failure_reports_json(&sess),
+        "media_diagnostics": ssh_latest_diagnostic_report(&sess, "diagnostics/media/latest.json", "updated_unix_ms"),
+        "media_live": remote_read(&sess, "/tmp/mister-magik/media-diagnostics.json"),
         "catalog_progress": ssh_latest_diagnostic_report(
             &sess,
             "diagnostics/catalog/progress-latest.json",
@@ -33842,6 +33844,16 @@ fn write_diagnostics_bundle(out_dir: &Path, bundle: &Value) -> Result<()> {
         bundle.get("fpga_video_diagnostics"),
     )?;
 
+    write_json_member(
+        out_dir,
+        "media-diagnostics-latest.json",
+        bundle.pointer("/media_diagnostics/report"),
+    )?;
+    write_string_pointer(
+        out_dir,
+        "media-diagnostics-live.json",
+        bundle.get("media_live"),
+    )?;
     write_string_pointer(out_dir, "ps.txt", bundle.pointer("/processes/ps"))?;
     write_string_pointer(
         out_dir,
@@ -43961,6 +43973,8 @@ fast_catalog_tmpfs_artifact_build_tsv\tenabled=true\tsystems=8\tartifactless_sys
         let _ = fs::remove_dir_all(&out);
         fs::create_dir_all(&out).unwrap();
         let bundle = json!({
+            "media_diagnostics": {"report": {"schema": "mister-magik-media-diagnostics-v1"}},
+            "media_live": "{\"schema\":\"mister-magik-media-diagnostics-v1\"}",
             "catalog_failures": {
                 "latest": {
                     "path": "/media/fat/mister-magik/diagnostics/catalog/latest.json",
@@ -43996,6 +44010,10 @@ fast_catalog_tmpfs_artifact_build_tsv\tenabled=true\tsystems=8\tartifactless_sys
         write_diagnostics_bundle(&out, &bundle).unwrap();
 
         assert!(out.join("catalog-failures.json").exists());
+        assert!(out.join("media-diagnostics-latest.json").exists());
+        assert!(out.join("media-diagnostics-live.json").exists());
+        // A pre-diagnostics device is still a valid bundle source.
+        write_diagnostics_bundle(&out, &json!({})).unwrap();
         let latest: Value =
             serde_json::from_slice(&fs::read(out.join("catalog-failure-latest.json")).unwrap())
                 .unwrap();

--- a/apps/mister/src/bin/ui_preview.rs
+++ b/apps/mister/src/bin/ui_preview.rs
@@ -1711,7 +1711,8 @@ mod macos {
             if matches!(
                 self.scenario,
                 Scenario::Arcade | Scenario::ArcadeSearch | Scenario::ArcadeCrossfade
-            ) {
+            ) && self.launcher.global::<ArcadeView>().get_load_state() == ArcadeLoadState::Ready
+            {
                 let low_resolution_backdrop = self.crt_backdrop.is_some()
                     && matches!(self.scenario, Scenario::Arcade | Scenario::ArcadeCrossfade);
                 if low_resolution_backdrop {

--- a/apps/mister/src/launcher.rs
+++ b/apps/mister/src/launcher.rs
@@ -1623,12 +1623,14 @@ impl LauncherNav {
         }
     }
 
+    #[cfg(any(feature = "ui", feature = "ui-preview"))]
     pub(crate) fn collection_declared_count(&self, id: &str) -> usize {
         self.taxonomy
             .collection(id)
             .map_or(0, |collection| collection.count)
     }
 
+    #[cfg(any(feature = "ui", feature = "ui-preview"))]
     pub(crate) fn collection_is_scanning(&self, id: &str) -> bool {
         let system = self
             .taxonomy
@@ -1646,6 +1648,7 @@ impl LauncherNav {
             )
     }
 
+    #[cfg(any(feature = "ui", feature = "ui-preview"))]
     pub(crate) fn collection_update_has_failed(&self, id: &str) -> bool {
         let system = self
             .taxonomy

--- a/apps/mister/src/launcher.rs
+++ b/apps/mister/src/launcher.rs
@@ -1568,6 +1568,7 @@ impl LauncherNav {
 
     pub fn catalog_system_update_ready(&mut self, system_id: &str) {
         self.catalog_update_states.remove(system_id);
+        self.catalog_system_hydration_finished(system_id);
     }
 
     pub fn catalog_system_update_failed(&mut self, system_id: &str) {
@@ -1576,17 +1577,22 @@ impl LauncherNav {
     }
 
     pub fn catalog_system_hydration_started(&mut self, system_id: &str) {
-        self.catalog_hydration_states
-            .insert(system_id.to_string(), CatalogSystemHydrationState::Loading);
+        self.catalog_hydration_states.insert(
+            Self::hydration_system_id(system_id).to_string(),
+            CatalogSystemHydrationState::Loading,
+        );
     }
 
     pub fn catalog_system_hydration_failed(&mut self, system_id: &str) {
-        self.catalog_hydration_states
-            .insert(system_id.to_string(), CatalogSystemHydrationState::Failed);
+        self.catalog_hydration_states.insert(
+            Self::hydration_system_id(system_id).to_string(),
+            CatalogSystemHydrationState::Failed,
+        );
     }
 
     pub fn catalog_system_hydration_finished(&mut self, system_id: &str) {
-        self.catalog_hydration_states.remove(system_id);
+        self.catalog_hydration_states
+            .remove(Self::hydration_system_id(system_id));
     }
 
     pub fn catalog_hydration_reset(&mut self) {
@@ -1598,15 +1604,63 @@ impl LauncherNav {
     }
 
     pub fn catalog_system_hydration_has_failed(&self, system_id: &str) -> bool {
-        self.catalog_hydration_states.get(system_id) == Some(&CatalogSystemHydrationState::Failed)
+        self.catalog_hydration_states
+            .get(Self::hydration_system_id(system_id))
+            == Some(&CatalogSystemHydrationState::Failed)
     }
 
     pub fn catalog_system_hydration_is_loading(&self, system_id: &str) -> bool {
-        self.catalog_hydration_states.get(system_id) == Some(&CatalogSystemHydrationState::Loading)
+        self.catalog_hydration_states
+            .get(Self::hydration_system_id(system_id))
+            == Some(&CatalogSystemHydrationState::Loading)
+    }
+
+    fn hydration_system_id(system_id: &str) -> &str {
+        if system_id == crate::arcade_catalog::MENU_ARCADE_SYSTEM_ID {
+            "arcade"
+        } else {
+            system_id
+        }
+    }
+
+    pub(crate) fn collection_declared_count(&self, id: &str) -> usize {
+        self.taxonomy
+            .collection(id)
+            .map_or(0, |collection| collection.count)
+    }
+
+    pub(crate) fn collection_is_scanning(&self, id: &str) -> bool {
+        let system = self
+            .taxonomy
+            .collection(id)
+            .map(|collection| collection.legacy_system_id.as_str())
+            .unwrap_or(id);
+        self.catalog_build_active
+            && matches!(
+                self.catalog_update_states.get(system),
+                Some(
+                    CatalogSystemUpdateState::Queued
+                        | CatalogSystemUpdateState::Scanning
+                        | CatalogSystemUpdateState::Prepared
+                )
+            )
+    }
+
+    pub(crate) fn collection_update_has_failed(&self, id: &str) -> bool {
+        let system = self
+            .taxonomy
+            .collection(id)
+            .map(|collection| collection.legacy_system_id.as_str())
+            .unwrap_or(id);
+        self.catalog_system_update_has_failed(system)
     }
 
     pub fn catalog_build_finished(&mut self, catalog: &ArcadeCatalog) {
         self.catalog_build_active = false;
+        let arcade_id = crate::arcade_catalog::MENU_ARCADE_SYSTEM_ID;
+        if catalog.system_game_count(arcade_id) > 0 {
+            self.catalog_system_hydration_finished(arcade_id);
+        }
         let authoritative_systems = catalog
             .systems
             .iter()
@@ -1677,7 +1731,8 @@ impl LauncherNav {
                     } else {
                         CatalogMenuItemStatus::Ready
                     },
-                    available: item.count > 0 && !load_failed,
+                    available: item.id == crate::arcade_catalog::MENU_ARCADE_SYSTEM_ID
+                        || (item.count > 0 && !load_failed),
                     retryable: load_failed,
                 }
             }
@@ -2709,6 +2764,11 @@ impl LauncherNav {
                 return None;
             }
             self.leave_arcade(false, &collection_id);
+            return None;
+        }
+        // A genuinely empty library has no game actions. Back and Home above
+        // remain available, including while its shard is loading or failed.
+        if catalog.system_game_count(&collection_id) == 0 {
             return None;
         }
         if pressed.btn_y {
@@ -6229,7 +6289,7 @@ mod tests {
     }
 
     #[test]
-    fn launcher_keeps_the_empty_arcade_shell_unavailable() {
+    fn launcher_keeps_the_empty_arcade_shell_available_and_back_works() {
         let catalog = arcade_catalog(vec![], vec![]);
         let mut nav = LauncherNav::new();
         let t0 = Instant::now();
@@ -6242,15 +6302,59 @@ mod tests {
             crate::arcade_catalog::MENU_ARCADE_SYSTEM_ID
         );
         assert!(
-            !nav.menu_item_catalog_presentation(&nav.current_menu_items()[0])
+            nav.menu_item_catalog_presentation(&nav.current_menu_items()[0])
                 .available
         );
 
         assert!(nav.handle_input(&press_a, t0, &catalog).is_none());
 
+        assert_eq!(nav.screen, Screen::Arcade);
+        release(&mut nav, &catalog, t0, 16);
+        let actions = pad_with(|pad| {
+            pad.btn_a = true;
+            pad.btn_x = true;
+            pad.btn_y = true;
+            pad.dpad_left = true;
+        });
+        assert!(
+            nav.handle_input(&actions, t0 + Duration::from_millis(32), &catalog)
+                .is_none()
+        );
+        assert!(!nav.arcade_filter.drawer_open);
+        assert!(!nav.arcade_search.is_active(&nav.arcade_filter.active));
+        release(&mut nav, &catalog, t0, 48);
+        let back = pad_with(|pad| pad.btn_b = true);
+        nav.handle_input(&back, t0 + Duration::from_millis(64), &catalog);
         assert_eq!(nav.screen, Screen::Home);
-        assert_eq!(nav.selected, 0);
-        assert_eq!(nav.scroll_x, 0);
+    }
+
+    #[test]
+    fn arcade_shell_stays_available_with_nonarcade_games_and_failed_hydration() {
+        for catalog in [
+            arcade_catalog(vec![], vec![arcade_system("arcade", 0)]),
+            arcade_catalog(
+                vec![arcade_game("Console game").system_id("snes").build()],
+                vec![arcade_system("snes", 1)],
+            ),
+            arcade_catalog(vec![], vec![arcade_system("arcade", 17)]),
+        ] {
+            let mut nav = LauncherNav::new();
+            nav.sync_launcher_taxonomy(&catalog);
+            nav.catalog_system_hydration_failed("arcade");
+            let item = nav
+                .current_menu_items()
+                .iter()
+                .find(|item| item.id == crate::arcade_catalog::MENU_ARCADE_SYSTEM_ID)
+                .unwrap();
+            assert!(nav.menu_item_catalog_presentation(item).available);
+            assert!(nav.open_default_arcade(&catalog));
+            assert_eq!(nav.screen, Screen::Arcade);
+            assert!(
+                nav.catalog_system_hydration_has_failed(
+                    crate::arcade_catalog::MENU_ARCADE_SYSTEM_ID
+                )
+            );
+        }
     }
 
     #[test]

--- a/apps/mister/src/launcher_presentation.rs
+++ b/apps/mister/src/launcher_presentation.rs
@@ -723,11 +723,7 @@ impl LauncherViewPresenters {
             arcade,
             get_load_state,
             set_load_state,
-            if active_games_loading(catalog, nav) {
-                ArcadeLoadState::Loading
-            } else {
-                ArcadeLoadState::Ready
-            }
+            active_games_load_state(catalog, nav)
         );
         set_view_string_if_changed!(arcade, get_active_title, set_active_title, &title);
         set_if_changed!(arcade, get_active_count, set_active_count, count as i32);
@@ -1081,10 +1077,29 @@ fn active_header(
     (title, count)
 }
 
-fn active_games_loading(catalog: &ArcadeCatalog, nav: &LauncherNav) -> bool {
-    nav.active_collection().is_some_and(|collection| {
-        collection.count > 0 && catalog.system_game_count(&collection.id) < collection.count
-    })
+pub(crate) fn active_games_load_state(
+    catalog: &ArcadeCatalog,
+    nav: &LauncherNav,
+) -> ArcadeLoadState {
+    let Some(collection) = nav.active_collection() else {
+        return ArcadeLoadState::Empty;
+    };
+    if nav.catalog_system_hydration_has_failed(&collection.id)
+        || (catalog.system_game_count(&collection.id) == 0
+            && nav.collection_update_has_failed(&collection.id))
+    {
+        ArcadeLoadState::Failed
+    } else if nav.catalog_system_hydration_is_loading(&collection.id)
+        || nav.collection_is_scanning(&collection.id)
+    {
+        ArcadeLoadState::Loading
+    } else if catalog.system_game_count(&collection.id) > 0 {
+        ArcadeLoadState::Ready
+    } else if nav.collection_declared_count(&collection.id) > 0 {
+        ArcadeLoadState::Failed
+    } else {
+        ArcadeLoadState::Empty
+    }
 }
 
 fn sync_arcade_search(arcade: &ArcadeView, nav: &LauncherNav) {
@@ -1133,6 +1148,70 @@ fn sync_arcade_search(arcade: &ArcadeView, nav: &LauncherNav) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn arcade_status_tracks_explicit_hydration_and_empty_library() {
+        let empty = ArcadeCatalog::new(std::path::PathBuf::new(), vec![], vec![]);
+        let mut nav = LauncherNav::new();
+        assert!(nav.open_default_arcade(&empty));
+        assert_eq!(
+            active_games_load_state(&empty, &nav),
+            ArcadeLoadState::Empty
+        );
+        let registered = ArcadeCatalog::new(
+            std::path::PathBuf::new(),
+            vec![],
+            vec![crate::test_support::arcade_system("arcade", 7)],
+        );
+        nav.sync_launcher_taxonomy(&registered);
+        let id = crate::arcade_catalog::MENU_ARCADE_SYSTEM_ID;
+        nav.catalog_system_hydration_started(id);
+        assert_eq!(
+            active_games_load_state(&registered, &nav),
+            ArcadeLoadState::Loading
+        );
+        nav.catalog_system_hydration_failed(id);
+        assert_eq!(
+            active_games_load_state(&registered, &nav),
+            ArcadeLoadState::Failed
+        );
+        assert_eq!(nav.screen, Screen::Arcade);
+        nav.catalog_system_hydration_finished(id);
+        // Declared rows with no usable shard is failure, not endless loading.
+        assert_eq!(
+            active_games_load_state(&registered, &nav),
+            ArcadeLoadState::Failed
+        );
+        nav.sync_launcher_taxonomy(&empty);
+        assert_eq!(
+            active_games_load_state(&empty, &nav),
+            ArcadeLoadState::Empty
+        );
+        assert_eq!(nav.screen, Screen::Arcade);
+    }
+
+    #[test]
+    fn arcade_publication_clears_failure_and_scanning_is_explicit() {
+        let catalog = ArcadeCatalog::new(std::path::PathBuf::new(), vec![], vec![]);
+        let mut nav = LauncherNav::new();
+        nav.open_default_arcade(&catalog);
+        nav.catalog_system_scanning("arcade");
+        assert_eq!(
+            active_games_load_state(&catalog, &nav),
+            ArcadeLoadState::Loading
+        );
+        nav.catalog_system_hydration_failed("arcade");
+        assert_eq!(
+            active_games_load_state(&catalog, &nav),
+            ArcadeLoadState::Failed
+        );
+        nav.catalog_system_update_ready("arcade");
+        assert_eq!(
+            active_games_load_state(&catalog, &nav),
+            ArcadeLoadState::Empty
+        );
+        assert_eq!(nav.screen, Screen::Arcade);
+    }
 
     fn target(item: &str) -> SelectionFeedbackTarget {
         SelectionFeedbackTarget {

--- a/apps/mister/src/launcher_runtime/media.rs
+++ b/apps/mister/src/launcher_runtime/media.rs
@@ -169,6 +169,25 @@ fn run_screenshot_media_worker(
         }
     };
     let state = read_media_state(&config.asset_dir);
+    {
+        use sha2::Digest;
+        let digest = sha2::Sha256::digest(manifest_text.as_bytes())
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        crate::media_diagnostics::record(
+            "manifest_identity",
+            format!(
+                "schema={} generated_at={} sha256={digest} packs={} requested_size={} asset_dir={}",
+                manifest.schema,
+                manifest.generated_at,
+                manifest.packs.len(),
+                config.image_size,
+                config.asset_dir.display()
+            ),
+            false,
+        );
+    }
     let packs_by_system = packs_by_system_for_size(&manifest.packs, &config.image_size);
     let mut counts = MediaCheckCounts::default();
     let mut queue = MediaRequestQueue::default();
@@ -1011,6 +1030,14 @@ fn stream_variant_to_stage_file(
     pack_count: usize,
     tx: &mpsc::Sender<MediaWorkerMessage>,
 ) -> Result<(StreamedPackDownload, HttpCacheMetadata), String> {
+    crate::media_diagnostics::record(
+        "pack_identity",
+        format!(
+            "system={} size={} version={} raw_sha256={} raw_bytes={}",
+            pack.id, pack.image_size, pack.version, pack.raw.sha256, pack.raw.bytes
+        ),
+        false,
+    );
     stream_media_object_to_path(
         &variant.url,
         variant.bytes,
@@ -1137,7 +1164,7 @@ fn stream_media_object_to_path(
     let started = Instant::now();
     let mut curl = Command::new("curl");
     add_curl_download_args(&mut curl, url, headers_path, expected_bytes);
-    let mut child = match curl.stdout(Stdio::piped()).stderr(Stdio::null()).spawn() {
+    let mut child = match curl.stdout(Stdio::piped()).stderr(Stdio::piped()).spawn() {
         Ok(child) => child,
         Err(error) => {
             drop(sha.stdin.take());
@@ -1145,6 +1172,10 @@ fn stream_media_object_to_path(
             return Err(format!("spawn curl: {error}"));
         }
     };
+    let stderr = child
+        .stderr
+        .take()
+        .map(crate::media_http::drain_curl_stderr);
     let mut input = match child.stdout.take() {
         Some(input) => input,
         None => {
@@ -1213,12 +1244,22 @@ fn stream_media_object_to_path(
         let _ = child.kill();
     }
     let status = child.wait().map_err(|e| format!("wait curl: {e}"))?;
+    let stderr = stderr
+        .and_then(|thread| thread.join().ok())
+        .unwrap_or_default();
     let sha_output = sha
         .wait_with_output()
         .map_err(|e| format!("wait sha256 command: {e}"))?;
     transfer_result?;
     if !status.success() {
-        return Err(format!("curl exited with {status}"));
+        let headers = fs::read_to_string(headers_path).unwrap_or_default();
+        let http_status = headers
+            .lines()
+            .rfind(|line| line.starts_with("HTTP/"))
+            .unwrap_or("HTTP status unavailable");
+        return Err(format!(
+            "curl exited with {status}; {http_status}; {stderr}"
+        ));
     }
     if !sha_output.status.success() {
         return Err(format!("sha256 command exited with {}", sha_output.status));
@@ -1268,12 +1309,22 @@ fn verify_streamed_download(
     expected_sha: &str,
 ) -> Result<(), String> {
     if streamed.bytes != expected_bytes {
+        crate::media_diagnostics::record(
+            "pack_size_failed",
+            format!("expected={expected_bytes} actual={}", streamed.bytes),
+            true,
+        );
         return Err(format!(
             "size mismatch expected={expected_bytes} actual={}",
             streamed.bytes
         ));
     }
     if streamed.sha256 != expected_sha {
+        crate::media_diagnostics::record(
+            "pack_sha256_failed",
+            format!("expected={expected_sha} actual={}", streamed.sha256),
+            true,
+        );
         return Err(format!(
             "sha256 mismatch expected={expected_sha} actual={}",
             streamed.sha256

--- a/apps/mister/src/lib.rs
+++ b/apps/mister/src/lib.rs
@@ -71,6 +71,7 @@ pub mod diagnostic_identity;
 pub mod display_config;
 #[doc(hidden)]
 pub mod fallible_log;
+pub(crate) mod media_diagnostics;
 pub use mister_magik_core::{input_event, input_info, input_repeat, input_state};
 #[cfg(feature = "ui")]
 pub use mister_magik_mister_runtime::fpga;

--- a/apps/mister/src/lib.rs
+++ b/apps/mister/src/lib.rs
@@ -71,6 +71,7 @@ pub mod diagnostic_identity;
 pub mod display_config;
 #[doc(hidden)]
 pub mod fallible_log;
+#[cfg(any(feature = "ui", feature = "ui-preview"))]
 pub(crate) mod media_diagnostics;
 pub use mister_magik_core::{input_event, input_info, input_repeat, input_state};
 #[cfg(feature = "ui")]

--- a/apps/mister/src/media_diagnostics.rs
+++ b/apps/mister/src/media_diagnostics.rs
@@ -1,0 +1,361 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Local-only, bounded screenshot support journal. Producers never perform IO
+//! or wait for the writer. A full queue drops events and counts the loss.
+
+use serde_json::{Value, json};
+use std::collections::{BTreeMap, VecDeque};
+use std::fs;
+use std::io::{self, Read, Write};
+use std::path::Path;
+use std::sync::OnceLock;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{self, SyncSender};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const MAX_BYTES: usize = 64 * 1024;
+const MAX_EVENTS: usize = 24;
+static DROPPED: AtomicU64 = AtomicU64::new(0);
+static WRITER: OnceLock<Option<SyncSender<Event>>> = OnceLock::new();
+
+struct Event {
+    name: String,
+    detail: String,
+    failure: bool,
+    at: u64,
+}
+
+/// Strip query strings, URL credentials and control characters before either
+/// memory retention or disk writes. Callers supply only media-specific data.
+pub(crate) fn sanitize(detail: &str) -> String {
+    let mut text = detail
+        .split_whitespace()
+        .take(80)
+        .map(|word| {
+            let word = word.split(['?', '#']).next().unwrap_or("");
+            if let Some((prefix, rest)) = word.split_once("://") {
+                let rest = rest.rsplit_once('@').map_or(rest, |(_, tail)| tail);
+                format!("{prefix}://{rest}")
+            } else if word.to_ascii_lowercase().contains("token=")
+                || word.to_ascii_lowercase().contains("password=")
+                || word.to_ascii_lowercase().contains("authorization")
+            {
+                "[redacted]".to_string()
+            } else {
+                word.chars().filter(|ch| !ch.is_control()).collect()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ");
+    if text.len() > 768 {
+        let mut end = 768;
+        while !text.is_char_boundary(end) {
+            end -= 1;
+        }
+        text.truncate(end);
+    }
+    text
+}
+
+pub(crate) fn record(name: &str, detail: impl AsRef<str>, failure: bool) {
+    let writer = WRITER.get_or_init(|| {
+        let (sender, receiver) = mpsc::sync_channel(64);
+        std::thread::Builder::new()
+            .name("media-diagnostics".into())
+            .spawn(move || run(receiver))
+            .ok()
+            .map(|_| sender)
+    });
+    let event = Event {
+        name: name
+            .chars()
+            .filter(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.' | ':'))
+            .take(64)
+            .collect(),
+        detail: sanitize(detail.as_ref()),
+        failure,
+        at: unix_ms(),
+    };
+    if writer
+        .as_ref()
+        .is_none_or(|writer| writer.try_send(event).is_err())
+    {
+        DROPPED.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+#[derive(Default)]
+struct Journal {
+    events: VecDeque<Value>,
+    counters: BTreeMap<String, u64>,
+    context: BTreeMap<String, String>,
+    last_failure: Option<(String, String)>,
+    pending_failure: bool,
+    suppressed: u64,
+    changed: bool,
+}
+
+impl Journal {
+    fn push(&mut self, event: Event) {
+        let key = if self.counters.contains_key(&event.name) || self.counters.len() < 48 {
+            event.name.clone()
+        } else {
+            "other".into()
+        };
+        *self.counters.entry(key).or_default() += 1;
+        if matches!(
+            event.name.as_str(),
+            "manifest_identity"
+                | "preview_configuration"
+                | "pack_identity"
+                | "preview_presentation_receipt"
+                | "screenshot_media_cache_metadata"
+        ) {
+            self.context
+                .insert(event.name.clone(), event.detail.clone());
+        }
+        if event.failure {
+            let key = (event.name.clone(), event.detail.clone());
+            if self.last_failure.as_ref() != Some(&key) {
+                self.pending_failure = true;
+                self.last_failure = Some(key);
+            } else {
+                self.suppressed += 1;
+            }
+        }
+        self.events.push_back(json!({"name": event.name, "detail": event.detail, "failure": event.failure, "unix_ms": event.at}));
+        if self.events.len() > MAX_EVENTS {
+            self.events.pop_front();
+        }
+        self.changed = true;
+    }
+
+    fn snapshot(&self, boot: &str, session: u64, saved: u64, io_errors: u64) -> Value {
+        json!({
+            "schema": "mister-magik-media-diagnostics-v1",
+            "updated_unix_ms": unix_ms(), "boot_id": boot, "session": session,
+            "launcher_pid": std::process::id(),
+            "build": crate::build_identity::BuildIdentity::current(),
+            "events": self.events, "counters": self.counters, "context": self.context,
+            "last_failure": self.last_failure,
+            "queue_dropped": DROPPED.load(Ordering::Relaxed),
+            "suppressed_failures": self.suppressed, "persistent_attempts_this_boot": saved,
+            "storage_errors": io_errors,
+            "visibility_assurance": "decode/apply and presentation receipts are not physical display verification",
+        })
+    }
+}
+
+fn run(receiver: mpsc::Receiver<Event>) {
+    let tmp = Path::new("/tmp/mister-magik");
+    let dir = mister_magik_catalog::device_layout::current_app_path("diagnostics/media");
+    let boot =
+        fs::read_to_string("/proc/sys/kernel/random/boot_id").unwrap_or_else(|_| "host".into());
+    let boot = sanitize(&boot);
+    let session = unix_ms();
+    let ledger_path = tmp.join("media-diagnostics-budget.json");
+    let ledger: Value = read_bounded(&ledger_path)
+        .ok()
+        .and_then(|bytes| serde_json::from_slice(&bytes).ok())
+        .unwrap_or(Value::Null);
+    let same_boot = ledger["boot_id"].as_str() == Some(boot.as_str());
+    let mut saved = if same_boot {
+        ledger["attempts"].as_u64().unwrap_or(16)
+    } else if ledger.is_null() && ledger_path.exists() {
+        16
+    } else {
+        0
+    };
+    let mut last_saved_ms = if same_boot {
+        ledger["at"].as_u64().unwrap_or(session)
+    } else {
+        0
+    };
+    let mut journal = Journal::default();
+    let platform_path =
+        mister_magik_catalog::device_layout::current_app_path("platform-v3.manifest");
+    if let Ok(bytes) = read_bounded(&platform_path) {
+        use sha2::Digest;
+        let digest = sha2::Sha256::digest(&bytes)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect::<String>();
+        journal.context.insert(
+            "platform_manifest".into(),
+            format!("path={} sha256={digest}", platform_path.display()),
+        );
+    }
+    let mut last_live = Instant::now();
+    let mut io_errors = 0;
+    loop {
+        let remaining = Duration::from_secs(2).saturating_sub(last_live.elapsed());
+        match receiver.recv_timeout(remaining) {
+            Ok(event) => journal.push(event),
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+        }
+        if last_live.elapsed() < Duration::from_secs(2) {
+            continue;
+        }
+        last_live = Instant::now();
+        if !journal.changed {
+            continue;
+        }
+        journal.changed = false;
+        if journal.pending_failure {
+            journal.pending_failure = false;
+            let now = unix_ms();
+            if persistent_budget_available(saved, last_saved_ms, now) {
+                // Reserve the budget in tmpfs first, even when the SD write fails.
+                // A restarted launcher must not restart the persistent-write budget.
+                saved += 1;
+                last_saved_ms = now;
+                let ledger = json!({"boot_id": boot, "attempts": saved, "at": now});
+                if atomic_json(&ledger_path, &ledger).is_ok() {
+                    let report = journal.snapshot(&boot, session, saved, io_errors);
+                    if persist(&dir, &report, now, saved).is_err() {
+                        io_errors += 1;
+                    }
+                } else {
+                    io_errors += 1;
+                }
+            } else {
+                journal.suppressed += 1;
+            }
+        }
+        if atomic_json(
+            &tmp.join("media-diagnostics.json"),
+            &journal.snapshot(&boot, session, saved, io_errors),
+        )
+        .is_err()
+        {
+            io_errors += 1;
+        }
+    }
+}
+
+fn persistent_budget_available(saved: u64, last_saved_ms: u64, now: u64) -> bool {
+    saved < 16 && now.saturating_sub(last_saved_ms) >= 60_000
+}
+
+fn read_bounded(path: &Path) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::new();
+    fs::File::open(path)?
+        .take((MAX_BYTES + 1) as u64)
+        .read_to_end(&mut bytes)?;
+    if bytes.len() > MAX_BYTES {
+        return Err(io::Error::other("media diagnostic input exceeds bound"));
+    }
+    Ok(bytes)
+}
+
+fn atomic_json(path: &Path, value: &Value) -> io::Result<()> {
+    let bytes = serde_json::to_vec(value)?;
+    if bytes.len() > MAX_BYTES {
+        return Err(io::Error::other("media report exceeds bound"));
+    }
+    fs::create_dir_all(
+        path.parent()
+            .ok_or_else(|| io::Error::other("no report directory"))?,
+    )?;
+    let temporary = path.with_extension("json.tmp");
+    let mut file = fs::File::create(&temporary)?;
+    file.write_all(&bytes)?;
+    drop(file);
+    fs::rename(temporary, path)
+}
+
+fn persist(dir: &Path, report: &Value, now: u64, sequence: u64) -> io::Result<()> {
+    atomic_json(
+        &dir.join(format!("report-{now:020}-{sequence:02}.json")),
+        report,
+    )?;
+    atomic_json(&dir.join("latest.json"), report)?;
+    let mut reports = fs::read_dir(dir)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| {
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name.starts_with("report-") && name.ends_with(".json"))
+        })
+        .collect::<Vec<_>>();
+    reports.sort();
+    let remove = reports.len().saturating_sub(5);
+    for path in reports.into_iter().take(remove) {
+        fs::remove_file(path)?;
+    }
+    Ok(())
+}
+
+fn unix_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn report_is_bounded_and_deduplicates_failures() {
+        let mut journal = Journal::default();
+        for _ in 0..1000 {
+            journal.push(Event {
+                name: "decode_failed".into(),
+                detail: sanitize(&"x".repeat(4000)),
+                failure: true,
+                at: 0,
+            });
+        }
+        assert_eq!(journal.events.len(), MAX_EVENTS);
+        assert_eq!(journal.suppressed, 999);
+        assert!(
+            serde_json::to_vec(&journal.snapshot("boot", 0, 0, 0))
+                .unwrap()
+                .len()
+                < MAX_BYTES
+        );
+    }
+    #[test]
+    fn credentials_queries_and_control_characters_are_removed() {
+        assert!(sanitize(&"🎮".repeat(1000)).len() <= 768);
+        assert_eq!(
+            sanitize("url=https://user:secret@example.org/a?token=secret password=secret\nnext"),
+            "url=https://example.org/a [redacted] next"
+        );
+    }
+    #[test]
+    fn snapshots_rotate_and_storage_errors_are_returned() {
+        let dir = std::env::temp_dir().join(format!(
+            "magik-media-report-test-{}-{}",
+            std::process::id(),
+            unix_ms()
+        ));
+        for i in 0..8 {
+            persist(&dir, &json!({"test": i}), i, i).unwrap();
+        }
+        assert_eq!(fs::read_dir(&dir).unwrap().count(), 6);
+        assert_eq!(
+            serde_json::from_slice::<Value>(&fs::read(dir.join("latest.json")).unwrap()).unwrap()["test"],
+            7
+        );
+        assert!(persist(&dir.join("latest.json"), &json!({}), 9, 9).is_err());
+        fs::remove_dir_all(dir).unwrap();
+    }
+    #[test]
+    fn persistent_budget_and_queue_are_fail_closed() {
+        assert!(persistent_budget_available(0, 0, 60_000));
+        assert!(!persistent_budget_available(1, 60_000, 119_999));
+        assert!(!persistent_budget_available(1, 60_000, 10));
+        assert!(!persistent_budget_available(16, 0, 999_999));
+        let (sender, _receiver) = mpsc::sync_channel(1);
+        sender.try_send(1).unwrap();
+        assert!(matches!(
+            sender.try_send(2),
+            Err(mpsc::TrySendError::Full(2))
+        ));
+    }
+}

--- a/apps/mister/src/media_http.rs
+++ b/apps/mister/src/media_http.rs
@@ -15,6 +15,29 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const MANIFEST_CONNECT_TIMEOUT_SECS: u64 = 10;
 const MANIFEST_FETCH_TIMEOUT_SECS: u64 = 15;
 
+/// Drain the entire pipe concurrently, but retain at most 2 KiB. Retaining
+/// only a prefix without draining the remainder can deadlock curl on stderr.
+pub(crate) fn drain_curl_stderr(
+    mut pipe: impl Read + Send + 'static,
+) -> std::thread::JoinHandle<String> {
+    std::thread::spawn(move || {
+        let mut retained = Vec::new();
+        let mut buffer = [0u8; 4096];
+        loop {
+            match pipe.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(count) => {
+                    let keep = count.min(2048usize.saturating_sub(retained.len()));
+                    retained.extend_from_slice(&buffer[..keep]);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+        crate::media_diagnostics::sanitize(&String::from_utf8_lossy(&retained))
+    })
+}
+
 #[derive(Debug)]
 pub struct ManifestFetch {
     pub bytes: Vec<u8>,
@@ -22,12 +45,25 @@ pub struct ManifestFetch {
 }
 
 pub fn fetch_manifest(url: &str) -> Result<ManifestFetch, String> {
-    fetch_manifest_with(
+    let result = fetch_manifest_with(
         url,
         configured_manifest_trust_mode(),
         fetch_https_bytes,
         verify_manifest_signature,
-    )
+    );
+    match &result {
+        Ok(manifest) => crate::media_diagnostics::record(
+            "manifest_fetched",
+            format!("url={url} bytes={}", manifest.bytes.len()),
+            false,
+        ),
+        Err(error) => crate::media_diagnostics::record(
+            "manifest_failed",
+            format!("url={url} stage=fetch_or_trust detail={error}"),
+            true,
+        ),
+    }
+    result
 }
 
 fn fetch_manifest_with<F, V>(
@@ -96,6 +132,7 @@ fn fetch_https_bytes(url: &str, max_bytes: u64, label: &str) -> Result<HttpsFetc
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|error| format!("spawn curl for {label}: {error}"))?;
+    let stderr = child.stderr.take().map(drain_curl_stderr);
     let mut stdout = match child.stdout.take() {
         Some(stdout) => stdout,
         None => {
@@ -123,7 +160,9 @@ fn fetch_https_bytes(url: &str, max_bytes: u64, label: &str) -> Result<HttpsFetc
         return Err(format!("{label} exceeds {max_bytes} bytes"));
     }
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        let stderr = stderr
+            .and_then(|thread| thread.join().ok())
+            .unwrap_or_default();
         if stderr.is_empty() {
             return Err(format!("{label} curl exited with {}", output.status));
         }
@@ -182,6 +221,14 @@ fn temporary_headers_path(label: &str) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn curl_stderr_is_fully_drained_but_retained_output_is_bounded() {
+        let bytes = std::io::Cursor::new(vec![b'x'; 256 * 1024]);
+        let result = drain_curl_stderr(bytes).join().unwrap();
+        assert_eq!(result.len(), 768);
+        assert!(result.bytes().all(|byte| byte == b'x'));
+    }
     use std::ffi::OsString;
 
     #[test]

--- a/apps/mister/src/preview_state.rs
+++ b/apps/mister/src/preview_state.rs
@@ -296,6 +296,17 @@ fn apply_preview_image_bridge(
     bridge: &slint_ui::launcher::ArcadeView,
     preview_image: &PreviewImage,
 ) {
+    crate::media_diagnostics::record(
+        "preview_applied",
+        format!(
+            "source={}x{} display={}x{} state=ready",
+            preview_image.source_w,
+            preview_image.source_h,
+            preview_image.display_w,
+            preview_image.display_h
+        ),
+        false,
+    );
     bridge.set_preview_state(ViewPreviewState::Ready);
     bridge.set_preview_source_width(preview_image.source_w as i32);
     bridge.set_preview_source_height(preview_image.source_h as i32);
@@ -687,6 +698,14 @@ impl PreviewState {
     }
 
     pub fn new_with_config(trace_start: Instant, config: PreviewStateConfig) -> Self {
+        crate::media_diagnostics::record(
+            "preview_configuration",
+            format!(
+                "loading_enabled={} turbo_runway_enabled={}",
+                config.loading_enabled, config.turbo_runway_enabled
+            ),
+            false,
+        );
         Self {
             worker: PreviewWorker::new_with_config(trace_start, config.worker.clone()),
             config,
@@ -1631,6 +1650,11 @@ pub fn request_arcade_preview_window(
                     return true;
                 }
                 if preview.cache.contains_failed(&path) {
+                    crate::media_diagnostics::record(
+                        "preview_failed_cache_suppressed",
+                        format!("generation={} key={path}", preview.current_generation),
+                        false,
+                    );
                     preview.select_empty_preview(preview_transition_mode(turbo_active));
                     bridge.set_preview_state(ViewPreviewState::Empty);
                     request_preview_prefetches_if_allowed(
@@ -1678,6 +1702,16 @@ pub fn request_arcade_preview_window(
 
     let selected_has_preview = game_preview_key(selected_game).is_some();
     let Some(candidate) = candidate else {
+        crate::media_diagnostics::record(
+            "preview_candidate_unavailable",
+            format!(
+                "system={} key={} requested_pack={} selected_has_preview={selected_has_preview}",
+                selected_game.system_id,
+                selected_game.preview_asset_key,
+                selected_game.preview_archive_path
+            ),
+            true,
+        );
         if preview_startup_trace_enabled() {
             crate::ui_errln!(
                 "startup_timing\tpreview_selected_candidate\t{}ms\tsystem={}\tselected_index={}\ttitle={}\thas_preview=0\tasset_key=\tcandidate_index=\tselected_has_preview={}",
@@ -1719,6 +1753,14 @@ pub fn request_arcade_preview_window(
     let preview_key = candidate.preview_key.clone();
     preview.selected_preview_key = Some(preview_key.clone());
     if preview.cache.contains_failed(&preview_key) {
+        crate::media_diagnostics::record(
+            "preview_failed_cache_suppressed",
+            format!(
+                "generation={} key={preview_key}",
+                preview.current_generation
+            ),
+            false,
+        );
         preview.select_empty_preview(preview_transition_mode(turbo_active));
         bridge.set_preview_state(ViewPreviewState::Empty);
         request_preview_prefetches_if_allowed(
@@ -2303,6 +2345,62 @@ pub fn apply_ready_preview(
             preview.current_generation,
             preview.selected_preview_key.as_deref(),
         );
+        crate::media_diagnostics::record(
+            if result.image.is_none() {
+                "preview_failed"
+            } else if is_selected_result {
+                "preview_selected_decoded"
+            } else {
+                "preview_nonselected_decoded"
+            },
+            format!(
+                "generation={} current_generation={} selected={} requested_pack={} resolved_pack={} key={} dimensions={}x{} bytes={} age_us={} source={:?}",
+                result.generation,
+                preview.current_generation,
+                is_selected_result,
+                result.preview_archive_path,
+                result.diagnostics.resolved_archive_path,
+                result.preview_asset_key,
+                result.source_width,
+                result.source_height,
+                result.decoded_bytes,
+                result.request_age_us,
+                result.load_source
+            ),
+            false,
+        );
+        if let Some(failure) = &result.diagnostics.failure {
+            crate::media_diagnostics::record(
+                "preview_load_failed",
+                format!(
+                    "generation={} selected={} stage={} code={} expected_bytes={:?} actual_bytes={:?} detail={}",
+                    result.generation,
+                    is_selected_result,
+                    failure.stage,
+                    failure.code,
+                    failure.expected_bytes,
+                    failure.actual_bytes,
+                    failure.detail
+                ),
+                true,
+            );
+        }
+        if let Some(fallback) = &result.diagnostics.index_fallback {
+            crate::media_diagnostics::record(
+                "preview_index_fallback",
+                format!(
+                    "generation={} recovered={} stage={} code={} expected_bytes={:?} actual_bytes={:?} detail={}",
+                    result.generation,
+                    result.image.is_some(),
+                    fallback.stage,
+                    fallback.code,
+                    fallback.expected_bytes,
+                    fallback.actual_bytes,
+                    fallback.detail
+                ),
+                false,
+            );
+        }
         if is_selected_result {
             selected_processed = true;
             preview.last_apply_trace.selected_processed += 1;
@@ -2413,6 +2511,19 @@ pub fn apply_ready_preview(
                 preview.visible_preview_key = result_preview_key;
                 preview.raw_dirty = true;
                 apply_preview_image_bridge(&bridge, &image);
+                crate::media_diagnostics::record(
+                    "preview_selected_applied",
+                    format!(
+                        "generation={} key={} source={}x{} display={}x{}",
+                        result.generation,
+                        preview.visible_preview_key,
+                        image.source_w,
+                        image.source_h,
+                        image.display_w,
+                        image.display_h
+                    ),
+                    false,
+                );
                 if preview_startup_trace_enabled() {
                     crate::ui_errln!(
                         "startup_timing\tpreview_selected_applied\t{}ms\tsystem={}\ttitle={}\thas_preview=1\tasset_key={}\tgeneration={}\tload_source={}\ttotal_us={}\tread_us={}\tdecode_us={}\tage_us={}",
@@ -3739,6 +3850,7 @@ mod tests {
         priority: PreviewPriority,
     ) -> PreviewResult {
         PreviewResult {
+            diagnostics: Default::default(),
             generation,
             title: preview_asset_key.to_string(),
             preview_archive_path: String::new(),

--- a/apps/mister/src/ui_runner/launcher_bridge.rs
+++ b/apps/mister/src/ui_runner/launcher_bridge.rs
@@ -1002,9 +1002,10 @@ fn sync_launcher_layout_if_changed(
     }
 }
 
-pub(super) fn active_system_games_loading(catalog: &ArcadeCatalog, nav: &LauncherNav) -> bool {
-    active_system(catalog, nav).is_some_and(|system| {
-        system.count > 0 && catalog.system_game_count(&system.id) < system.count
+pub(super) fn active_system_games_loading(_catalog: &ArcadeCatalog, nav: &LauncherNav) -> bool {
+    nav.active_collection().is_some_and(|collection| {
+        nav.catalog_system_hydration_is_loading(&collection.id)
+            || nav.collection_is_scanning(&collection.id)
     })
 }
 
@@ -1589,12 +1590,12 @@ mod tests {
         );
         let mut nav = LauncherNav::new();
         assert!(nav.open_system(&catalog, "pet2001"));
-
+        nav.catalog_system_hydration_started("pet2001");
         assert!(active_system_games_loading(&catalog, &nav));
     }
 
     #[test]
-    fn arcade_collection_reports_missing_registry_rows_as_loading() {
+    fn arcade_collection_reports_explicit_hydration_as_loading() {
         let catalog = ArcadeCatalog::new(
             PathBuf::from(DEFAULT_ARCADE_ROOT),
             vec![arcade_game("Arcade One").system_id("arcade").build()],
@@ -1619,6 +1620,8 @@ mod tests {
             1
         );
         assert_eq!(active_system_game_view(&catalog, &nav).len(), 1);
+        assert!(!active_system_games_loading(&catalog, &nav));
+        nav.catalog_system_hydration_started("arcade");
         assert!(active_system_games_loading(&catalog, &nav));
     }
 

--- a/apps/mister/src/ui_runner/launcher_frame_accounting.rs
+++ b/apps/mister/src/ui_runner/launcher_frame_accounting.rs
@@ -60,6 +60,7 @@ pub(super) struct LauncherFrameAccounting {
     runtime_status_publisher: runtime_status::RuntimeStatusPublisher,
     last_status_write: Instant,
     status_sequence: u64,
+    last_media_receipt: String,
     profile_completion_submitted: bool,
     first_copy_logged: bool,
     first_frame_logged: bool,
@@ -1190,6 +1191,7 @@ impl LauncherFrameAccounting {
             runtime_status_publisher: runtime_status::RuntimeStatusPublisher::new(),
             last_status_write: Instant::now() - Duration::from_secs(2),
             status_sequence: 0,
+            last_media_receipt: String::new(),
             profile_completion_submitted: false,
             first_copy_logged: false,
             first_frame_logged: false,
@@ -2561,6 +2563,26 @@ impl LauncherFrameAccounting {
             self.take_frame_budget_status()
         };
         self.status_sequence = self.status_sequence.saturating_add(1);
+        let receipt_system = nav.active_collection_scope_id(catalog);
+        let receipt_key = nav
+            .active_arcade_game_at(catalog, receipt_system, nav.arcade.selected)
+            .map_or("", |game| game.preview_asset_key.as_ref());
+        let media_receipt = format!(
+            "key={receipt_key} cache={preview_cache_state} catalog_generation={} view={} present_backend={} present_status={} frozen={} output={}x{} state_revision={} presented_state_revision={}",
+            self.catalog_generation,
+            self.effective_view,
+            self.last_present_backend,
+            self.last_present_status,
+            self.display_frozen,
+            self.framebuffer_width,
+            self.framebuffer_height,
+            self.automation_state_revision,
+            self.automation_presented_state_revision
+        );
+        if self.last_media_receipt != media_receipt {
+            crate::media_diagnostics::record("preview_presentation_receipt", &media_receipt, false);
+            self.last_media_receipt = media_receipt;
+        }
         let screensaver_profile_state = cpu_profile::screensaver_profile_state();
         let build_identity = crate::build_identity::BuildIdentity::current();
         let selected_system_id = nav.active_collection_scope_id(catalog);

--- a/apps/mister/src/ui_runner/launcher_loop.rs
+++ b/apps/mister/src/ui_runner/launcher_loop.rs
@@ -1155,7 +1155,11 @@ fn system_entry_collection_id(system_id: &str) -> &str {
 fn empty_collection_invariant_violated(catalog: &ArcadeCatalog, nav: &LauncherNav) -> bool {
     nav.screen == Screen::Arcade
         && active_system(catalog, nav).is_some_and(|system| {
-            system.count > 0 && !collection_has_resident_rows(catalog, &system.id)
+            system.count > 0
+                && !collection_has_resident_rows(catalog, &system.id)
+                && !nav.catalog_system_hydration_is_loading(&system.id)
+                && !nav.catalog_system_hydration_has_failed(&system.id)
+                && !nav.collection_is_scanning(&system.id)
         })
 }
 
@@ -4392,6 +4396,16 @@ fn begin_cold_collection_entry(
     lifecycle: &LauncherLifecycle,
     start: Instant,
 ) -> ColdCollectionEntryStart {
+    // The Arcade shell exists independently of installed games. Do not ask
+    // the shard scheduler to read a file for an unregistered/zero-row library.
+    if collection_id == arcade_catalog::MENU_ARCADE_SYSTEM_ID
+        && nav.collection_declared_count(collection_id) == 0
+    {
+        return ColdCollectionEntryStart {
+            pending: None,
+            bridge_dirty: true,
+        };
+    }
     let hydration_failed = nav.catalog_system_hydration_has_failed(collection_id);
     let already_loading = nav.catalog_system_hydration_is_loading(collection_id);
     let preview_dispatch = (!already_loading).then(|| {
@@ -4427,6 +4441,17 @@ fn begin_cold_collection_entry(
     }
     if hydration_requested {
         nav.catalog_system_hydration_started(collection_id);
+    }
+    if collection_id == arcade_catalog::MENU_ARCADE_SYSTEM_ID {
+        if !hydration_requested && !already_loading && !nav.collection_is_scanning(collection_id) {
+            nav.catalog_system_hydration_failed(collection_id);
+        }
+        // Navigation commits now; hydration only updates the open screen.
+        // In particular a late result must never reopen Arcade after Back.
+        return ColdCollectionEntryStart {
+            pending: None,
+            bridge_dirty: true,
+        };
     }
     let pending = (hydration_requested || nav.catalog_system_hydration_is_loading(collection_id))
         .then(|| {
@@ -8134,10 +8159,12 @@ pub(super) fn run_launcher_loop(
                                         } else if collection_id.is_none()
                                             || collection_id.as_deref().is_some_and(
                                                 |collection_id| {
-                                                    collection_has_resident_rows(
-                                                        &catalog,
-                                                        collection_id,
-                                                    )
+                                                    collection_id
+                                                        == arcade_catalog::MENU_ARCADE_SYSTEM_ID
+                                                        || collection_has_resident_rows(
+                                                            &catalog,
+                                                            collection_id,
+                                                        )
                                                 },
                                             )
                                         {
@@ -8788,7 +8815,10 @@ pub(super) fn run_launcher_loop(
                     format!("system={} registered_rows={}", system.id, system.count),
                 );
             }
-            nav.recover_empty_collection_to_home();
+            if let Some(system) = active_system(&catalog, &nav) {
+                let id = system.id.clone();
+                nav.catalog_system_hydration_failed(&id);
+            }
             full_bridge_dirty = true;
             request_launcher_redraw!();
         }
@@ -9034,6 +9064,9 @@ pub(super) fn run_launcher_loop(
             ArcadeGameView::empty()
         };
         let active_arcade_games_available = !active_arcade_games.is_empty();
+        let arcade_status_only =
+            crate::launcher_presentation::active_games_load_state(&catalog, &nav)
+                != slint_ui::launcher::ArcadeLoadState::Ready;
         let arcade_search_active = nav.arcade_search.is_active(&nav.arcade_filter.active);
         if !launching && nav.screen == Screen::Arcade {
             if let Some(system) = active_system(&catalog, &nav) {
@@ -9179,6 +9212,7 @@ pub(super) fn run_launcher_loop(
             || display_session.should_present_full_frame(launching, route_action)
             || startup_reveal_ready;
         let wants_arcade_list = !screensaver.active
+            && !arcade_status_only
             && should_draw_arcade_overlay(&nav, launching, active_arcade_games_available);
         let presentation_route = if preserve_navigation_source_preview {
             PreviewRoute::Occluded
@@ -9257,7 +9291,9 @@ pub(super) fn run_launcher_loop(
         // The list is the navigation destination. Preview media is asynchronous and
         // must never hold the full-screen transition closed after the list is ready.
         let navigation_destination_layers_ready = navigation_destination_committed
-            && (nav.screen != Screen::Arcade || active_arcade_games_available);
+            && (nav.screen != Screen::Arcade
+                || active_arcade_games_available
+                || nav.active_collection_id() == Some(arcade_catalog::MENU_ARCADE_SYSTEM_ID));
         let composition_decision = composition.tick(UiCompositionInput {
             screensaver_active: effective_view == EffectiveLauncherView::Screensaver,
             navigation_transition_active: navigation_transition.is_active(),
@@ -9267,7 +9303,8 @@ pub(super) fn run_launcher_loop(
             return_screen: effective_view.return_screen(),
             confirm_visible,
             fullscreen_overlay_visible: catalog_scan_visible,
-            arcade_ready: active_arcade_games_available,
+            arcade_ready: active_arcade_games_available
+                || nav.active_collection_id() == Some(arcade_catalog::MENU_ARCADE_SYSTEM_ID),
             route_ok: display_session.route_ok(),
             wants_arcade_list,
             wants_preview: wants_preview_layer,
@@ -10564,7 +10601,13 @@ pub(super) fn run_launcher_loop(
                         }
                         true
                     };
-                    if preview_surface_ready {
+                    if preview_surface_ready && arcade_status_only {
+                        // The Slint status panel is the complete destination for
+                        // loading, empty and failed Arcade. Do not paint the old
+                        // custom "NO GAMES" layer over it.
+                        destination_layers_ready = true;
+                    }
+                    if preview_surface_ready && !arcade_status_only {
                         configure_arcade_list_renderer_geometry(
                             &mut arcade_list_renderer,
                             &nav,
@@ -16638,7 +16681,7 @@ mod tests {
         restored_nav.catalog_system_hydration_started("arcade");
         let registry = summary_catalog_for_media_systems(&["arcade"]);
 
-        assert!(empty_collection_invariant_violated(
+        assert!(!empty_collection_invariant_violated(
             &registry,
             &restored_nav,
         ));

--- a/apps/mister/src/ui_runner/screenshot_media_update_session.rs
+++ b/apps/mister/src/ui_runner/screenshot_media_update_session.rs
@@ -53,11 +53,11 @@ impl ScreenshotMediaUpdateEffects {
     }
 
     fn event(&mut self, name: impl Into<String>, detail: impl Into<String>) {
+        let name = name.into();
+        let detail = detail.into();
+        crate::media_diagnostics::record(&name, &detail, name.ends_with("failed"));
         self.push(ScreenshotMediaUpdateEffect::StartupEvent(
-            ScreenshotMediaUpdateEvent {
-                name: name.into(),
-                detail: detail.into(),
-            },
+            ScreenshotMediaUpdateEvent { name, detail },
         ));
     }
 
@@ -321,6 +321,13 @@ impl ScreenshotMediaUpdateSession {
                 status,
                 detail,
             } => {
+                if matches!(status.as_str(), "failed" | "unavailable") {
+                    crate::media_diagnostics::record(
+                        "pack_unavailable",
+                        format!("system={system} size={image_size} status={status} {detail}"),
+                        true,
+                    );
+                }
                 effects.event(
                     "screenshot_media_pack_status",
                     format!("system={system} image_size={image_size} status={status} {detail}"),
@@ -337,6 +344,23 @@ impl ScreenshotMediaUpdateSession {
                 }
             }
             MediaWorkerMessage::PreviewAvailabilityUpdated { outcome } => {
+                if outcome.candidate_rows > outcome.available_rows {
+                    crate::media_diagnostics::record(
+                        "preview_identity_unavailable",
+                        format!(
+                            "system={} generation={} candidates={} available={} existing={} derived={} ambiguous={} resolver={:?}",
+                            outcome.system_id,
+                            outcome.generation,
+                            outcome.candidate_rows,
+                            outcome.available_rows,
+                            outcome.existing_identity_rows,
+                            outcome.derived_identity_rows,
+                            outcome.ambiguous_identity_rows,
+                            outcome.resolver_status
+                        ),
+                        true,
+                    );
+                }
                 effects.event(
                     "screenshot_media_catalog_updated",
                     format!(

--- a/apps/mister/ui/api.slint
+++ b/apps/mister/ui/api.slint
@@ -23,7 +23,7 @@ export enum AboutSection { information, licenses }
 export enum InputAvailability { available, unavailable }
 export enum SetupPhase { none, detected, new-or-existing, pick-existing, configure, name-kind }
 export enum ArcadeListMode { games, recent, favourites }
-export enum ArcadeLoadState { ready, loading }
+export enum ArcadeLoadState { ready, loading, empty, failed }
 export enum ArcadeSearchMode { inactive, active }
 export enum ArcadeSearchStatus { idle, searching, ready, failed }
 export enum ArcadeSearchPane { keyboard, results }

--- a/apps/mister/ui/views/crt/arcade_list.slint
+++ b/apps/mister/ui/views/crt/arcade_list.slint
@@ -165,7 +165,7 @@ export component ArcadeListScreen inherits Rectangle {
         }
     }
 
-    if ArcadeView.load-state == ArcadeLoadState.loading : Rectangle {
+    if ArcadeView.load-state != ArcadeLoadState.ready : Rectangle {
         x: (LauncherLayout.arcade-list.x - MisterUi.crt-content-x) * 1px;
         y: (LauncherLayout.arcade-list.y - MisterUi.crt-content-y) * 1px;
         width: LauncherLayout.arcade-list.width * 1px;
@@ -176,7 +176,7 @@ export component ArcadeListScreen inherits Rectangle {
         accessible-description: "Loading arcade list";
 
         Spleen6x12 {
-            text: "Loading list...";
+            text: ArcadeView.load-state == ArcadeLoadState.loading ? "Loading Arcade games…" : ArcadeView.load-state == ArcadeLoadState.failed ? "Arcade library unavailable.\nLibrary Refresh in Settings." : "No Arcade games found.\nLibrary Refresh in Settings.";
             color: CrtTheme.muted;
             size: MisterUi.crt-body-font;
             horizontal-alignment: center;
@@ -191,7 +191,7 @@ export component ArcadeListScreen inherits Rectangle {
         background: transparent;
         border-width: 0px;
         border-color: transparent;
-        left-hint: "A Launch   X Options   Y Search";
+        left-hint: ArcadeView.load-state == ArcadeLoadState.ready ? "A Launch   X Options   Y Search" : "";
         right-hint: "B Back   HOME Launcher";
     }
 }

--- a/apps/mister/ui/views/hdmi/arcade_list.slint
+++ b/apps/mister/ui/views/hdmi/arcade_list.slint
@@ -156,6 +156,7 @@ component SearchKeyboard inherits Rectangle {
 export component ArcadeListScreen inherits Rectangle {
     property <int> count: ArcadeView.active-count;
     property <bool> games-loading: ArcadeView.load-state == ArcadeLoadState.loading;
+    property <string> library-status: root.games-loading ? "Loading Arcade games…" : ArcadeView.load-state == ArcadeLoadState.failed ? "Arcade library unavailable." : "No Arcade games found.";
     background: #1a1424;
 
     if ArcadeView.drawer-open : Rectangle {
@@ -328,6 +329,23 @@ export component ArcadeListScreen inherits Rectangle {
             y: LauncherLayout.arcade-list.y * 1px + LauncherLayout.arcade-list.height * 1px + 8px;
             width: parent.width;
             height: parent.height - self.y;
+        }
+    }
+
+    if ArcadeView.search-mode == ArcadeSearchMode.inactive && ArcadeView.load-state != ArcadeLoadState.ready : Rectangle {
+        x: LauncherLayout.arcade-list.x * 1px;
+        y: LauncherLayout.arcade-list.y * 1px;
+        width: LauncherLayout.arcade-list.width * 1px;
+        height: LauncherLayout.arcade-list.height * 1px;
+        background: #120d1a;
+        accessible-role: text;
+        accessible-label: root.library-status;
+        VerticalLayout {
+            alignment: center;
+            spacing: 10px;
+            Spleen6x12 { text: root.library-status; color: #c4b4d4; horizontal-alignment: center; wrap: word-wrap; }
+            Spleen6x12 { text: root.games-loading ? "" : "Use Library Refresh in Settings."; color: #a090b0; horizontal-alignment: center; wrap: word-wrap; }
+            Spleen6x12 { text: "B Back   HOME Launcher"; color: #a090b0; horizontal-alignment: center; }
         }
     }
 

--- a/crates/catalog/src/preview_worker.rs
+++ b/crates/catalog/src/preview_worker.rs
@@ -80,7 +80,26 @@ impl PreviewPriority {
 }
 
 #[derive(Clone, Debug)]
+pub struct PreviewDiagnostic {
+    pub stage: &'static str,
+    pub code: &'static str,
+    pub detail: String,
+    pub expected_bytes: Option<u64>,
+    pub actual_bytes: Option<u64>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PreviewDiagnostics {
+    pub resolved_archive_path: String,
+    pub failure: Option<PreviewDiagnostic>,
+    /// The index failure which caused fallback, whether fallback then succeeds or fails.
+    pub index_fallback: Option<PreviewDiagnostic>,
+}
+
+#[derive(Clone, Debug)]
 pub struct PreviewResult {
+    // Keep mailbox and scheduler messages small as diagnostic context grows.
+    pub diagnostics: Box<PreviewDiagnostics>,
     pub generation: u64,
     pub title: String,
     pub preview_archive_path: String,
@@ -935,6 +954,10 @@ fn load_preview(
     let resize = config.resize();
     let storage = config.storage_format();
     let resolved_archive_path = resolve_preview_archive_path(&req.preview_archive_path);
+    scratch.diagnostic_stage = "resolve";
+    scratch.index_failure = None;
+    scratch.expected_bytes = None;
+    scratch.actual_bytes = None;
     let cache_key = preview_cache_key(&resolved_archive_path, &req.preview_asset_key, resize);
     let mut cache_hit = false;
     let queue_age_us = req.requested_at.elapsed().as_micros() as u64;
@@ -1012,6 +1035,11 @@ fn load_preview(
             }
             let decoded_bytes = loaded.image.decoded_bytes();
             PreviewResult {
+                diagnostics: Box::new(PreviewDiagnostics {
+                    resolved_archive_path,
+                    failure: None,
+                    index_fallback: scratch.index_failure.take(),
+                }),
                 generation: req.generation,
                 title: req.title,
                 preview_archive_path: req.preview_archive_path,
@@ -1054,6 +1082,17 @@ fn load_preview(
                 );
             }
             PreviewResult {
+                diagnostics: Box::new(PreviewDiagnostics {
+                    resolved_archive_path,
+                    failure: Some(PreviewDiagnostic {
+                        stage: scratch.diagnostic_stage,
+                        code: "preview_load_failed",
+                        detail: e.chars().take(384).collect(),
+                        expected_bytes: scratch.expected_bytes,
+                        actual_bytes: scratch.actual_bytes,
+                    }),
+                    index_fallback: scratch.index_failure.take(),
+                }),
                 generation: req.generation,
                 title: req.title,
                 preview_archive_path: req.preview_archive_path,
@@ -1242,10 +1281,12 @@ fn load_raw565_preview_asset_timed(
 ) -> Result<LoadedPreviewPixels, String> {
     let archive_path = preview_archive_path.trim();
     let asset_key = preview_asset_key.trim();
+    scratch.diagnostic_stage = "identity";
     if archive_path.is_empty() || asset_key.is_empty() {
         return Err("preview asset missing archive path or key".to_string());
     }
     let entry_name = format!("{asset_key}.rgb565");
+    scratch.diagnostic_stage = "archive";
     if archive_mem_primary
         && let Some(loaded) =
             load_raw565_preview_asset_from_archive_mem(archive_path, &entry_name, scratch)?
@@ -1263,13 +1304,23 @@ fn load_raw565_preview_asset_timed(
                 return Ok(loaded);
             }
             PreviewIndexLoad::MissingEntry => {
+                scratch.diagnostic_stage = "index_entry";
                 return Err(format!(
                     "preview asset {entry_name} missing from index for archive {archive_path}"
                 ));
             }
-            PreviewIndexLoad::NoSidecar => {}
+            PreviewIndexLoad::NoSidecar => {
+                scratch.index_failure = Some(PreviewDiagnostic {
+                    stage: "index_lookup",
+                    code: "index_missing",
+                    detail: "No sidecar; attempting archive fallback".into(),
+                    expected_bytes: None,
+                    actual_bytes: None,
+                });
+            }
         }
     }
+    scratch.diagnostic_stage = "archive_fallback";
     if let Some(loaded) =
         load_raw565_preview_asset_from_archive_mem(archive_path, &entry_name, scratch)?
     {
@@ -1332,6 +1383,10 @@ struct PreviewArchive {
 #[derive(Default)]
 struct PreviewArchiveScratch {
     index_pread_file: Option<CachedIndexPreadFile>,
+    diagnostic_stage: &'static str,
+    index_failure: Option<PreviewDiagnostic>,
+    expected_bytes: Option<u64>,
+    actual_bytes: Option<u64>,
 }
 
 struct CachedIndexPreadFile {
@@ -2180,6 +2235,13 @@ fn try_load_raw565_preview_asset_from_index(
     match load_raw565_preview_asset_from_index(archive_path, entry_name, scratch) {
         Ok(loaded) => Some(loaded),
         Err(error) => {
+            scratch.index_failure = Some(PreviewDiagnostic {
+                stage: scratch.diagnostic_stage,
+                code: "index_fallback",
+                detail: error.chars().take(384).collect(),
+                expected_bytes: scratch.expected_bytes,
+                actual_bytes: scratch.actual_bytes,
+            });
             if preview_trace_enabled() {
                 crate::catalog_errln!(
                     "preview_trace index_pread_failed archive_path={} asset_key={} error={}",
@@ -2198,6 +2260,7 @@ fn load_raw565_preview_asset_from_index(
     entry_name: &str,
     scratch: &mut PreviewArchiveScratch,
 ) -> Result<PreviewIndexLoad, String> {
+    scratch.diagnostic_stage = "index_lookup";
     let Some(sidecar) = preview_archive_sidecar_lookup(archive_path)? else {
         return Ok(PreviewIndexLoad::NoSidecar);
     };
@@ -2208,6 +2271,9 @@ fn load_raw565_preview_asset_from_index(
     let total_t = Instant::now();
     let read_t = Instant::now();
     let mut payload = vec![0u8; entry.compressed_len];
+    scratch.diagnostic_stage = "index_read";
+    scratch.expected_bytes = Some(entry.compressed_len as u64);
+    scratch.actual_bytes = None;
     let file = scratch.index_pread_file(archive_path, &sidecar.archive_fingerprint)?;
     read_exact_at(file, &mut payload, entry.offset)
         .map_err(|e| format!("pread preview archive {}: {e}", archive_path.display()))?;
@@ -2215,12 +2281,15 @@ fn load_raw565_preview_asset_from_index(
 
     let decode_t = Instant::now();
     let decode_cpu_t = thread_cpu_us();
+    scratch.diagnostic_stage = "decode";
+    scratch.actual_bytes = Some(payload.len() as u64);
     let words = decode_preview_archive_entry_words(&payload, entry)
         .map_err(|e| format!("preview archive index decode {entry_name}: {e}"))?;
     let decode_us = decode_t.elapsed().as_micros() as u64;
     let decode_cpu_us = elapsed_thread_cpu_us(decode_cpu_t);
     let parse_t = Instant::now();
     let parse_cpu_t = thread_cpu_us();
+    scratch.diagnostic_stage = "geometry";
     let image = decode_pixel_preview_words(entry, words)?;
     let raw565_parse_us = parse_t.elapsed().as_micros() as u64;
     let raw565_parse_cpu_us = elapsed_thread_cpu_us(parse_cpu_t);
@@ -2670,8 +2739,9 @@ impl PreviewArchive {
     fn load_timed(
         &self,
         name: &str,
-        _scratch: &mut PreviewArchiveScratch,
+        scratch: &mut PreviewArchiveScratch,
     ) -> Result<Option<LoadedPreviewPixels>, String> {
+        scratch.diagnostic_stage = "archive_entry";
         let key = name.to_ascii_lowercase();
         let Some(entry) = self.entries.get(&key).copied() else {
             return Ok(None);
@@ -2679,6 +2749,9 @@ impl PreviewArchive {
         let total_t = Instant::now();
         let read_t = Instant::now();
         let start = entry.offset as usize;
+        scratch.diagnostic_stage = "archive_read";
+        scratch.expected_bytes = Some(entry.compressed_len as u64);
+        scratch.actual_bytes = None;
         let end = start
             .checked_add(entry.compressed_len)
             .ok_or_else(|| format!("preview archive offset overflow {name}"))?;
@@ -2690,12 +2763,15 @@ impl PreviewArchive {
 
         let decode_t = Instant::now();
         let decode_cpu_t = thread_cpu_us();
+        scratch.diagnostic_stage = "decode";
+        scratch.actual_bytes = Some(compressed_slice.len() as u64);
         let words = decode_preview_archive_entry_words(compressed_slice, entry)
             .map_err(|e| format!("preview archive lz4 decode {name}: {e}"))?;
         let decode_us = decode_t.elapsed().as_micros() as u64;
         let decode_cpu_us = elapsed_thread_cpu_us(decode_cpu_t);
         let parse_t = Instant::now();
         let parse_cpu_t = thread_cpu_us();
+        scratch.diagnostic_stage = "geometry";
         let image = decode_pixel_preview_words(entry, words)?;
         let raw565_parse_us = parse_t.elapsed().as_micros() as u64;
         let raw565_parse_cpu_us = elapsed_thread_cpu_us(parse_cpu_t);
@@ -3331,6 +3407,15 @@ mod tests {
         );
         assert_eq!(result.preview_asset_key, "missing");
         assert!(result.image.is_none());
+        let failure = result
+            .diagnostics
+            .failure
+            .as_ref()
+            .expect("structured failure");
+        assert_eq!(failure.code, "preview_load_failed");
+        assert!(!failure.stage.is_empty());
+        assert!(!failure.detail.is_empty());
+        assert!(failure.detail.chars().count() <= 384);
         assert_eq!(result.decoded_bytes, 0);
         assert_eq!(result.source_width, 0);
         assert_eq!(result.source_height, 0);
@@ -3777,6 +3862,12 @@ mod tests {
         .expect("fall back to full archive");
 
         assert_eq!(loaded.timing.load_source, PreviewLoadSource::ArchiveMem);
+        let diagnostic = scratch
+            .index_failure
+            .as_ref()
+            .expect("fallback retains original failure");
+        assert_eq!(diagnostic.stage, "index_lookup");
+        assert_eq!(diagnostic.code, "index_fallback");
         let _ = std::fs::remove_file(preview_archive_sidecar_path(&path));
         let _ = std::fs::remove_file(path);
     }

--- a/docs/device.md
+++ b/docs/device.md
@@ -1,5 +1,40 @@
 # Device operations and recovery
 
+## Screenshot support reports
+
+Screenshot diagnostics are local only. Collect them before uninstalling with
+`scripts/agent device diagnostics --out /absolute/path/to/support-bundle`.
+The bundle includes `media-diagnostics-live.json` when available and
+`media-diagnostics-latest.json` for the most recent saved failure. Old devices
+without these fields remain compatible. Review a bundle before sharing it;
+the broader device bundle has information beyond the media reports.
+
+The live report is `/tmp/mister-magik/media-diagnostics.json`. Persistent
+reports live under the active installation's `diagnostics/media/` directory
+and use schema `mister-magik-media-diagnostics-v1`. There are at most five
+historical reports plus `latest.json`, each at most 64 KiB. Changed live state
+is published at most once every two seconds; persistent failure snapshots are
+limited to one per minute and sixteen attempts per boot, including failed
+writes. A tmpfs ledger preserves that budget across launcher restarts. Repeated
+failures and dropped queue events are counted. Healthy operation writes no
+persistent media reports, and producers never wait for report IO.
+
+Reports include bounded media events, build/session identity, pack/manifest
+identity, requested/resolved preview paths, decoding stages, index fallback,
+failed-cache suppression and presentation receipts. A decoded or applied image
+does **not** prove it appeared on the physical display. If it remains black,
+include the game/system, approximate time, output route, and a display photo
+or a capture through the supported device capture command below. Do not use
+raw framebuffer reads. No ROM/image contents, credentials, URL query strings,
+automatic screenshots or uploads are included in media reports. Uninstalling
+removes the installation's persistent reports.
+
+Arcade is always reachable, even with zero installed games. Its status panel
+distinguishes loading, an empty library and an unavailable library; Back/Home
+remain usable. Recovery is through Library Refresh in Settings. Entering an
+empty Arcade never creates or rebuilds a catalog, and a late shard result must
+not reopen a screen the user has left.
+
 `scripts/agent device` is the operator interface for MiSTer access. The
 MiSTer-side `mister-magik-agent` remains a separate service. Raw SSH/SCP and
 generic remote-shell orchestration are not accepted interfaces.

--- a/docs/installer.md
+++ b/docs/installer.md
@@ -1,5 +1,13 @@
 # MiSTer MagiK installer and boot-configuration safety
 
+Interactive confirmation accepts Down (`ESC [ B` or `ESC O B`) only. Escape
+sequences may arrive in separate terminal reads; all remaining bytes must arrive
+within a single 100 ms deadline after Escape. Interrupted reads do not extend
+that deadline. Incomplete and unsupported sequences cancel, terminal settings
+are restored, and confirmation still precedes installation writes. Rejected
+escape sequences print a bounded hexadecimal diagnostic, never arbitrary typed
+text. This addresses fragmented input, not every possible controller mapping.
+
 `Scripts/MiSTer-MagiK.sh` is only the stable MiSTer Scripts, Downloader, and
 update_all entrypoint. It verifies the fixed path and SHA-256 of
 `mister-magik-manager` from `platform-v3.manifest`, then replaces itself with

--- a/mister/tools/agent/src/main.rs
+++ b/mister/tools/agent/src/main.rs
@@ -3388,6 +3388,11 @@ mod linux {
             },
             "crashes": crash_reports_json(),
             "catalog_failures": catalog_failure_reports_json(),
+            "media_diagnostics": latest_diagnostic_report(
+                &["/media/fat/mister-magik/diagnostics/media/latest.json", "/media/fat/mister-magik-dev/diagnostics/media/latest.json"],
+                "updated_unix_ms",
+            ),
+            "media_live": read_text_value("/tmp/mister-magik/media-diagnostics.json"),
             "catalog_progress": latest_diagnostic_report(
                 &CATALOG_PROGRESS_PATHS,
                 "updated_unix_ms",

--- a/mister/tools/manager/src/main.rs
+++ b/mister/tools/manager/src/main.rs
@@ -9,7 +9,7 @@ use std::cell::RefCell;
 use std::collections::{BTreeMap, VecDeque};
 use std::env;
 use std::fs::{self, File, OpenOptions};
-use std::io::{self, IsTerminal, Read, Write};
+use std::io::{self, IsTerminal, Write};
 use std::mem::MaybeUninit;
 use std::os::fd::{AsRawFd, RawFd};
 use std::os::unix::fs::PermissionsExt;
@@ -47,6 +47,7 @@ impl InputDecoder {
         }
     }
 
+    #[cfg(test)]
     fn finish(&self) -> Option<InputEvent> {
         match self.bytes.as_slice() {
             [] => None,
@@ -79,6 +80,7 @@ impl TerminalMode {
         })
     }
 
+    #[cfg(test)]
     fn set_tail_timeout(&mut self) -> io::Result<()> {
         let mut timed = self.original;
         timed.c_lflag &= !(libc::ECHO | libc::ICANON);
@@ -409,7 +411,7 @@ fn read_event(paths: &Paths) -> Result<Option<InputEvent>> {
     }
     let stdin = io::stdin();
     let mut terminal = TerminalMode::enter(stdin.as_raw_fd())?;
-    let result = read_event_bytes(&mut stdin.lock(), &mut terminal);
+    let result = read_event_fd(stdin.as_raw_fd());
     let restore = terminal.restore();
     println!();
     match (result, restore) {
@@ -423,20 +425,83 @@ fn read_event(paths: &Paths) -> Result<Option<InputEvent>> {
     }
 }
 
-fn read_event_bytes(input: &mut impl Read, terminal: &mut TerminalMode) -> Result<InputEvent> {
-    let mut first = [0_u8; 1];
-    input.read_exact(&mut first)?;
+fn read_event_fd(fd: RawFd) -> Result<InputEvent> {
     let mut decoder = InputDecoder::default();
-    if let Some(event) = decoder.push(&first) {
-        return Ok(event);
+    let mut escape_started: Option<Instant> = None;
+    loop {
+        let timeout = if let Some(started) = escape_started {
+            let remaining = Duration::from_millis(100).saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                log_rejected_escape(&decoder, started, "timeout");
+                return Ok(InputEvent::Cancel);
+            }
+            remaining.as_millis().max(1) as i32
+        } else {
+            -1
+        };
+        let mut descriptor = libc::pollfd {
+            fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        // SAFETY: descriptor is valid writable storage for one pollfd.
+        let ready = unsafe { libc::poll(&mut descriptor, 1, timeout) };
+        if ready < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error.into());
+        }
+        if ready == 0 {
+            continue;
+        }
+        if let Some(started) = escape_started
+            && started.elapsed() >= Duration::from_millis(100)
+        {
+            log_rejected_escape(&decoder, started, "timeout");
+            return Ok(InputEvent::Cancel);
+        }
+        let mut byte = [0_u8; 1];
+        // Unbuffered reads are essential: poll cannot see bytes held by StdinLock.
+        // SAFETY: byte is writable storage and fd is borrowed for this call.
+        let count = unsafe { libc::read(fd, byte.as_mut_ptr().cast(), 1) };
+        if count < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+            return Err(error.into());
+        }
+        if count == 0 {
+            return Ok(InputEvent::Cancel);
+        }
+        if byte[0] == 0x1b && escape_started.is_none() {
+            escape_started = Some(Instant::now());
+        }
+        if let Some(event) = decoder.push(&byte) {
+            if event == InputEvent::Cancel
+                && let Some(started) = escape_started
+            {
+                log_rejected_escape(&decoder, started, "unsupported");
+            }
+            return Ok(event);
+        }
     }
-    let mut tail = [0_u8; 2];
-    terminal.set_tail_timeout()?;
-    let count = input.read(&mut tail)?;
-    decoder
-        .push(&tail[..count])
-        .or_else(|| decoder.finish())
-        .ok_or_else(|| "interactive input ended before a complete event".into())
+}
+
+fn log_rejected_escape(decoder: &InputDecoder, started: Instant, reason: &str) {
+    let bytes = decoder
+        .bytes
+        .iter()
+        .take(3)
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    eprintln!(
+        "terminal_input rejected={reason} elapsed_ms={} escape_hex={bytes}",
+        started.elapsed().as_millis()
+    );
 }
 
 fn effective(path: &Path, section: &str, key: &str) -> Result<Option<String>> {
@@ -1299,6 +1364,58 @@ mod tests {
             }
             assert_eq!(event, Some(InputEvent::Down));
         }
+    }
+
+    #[test]
+    fn terminal_accepts_fragmented_arrows_and_restores_settings() {
+        for sequence in [b"\x1b[B", b"\x1bOB", b"\x1b[A", b"\x1bOA"] {
+            for split in 1..sequence.len() {
+                let (master, slave) = pseudo_terminal();
+                let original = terminal_settings(slave.as_raw_fd()).unwrap();
+                let mode = TerminalMode::enter(slave.as_raw_fd()).unwrap();
+                let bytes = *sequence;
+                let writer = std::thread::spawn(move || {
+                    let mut master = File::from(master);
+                    master.write_all(&bytes[..split]).unwrap();
+                    std::thread::sleep(Duration::from_millis(10));
+                    master.write_all(&bytes[split..]).unwrap();
+                    master
+                });
+                let expected = if sequence[2] == b'B' {
+                    InputEvent::Down
+                } else {
+                    InputEvent::Up
+                };
+                assert_eq!(read_event_fd(slave.as_raw_fd()).unwrap(), expected);
+                let _master = writer.join().unwrap();
+                drop(mode);
+                assert_terminal_settings_eq(
+                    &original,
+                    &terminal_settings(slave.as_raw_fd()).unwrap(),
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn terminal_escape_timeout_is_one_deadline() {
+        let (master, slave) = pseudo_terminal();
+        let _mode = TerminalMode::enter(slave.as_raw_fd()).unwrap();
+        let writer = std::thread::spawn(move || {
+            let mut master = File::from(master);
+            master.write_all(b"\x1b").unwrap();
+            std::thread::sleep(Duration::from_millis(70));
+            master.write_all(b"[").unwrap();
+            master
+        });
+        let started = Instant::now();
+        assert_eq!(
+            read_event_fd(slave.as_raw_fd()).unwrap(),
+            InputEvent::Cancel
+        );
+        let _master = writer.join().unwrap();
+        assert!(started.elapsed() >= Duration::from_millis(95));
+        assert!(started.elapsed() < Duration::from_millis(160));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Read fragmented installer arrow sequences within one 100 ms deadline while preserving fail-closed confirmation and terminal restoration.
- Keep Arcade accessible with no games, loading shards or failed hydration. Show explicit status and Back/Home guidance; allow publication to recover the open screen.
- Preserve structured preview failure and index-fallback context; add bounded local media reports, curl diagnostics, and support-bundle export.

Related to #72. The reported controller bytes and physical screenshot failure have not been reproduced on hardware.

## Validation
- Installer: 21 tests passed, including PTY fragmentation and timeout cases.
- Navigation: 144 tests passed; launcher loop: 179 passed.
- Preview worker: 56 tests passed; media: 77 passed; explicit Arcade state: 2 passed; bounded report writer: 4 passed.
- Support-bundle export test passed; device agent host test target compiled.
- Eight Slint tests passed in separate processes after the combined run hit the existing single-thread platform restriction.
- Empty-card HDMI, CRT and portrait renders inspected.
- Pre-commit and pre-push gates passed. Full Clippy is not clean; CI is authoritative. Worktree LSP access and embedded MCP interaction coverage were unavailable.

No device deployment or automatic uploads. Persistent media reports are capped at five plus latest, 64 KiB each, one snapshot per minute and sixteen attempts per boot.