### PR TITLE
fix(agent): derive cross test toolchain from config

### DIFF
--- a/agent-cli/src/build.rs
+++ b/agent-cli/src/build.rs
@@ -2221,7 +2221,7 @@ mod tests {
                 .filter_map(|(key, value)| value.map(|value| (key.to_owned(), value.to_owned())))
                 .collect();
             let expected_config = repository.join("apps/mister/Cross.toml").into_os_string();
-            let expected_toolchain = OsString::from("1.98.0");
+            let expected_toolchain = OsString::from(rust_toolchain_channel(repository).unwrap());
             assert_eq!(
                 environment.get(OsStr::new("CROSS_CONFIG")),
                 Some(&expected_config)


### PR DESCRIPTION
Keeps the cross-toolchain assertion aligned with apps/mister/rust-toolchain.toml so toolchain updates remain testable.