### PR TITLE
fix(ci): pass FFmpeg headers to cross host probe

### DIFF
--- a/.github/workflows/rust-arm.yml
+++ b/.github/workflows/rust-arm.yml
@@ -256,7 +256,13 @@ jobs:
         uses: actions/cache@v6
         with:
           path: apps/mister/target/ffmpeg-minimal/armv7
-          key: ffmpeg-minimal-v2-${{ runner.os }}-${{ runner.arch }}-armv7-unknown-linux-gnueabihf-8.1.2-${{ steps.cache-id.outputs.cross_abi }}-${{ steps.cache-id.outputs.ffmpeg }}
+          # FFmpeg depends on its recipe and cross image, not the Rust toolchain.
+          # Keep the recipe hash ahead of the Rust-derived cache identity so a
+          # toolchain-only update restores this expensive, complete prefix.
+          key: ffmpeg-minimal-v3-${{ runner.os }}-${{ runner.arch }}-armv7-unknown-linux-gnueabihf-8.1.2-${{ steps.cache-id.outputs.ffmpeg }}-${{ steps.cache-id.outputs.cross_abi }}
+          restore-keys: |
+            ffmpeg-minimal-v3-${{ runner.os }}-${{ runner.arch }}-armv7-unknown-linux-gnueabihf-8.1.2-${{ steps.cache-id.outputs.ffmpeg }}-
+            ffmpeg-minimal-v2-${{ runner.os }}-${{ runner.arch }}-armv7-unknown-linux-gnueabihf-8.1.2-
 
       - name: Cache ARM build outputs
         uses: actions/cache@v6

--- a/scripts/magik_ci/build.py
+++ b/scripts/magik_ci/build.py
@@ -45,7 +45,8 @@ def _environment(
     environment["RUSTFLAGS"] = rustflags
 
     if runner == "cross" and intent in {"runtime-ci", "runtime-device"}:
-        dist = repository / "apps/mister/target/ffmpeg-minimal/armv7/dist"
+        # cross mounts the repository at /project, not at the host checkout path.
+        dist = Path("/project/apps/mister/target/ffmpeg-minimal/armv7/dist")
         include = dist / "include"
         environment.update(
             {

--- a/scripts/magik_ci/build.py
+++ b/scripts/magik_ci/build.py
@@ -54,6 +54,7 @@ def _environment(
                 "PKG_CONFIG_ALLOW_CROSS": "1",
                 "CFLAGS": f"-I{include}",
                 "HOST_CFLAGS": f"-I{include}",
+                "CFLAGS_x86_64_unknown_linux_gnu": f"-I{include}",
             }
         )
     return environment

--- a/scripts/tests/test_magik_ci.py
+++ b/scripts/tests/test_magik_ci.py
@@ -310,21 +310,26 @@ import scripts.magik_ci.cli
             ("apps/mister/Cargo.toml", "all", ""),
         )
 
-    def test_cross_runtime_environment_supplies_ffmpeg_headers_to_host_probes(
+    def test_cross_runtime_environment_uses_container_ffmpeg_paths(
         self,
     ) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
-            include = root / "apps/mister/target/ffmpeg-minimal/armv7/dist/include"
             with patch.dict(os.environ, {}, clear=True):
                 environment = build._environment(
                     root, "runtime-ci", "ci-fast", "ui", "cross"
                 )
 
-            expected = f"-I{include}"
+            dist = Path("/project/apps/mister/target/ffmpeg-minimal/armv7/dist")
+            expected = f"-I{dist / 'include'}"
+            self.assertEqual(environment["FFMPEG_DIR"], str(dist))
+            self.assertEqual(
+                environment["PKG_CONFIG_PATH"], str(dist / "lib/pkgconfig")
+            )
             self.assertEqual(environment["CFLAGS"], expected)
             self.assertEqual(environment["HOST_CFLAGS"], expected)
             self.assertEqual(environment["CFLAGS_x86_64_unknown_linux_gnu"], expected)
+            self.assertNotIn(str(root), environment["FFMPEG_DIR"])
 
     def test_build_writes_artifact_identity_sidecars(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/scripts/tests/test_magik_ci.py
+++ b/scripts/tests/test_magik_ci.py
@@ -310,6 +310,22 @@ import scripts.magik_ci.cli
             ("apps/mister/Cargo.toml", "all", ""),
         )
 
+    def test_cross_runtime_environment_supplies_ffmpeg_headers_to_host_probes(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            include = root / "apps/mister/target/ffmpeg-minimal/armv7/dist/include"
+            with patch.dict(os.environ, {}, clear=True):
+                environment = build._environment(
+                    root, "runtime-ci", "ci-fast", "ui", "cross"
+                )
+
+            expected = f"-I{include}"
+            self.assertEqual(environment["CFLAGS"], expected)
+            self.assertEqual(environment["HOST_CFLAGS"], expected)
+            self.assertEqual(environment["CFLAGS_x86_64_unknown_linux_gnu"], expected)
+
     def test_build_writes_artifact_identity_sidecars(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)


### PR DESCRIPTION
Sets the x86_64 host-probe CFLAGS that ffmpeg-sys-next uses inside cross, with a regression test. Restores the main ARM runtime build after the Rust 1.98.1 update.