### PR TITLE
Start Rust LSP with the pinned runtime in each checkout

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -9,22 +9,7 @@ model_reasoning_summary = "concise"
 model_verbosity = "low"
 
 [mcp_servers.magik-rust-lsp]
-command = "./scripts/cargo"
-args = [
-  "run",
-  "--quiet",
-  "--locked",
-  "--manifest-path",
-  "private/lspi/Cargo.toml",
-  "-p",
-  "lspi",
-  "--",
-  "mcp",
-  "--workspace-root",
-  ".",
-  "--config",
-  ".codex/lspi.toml",
-]
+command = "./scripts/rust-lsp"
 required = false
 startup_timeout_sec = 120
 enabled_tools = [

--- a/.codex/skills/magik-rust-lsp/SKILL.md
+++ b/.codex/skills/magik-rust-lsp/SKILL.md
@@ -33,3 +33,13 @@ and `max_total_chars=10000`. If incomplete, use ordinary patches. Otherwise:
 If MCP is unavailable or fails once, report reduced semantic assurance and
 fall back to source navigation and focused Cargo validation. Do not repeatedly
 retry or broaden allowed roots to unrelated directories.
+
+## Runtime startup
+
+`scripts/rust-lsp` prepares this checkout's pinned `private/lspi` revision and
+passes explicit workspace/config paths. It refuses to overwrite local submodule
+edits. After updating the launching checkout or MCP configuration, restart the
+MCP session; an already-running server does not reload these changes. Rebasing
+a different worktree cannot update a server launched from an older checkout.
+If worktree routing is rejected, compare the launching checkout and its config
+with the intended branch before changing allowed roots.

--- a/scripts/rust-lsp
+++ b/scripts/rust-lsp
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+# Use this checkout's dependency, not a possibly stale primary-checkout copy.
+expected="$(git rev-parse HEAD:private/lspi)"
+if [[ "$(git rev-parse :private/lspi)" != "$expected" ]]; then
+  echo "Rust LSP: commit the staged private/lspi revision before starting the pinned runtime." >&2
+  exit 1
+fi
+if [[ -e private/lspi/.git ]]; then
+  actual="$(git -C private/lspi rev-parse HEAD)"
+  if [[ -n "$(git -C private/lspi status --porcelain)" ]]; then
+    echo "Rust LSP: private/lspi has local changes; preserve or commit them before starting the pinned runtime." >&2
+    exit 1
+  fi
+else
+  actual=""
+fi
+if [[ "$actual" != "$expected" ]]; then
+  git submodule update --init --checkout -- private/lspi >&2
+fi
+if [[ "$(git -C private/lspi rev-parse HEAD)" != "$expected" ]]; then
+  echo "Rust LSP: private/lspi does not match this checkout's committed revision." >&2
+  exit 1
+fi
+
+exec "$ROOT/scripts/cargo" run --quiet --locked \
+  --manifest-path "$ROOT/private/lspi/Cargo.toml" -p lspi -- \
+  mcp --workspace-root "$ROOT" --config "$ROOT/.codex/lspi.toml"

--- a/scripts/tests/test_rust_lsp_startup.py
+++ b/scripts/tests/test_rust_lsp_startup.py
@@ -1,0 +1,110 @@
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Exercise pinned LSP startup using temporary local Git repositories."""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+
+LAUNCHER = Path(__file__).resolve().parents[1] / "rust-lsp"
+
+
+class RustLspStartupTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.root = Path(self.temp.name)
+        self.env = {
+            **os.environ,
+            "GIT_ALLOW_PROTOCOL": "file",
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.invalid",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.invalid",
+        }
+        self.source = self.root / "source"
+        self.source.mkdir()
+        self.git(self.source, "init", "-q")
+        (self.source / "runtime").write_text("old")
+        self.git(self.source, "add", ".")
+        self.git(self.source, "commit", "-qm", "old")
+        self.old = self.git(self.source, "rev-parse", "HEAD").stdout.strip()
+        (self.source / "runtime").write_text("pinned")
+        self.git(self.source, "commit", "-qam", "pinned")
+        self.repo = self.root / "repo"
+        self.repo.mkdir()
+        self.git(self.repo, "init", "-q")
+        self.git(self.repo, "submodule", "add", str(self.source), "private/lspi")
+        (self.repo / "scripts").mkdir()
+        shutil.copy2(LAUNCHER, self.repo / "scripts/rust-lsp")
+        cargo = self.repo / "scripts/cargo"
+        cargo.write_text('#!/bin/bash\nprintf "%s\\n" "$@"\n')
+        cargo.chmod(0o755)
+        self.git(self.repo, "add", ".")
+        self.git(self.repo, "commit", "-qm", "fixture")
+
+    def git(self, cwd, *args):
+        return subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            env=self.env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+
+    def launch(self, repo=None):
+        return subprocess.run(
+            [str((repo or self.repo) / "scripts/rust-lsp")],
+            cwd=self.root,
+            env=self.env,
+            text=True,
+            capture_output=True,
+        )
+
+    def test_clean_stale_runtime_is_updated_to_pin(self):
+        runtime = self.repo / "private/lspi"
+        self.git(runtime, "checkout", "--detach", self.old)
+        result = self.launch()
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((runtime / "runtime").read_text(), "pinned")
+        self.assertIn(str(self.repo / ".codex/lspi.toml"), result.stdout)
+        self.assertNotIn("Submodule", result.stdout)
+
+    def test_staged_dependency_change_is_preserved(self):
+        runtime = self.repo / "private/lspi"
+        self.git(runtime, "checkout", "--detach", self.old)
+        self.git(self.repo, "add", "private/lspi")
+        result = self.launch()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("staged", result.stderr)
+        self.assertEqual(
+            self.git(runtime, "rev-parse", "HEAD").stdout.strip(), self.old
+        )
+
+    def test_local_edits_are_preserved(self):
+        runtime_file = self.repo / "private/lspi/runtime"
+        runtime_file.write_text("user edit")
+        result = self.launch()
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("local changes", result.stderr)
+        self.assertEqual(runtime_file.read_text(), "user edit")
+        self.assertEqual(result.stdout, "")
+
+    def test_linked_worktree_initializes_its_own_runtime(self):
+        linked = self.root / "linked"
+        self.git(self.repo, "worktree", "add", "--detach", str(linked))
+        result = self.launch(linked)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual((linked / "private/lspi/runtime").read_text(), "pinned")
+        self.assertIn(str(linked / "private/lspi/Cargo.toml"), result.stdout)
+        self.assertIn(str(linked / ".codex/lspi.toml"), result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_rust_lsp_startup.py
+++ b/scripts/tests/test_rust_lsp_startup.py
@@ -4,12 +4,11 @@
 """Exercise pinned LSP startup using temporary local Git repositories."""
 
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import tempfile
 import unittest
-
+from pathlib import Path
 
 LAUNCHER = Path(__file__).resolve().parents[1] / "rust-lsp"
 
@@ -61,6 +60,7 @@ class RustLspStartupTests(unittest.TestCase):
     def launch(self, repo=None):
         return subprocess.run(
             [str((repo or self.repo) / "scripts/rust-lsp")],
+            check=False,
             cwd=self.root,
             env=self.env,
             text=True,


### PR DESCRIPTION
MCP startup could run an older `private/lspi` checkout even though the parent repository already pinned the linked-worktree fix. A server launched from an older primary checkout then rejected files in registered worktrees.

Route Codex startup through `scripts/rust-lsp`: initialize or update only the clean LSP dependency to the committed pin, preserve local edits and staged gitlink changes, and pass explicit paths for this checkout's workspace and configuration. Bootstrap output goes to stderr so MCP stdout remains clean. Document that existing MCP sessions need restarting and that rebasing a different worktree cannot update an already-running server.

Validation:
- Four temporary-repository regression tests passed: stale clean dependency, local edits, staged dependency changes, and a fresh linked worktree.
- A real newly launched MCP process accepted diagnostics for another registered worktree and returned `workspace_root=/Users/nigelb/slint/mister-slint-mini-magik`, `ok=true`, without the former allowed-root error. This verifies routing, not full application assurance.
- Python formatting, shell syntax and commit checks passed. No device tests or broad Cargo assurance.

After merge, update the checkout from which Codex launches MCP and restart that MCP session. This PR cannot hot-replace the runtime already attached to an existing conversation.
