### PR TITLE
Make 2.0 the everyday MagiK development workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,13 @@ manifest and adjacent lockfile.
 
 ## Operations
 
-Use typed `scripts/agent deliver`, `benchmark`, `diagnose`, and `db report`;
+For ordinary application development, use `scripts/magik2 deploy`, `check`, and
+`watch`; real MagiK is the default, Mini uses `--app mini-magik`. `check` runs
+one smoke journey; request idle/motion measurements or profiling explicitly.
+Use the 2.0 exception below. Do not route ordinary app development through 1.0.
+
+For retained platform/release and legacy operations, use typed
+`scripts/agent deliver`, `benchmark`, `diagnose`, and `db report`;
 human device operations use attended `scripts/agent device`. Never use raw
 SSH/SCP, generic remote shells, or ad-hoc SQL. Device, Apple-container, and
 virtualization commands require first-attempt escalation. Retry read-only
@@ -42,7 +48,7 @@ arming, bounded timeouts, interruption-safe cleanup, verified disarming, and
 non-network recovery are mandatory. Never leave persistent/unattended reboot
 loops or replay diagnosis's one-shot reboot; stop on reboot/SSH instability.
 
-“Build and deploy” means commit then deliver the exact clean app revision with
+“Build and deploy” for retained 1.0 platform/release work means commit then deliver the exact clean app revision with
 the latest qualified platform. Replace runtime and regenerated
 `platform-v3.manifest` transactionally. Local Main delivery requires committed
 Dev Main work. Release qualification requires an explicit attended request.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ Only the MagiK launcher belongs in the Scripts menu. See
 [installer safety and upgrade notes](docs/installer.md) for the obsolete
 constants helper and failed-package recovery.
 
+## Application development
+
+Use `scripts/magik2 deploy`, `scripts/magik2 check`, and `scripts/magik2 watch`.
+These target the real development app and `/media/fat/mister-magik-dev` data.
+Use `--app mini-magik` for the fast experiment. The default check is one smoke
+journey; benchmarks and profiles are explicit. See [development setup and
+commands](magik2/README.md). Production installation above is a separate workflow.
+
 ## Built With Slint
 
 MiSTer MagiK is built with [Slint](https://slint.dev), a modern declarative UI

--- a/apps/mister/src/ui_runner/launcher_loop.rs
+++ b/apps/mister/src/ui_runner/launcher_loop.rs
@@ -5009,6 +5009,8 @@ pub(super) fn run_launcher_loop(
     launcher_config: mister_magik_fb::process_config::LauncherProcessConfig,
 ) {
     let launcher_ui_actions = LauncherUiActionsAdapter::install(&app);
+    #[cfg(feature = "magik2")]
+    app.set_development_keyboard_input(true);
     let start = Instant::now();
     #[cfg(feature = "ui-device-tests")]
     let ui_test_fixture = std::env::var(crate::ui_test_support::FIXTURE_ENV)

--- a/apps/mister/ui/launcher.slint
+++ b/apps/mister/ui/launcher.slint
@@ -111,6 +111,24 @@ export component Launcher inherits MisterWindow {
     accessible-enabled: true;
     accessible-description: NavigationView.menu-title;
 
+    // Development events use the same bounded action queue as UI intents.
+    in property <bool> development-keyboard-input: false;
+    forward-focus: development-keys;
+    development-keys := FocusScope {
+        key-pressed(event) => {
+            if !root.development-keyboard-input { return reject; }
+            if event.text == Key.Home { LauncherActions.home(); }
+            else if event.text == Key.UpArrow { LauncherActions.navigate(NavigationDirection.up); }
+            else if event.text == Key.DownArrow { LauncherActions.navigate(NavigationDirection.down); }
+            else if event.text == Key.LeftArrow { LauncherActions.navigate(NavigationDirection.left); }
+            else if event.text == Key.RightArrow { LauncherActions.navigate(NavigationDirection.right); }
+            else if event.text == Key.Return { LauncherActions.activate(); }
+            else if event.text == Key.Escape { LauncherActions.back(); }
+            else { return reject; }
+            accept
+        }
+    }
+
     if MisterUi.crt-layout : CrtLauncherUi { }
     if !MisterUi.crt-layout : HdmiLauncherUi { }
 

--- a/magik2/ACCEPTANCE.md
+++ b/magik2/ACCEPTANCE.md
@@ -69,7 +69,8 @@ publication stays responsive with a bounded latest-frame slot.
 - Latest recovery and viewer-on checks used the final device implementation.
   The user ended further acceptance before another profile repetition.
 
-Run `scripts/magik2 check smoke` or `scripts/magik2 check motion --profile` to
+Run `scripts/magik2 check smoke --app mini-magik` or
+`scripts/magik2 check motion --profile --app mini-magik` to
 reproduce those scenarios. Both use the same consumer pytest tests; profiling
 is an additional labeled repetition, not part of the benchmark distribution.
 

--- a/magik2/AGENTS.md
+++ b/magik2/AGENTS.md
@@ -25,3 +25,8 @@ or invoke `scripts/agent`, `agent-cli`, or `mister/tools/agent`.
   dedicated tooling PR. Probe and scenario changes are consumer changes.
 - Run focused tests only: `uv run --project magik2/host pytest tests -q` and
   `scripts/cargo test --manifest-path magik2/agent/Cargo.toml`.
+
+- Everyday commands default to real MagiK; keep Mini-specific runners explicit
+  with `--app mini-magik`. Default smoke must not expand into benchmark matrices.
+- `legacy-stop` is an explicit migration operation, never an automatic deployment
+  step. Preserve startup files and do not add retry/escalation loops to it.

--- a/magik2/README.md
+++ b/magik2/README.md
@@ -22,19 +22,20 @@ The existing `slint-testing==0.3` private-index authentication must be available
 to uv. Keep credentials in the environment/user credential store, never Git.
 
 ```sh
+# Real development application (default):
 scripts/magik2 deploy
-scripts/magik2 check smoke
-scripts/magik2 check motion
-scripts/magik2 check motion --profile
+scripts/magik2 check
 scripts/magik2 watch
+scripts/magik2 check idle
+scripts/magik2 check idle --profile
 scripts/magik2 status
 scripts/magik2 stop
 
-# Same workflow, real application development copy:
-scripts/magik2 deploy --app magik
-scripts/magik2 check smoke --app magik
-scripts/magik2 check idle --profile --app magik
-scripts/magik2 watch --app magik
+# Fast experiment, through exactly the same tooling:
+scripts/magik2 deploy --app mini-magik
+scripts/magik2 check --app mini-magik
+scripts/magik2 check motion --app mini-magik
+scripts/magik2 check motion --profile --app mini-magik
 ```
 
 `deploy` automatically prepares a checkout-specific Apple container and compiles
@@ -66,8 +67,14 @@ The consumer scenarios live in `scenarios/` and run through pytest:
 
 ```sh
 uv run --project magik2/host pytest magik2/scenarios --collect-only
-uv run --project magik2/host pytest magik2/scenarios --magik2-device -k motion
+uv run --project magik2/host pytest magik2/scenarios --magik2-device --magik2-app mini-magik -k motion
 ```
+
+The real app is the default. `scripts/magik2 check` selects only smoke, including
+Settings navigation; measurements require an explicit scenario. Direct pytest
+selects all ordinary scenarios for its chosen app. Use `--magik2-app mini-magik`
+when invoking Mini scenarios directly. Failures print the result and device-log
+paths; unavailable diagnostics remain recorded as unavailable.
 
 Without `--magik2-device` they skip hardware operations. Mini-MagiK motion has two separate
 unprofiled repetitions, each two seconds warm-up and five measured seconds on

--- a/magik2/README.md
+++ b/magik2/README.md
@@ -149,3 +149,13 @@ MB/s for app-size comparisons; Mini-MagiK compile times are not full-app targets
 
 The completed implementation and hardware evidence are recorded in
 [the milestone evidence](docs/milestone-2.md).
+
+
+## Migration boundary
+
+`legacy-stop` is an explicit one-shot migration operation: it validates and
+signals only the old agent, waits at most three seconds, and leaves startup
+files unchanged. It is never invoked by deploy/check/watch. `status` uses the
+corrected Linux process-name check and reports whether the old agent is running.
+
+See [the everyday milestone](docs/milestone-3.md) and [legacy feature decisions](docs/legacy-disposition.md).

--- a/magik2/agent/src/lib.rs
+++ b/magik2/agent/src/lib.rs
@@ -183,6 +183,7 @@ impl Agent {
             "test-deadline-v2",
             "legacy-isolation-v1",
             "legacy-process-status",
+            "legacy-stop",
         ]
     }
 
@@ -350,7 +351,7 @@ impl Agent {
             let _mutation = self.mutations.lock().expect("mutation state poisoned");
             return self.start_test_session(stream, &request, &body);
         }
-        let replayable = matches!(request.op.as_str(), "start" | "stop");
+        let replayable = matches!(request.op.as_str(), "start" | "stop" | "legacy-stop");
         let _mutation = replayable.then(|| self.mutations.lock().expect("mutation state poisoned"));
         if replayable {
             match self.replayed_response(&request, &body) {
@@ -380,6 +381,18 @@ impl Agent {
             ),
             "start" => self.start(&request),
             "stop" => self.stop(&request),
+            "legacy-stop" => match stop_legacy_agent() {
+                Ok(()) => response(
+                    &request.id,
+                    "legacy-stopped",
+                    serde_json::json!({"legacy_agent_running": false}),
+                ),
+                Err(error) => response(
+                    &request.id,
+                    "error",
+                    serde_json::json!({"code":"legacy-stop", "detail":error.to_string()}),
+                ),
+            },
             "metrics" => self.metrics(&request),
             "measure" => match fs::write(self.state_root.join("measure-request"), b"start") {
                 Ok(()) => response(&request.id, "measurement-requested", serde_json::json!({})),
@@ -1343,6 +1356,61 @@ fn legacy_agent_running() -> bool {
     })
 }
 
+fn stop_legacy_agent() -> io::Result<()> {
+    // Explicit migration operation, never part of ordinary deployment.
+    for entry in fs::read_dir("/proc")? {
+        let entry = entry?;
+        let Some(pid) = entry
+            .file_name()
+            .to_str()
+            .and_then(|name| name.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        if !fs::read_to_string(entry.path().join("comm"))
+            .ok()
+            .is_some_and(|name| is_legacy_agent_comm(name.trim()))
+        {
+            continue;
+        }
+        if pid <= 1 {
+            return Err(io::Error::other("refusing to signal a system process"));
+        }
+        let birth = process_start_ticks(pid)
+            .ok_or_else(|| io::Error::other("legacy process identity unavailable"))?;
+        let executable = fs::read_link(entry.path().join("exe"))?;
+        let name = executable
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("");
+        if name.trim_end_matches(" (deleted)") != "mister-magik-agent" {
+            return Err(io::Error::other(
+                "legacy process executable does not match; not signalled",
+            ));
+        }
+        if process_start_ticks(pid).as_deref() != Some(&birth) {
+            continue;
+        }
+        // SAFETY: positive PID with checked executable and birth identity; one TERM only.
+        if unsafe { libc::kill(pid as libc::pid_t, libc::SIGTERM) } != 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ESRCH) {
+                return Err(error);
+            }
+        }
+    }
+    let deadline = Instant::now() + Duration::from_secs(3);
+    while legacy_agent_running() {
+        if Instant::now() >= deadline {
+            return Err(io::Error::other(
+                "legacy agent did not stop or respawned; startup files were not changed",
+            ));
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+    Ok(())
+}
+
 fn is_legacy_agent_comm(name: &str) -> bool {
     // Linux /proc/PID/comm contains at most 15 bytes, even for a longer binary name.
     let legacy = "mister-magik-agent";
@@ -1395,7 +1463,6 @@ mod tests {
         assert!(!is_legacy_agent_comm(&"mister-magik2-agent"[..15]));
         assert!(!is_legacy_agent_comm("MiSTer_MagiKDev"));
     }
-
 
     #[test]
     fn app_switch_discards_cached_and_inflight_old_previews() {

--- a/magik2/agent/src/lib.rs
+++ b/magik2/agent/src/lib.rs
@@ -182,6 +182,7 @@ impl Agent {
             "test-deadline-v1",
             "test-deadline-v2",
             "legacy-isolation-v1",
+            "legacy-process-status",
         ]
     }
 
@@ -1338,8 +1339,14 @@ fn legacy_agent_running() -> bool {
             .is_some_and(|name| name.bytes().all(|byte| byte.is_ascii_digit()))
             && fs::read_to_string(entry.path().join("comm"))
                 .ok()
-                .is_some_and(|name| name.trim() == "mister-magik-agent")
+                .is_some_and(|name| is_legacy_agent_comm(name.trim()))
     })
+}
+
+fn is_legacy_agent_comm(name: &str) -> bool {
+    // Linux /proc/PID/comm contains at most 15 bytes, even for a longer binary name.
+    let legacy = "mister-magik-agent";
+    name == legacy || name == &legacy[..15]
 }
 
 #[cfg(test)]
@@ -1380,6 +1387,15 @@ fn publish_atomically(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn legacy_process_detection_handles_linux_comm_truncation() {
+        assert!(is_legacy_agent_comm("mister-magik-agent"));
+        assert!(is_legacy_agent_comm(&"mister-magik-agent"[..15]));
+        assert!(!is_legacy_agent_comm(&"mister-magik2-agent"[..15]));
+        assert!(!is_legacy_agent_comm("MiSTer_MagiKDev"));
+    }
+
 
     #[test]
     fn app_switch_discards_cached_and_inflight_old_previews() {

--- a/magik2/docs/first-version.md
+++ b/magik2/docs/first-version.md
@@ -17,11 +17,11 @@ The experiment remains running after deployment. An explicit stop command restor
 The thin entrypoint is `scripts/magik2`.
 
 ```text
-scripts/magik2 deploy
-scripts/magik2 check smoke
-scripts/magik2 check motion
-scripts/magik2 check motion --profile
-scripts/magik2 watch
+scripts/magik2 deploy --app mini-magik
+scripts/magik2 check smoke --app mini-magik
+scripts/magik2 check motion --app mini-magik
+scripts/magik2 check motion --profile --app mini-magik
+scripts/magik2 watch --app mini-magik
 scripts/magik2 status
 scripts/magik2 stop
 ```

--- a/magik2/docs/legacy-disposition.md
+++ b/magik2/docs/legacy-disposition.md
@@ -1,0 +1,41 @@
+# Legacy tooling: deletion decisions
+
+This is a source-backed consumer inventory for milestone 3, not a parity backlog.
+Do not migrate a command merely because it exists. Owners below identify code
+boundaries, not commitments to implement replacement features.
+
+| Current consumer / source | Decision | Boundary before deletion |
+|---|---|---|
+| Everyday app delivery and build orchestration (`agent-cli/src/cli.rs`, `agent-cli/src/host/mod.rs`) | Replace with the existing 2.0 commands; remove the old app-development path after documentation/callers move. | Keep platform/Main delivery separate; do not remove their implementation by deleting the shared host module wholesale. |
+| Runtime deployment contracts, matching build numbers and qualification ladders (`agent-cli/src/host/platform_deploy.rs`, `installed_layout.rs`) | Do not port into development tooling. | Keep only contracts required by production platform delivery under that workflow's owner. |
+| Legacy UI test input bridge (`apps/mister/ui_tests/driver.py`, `agent_input.py`) | Replace needed journeys with ordinary Slint events/assertions through 2.0. | The new Settings journey uses the existing application action queue. Do not copy the driver, input-correlation machinery or entire scenario catalogue. Physical controller health is a different claim. |
+| Profile/route cross-product (`apps/mister/ui_tests/tests/test_profile_matrix.py`) | Drop from everyday development. | CI may retain narrowly justified hardware/layout coverage; no automatic local matrix. |
+| Particle and scene experiments (`agent-cli/src/host/live_particles.rs`, `startup_particles.rs`, `agent-cli/src/commands/device.rs`) | Default to deletion. | Rescue an experiment into Mini only if it answers a current question; no command-by-command port. |
+| Dedicated frame-profile runners/reports (`scripts/bench/reports/`, `agent-cli/src/host/performance_attribution.rs`) | Drop duplicate orchestration. | Keep a particular offline analysis only if someone uses it; pytest results and optional profiles are the normal evidence. |
+| Workflow database commands (`agent-cli/src/cli.rs`, `DbCommand`) | Do not port. | Development results remain files. Retain only independently needed release/report consumers until their owner is established. |
+| Desktop dashboard, SD browsing, framebuffer and telemetry (`apps/desktop/src/agent_client.rs`) | Active legacy consumer: retain temporarily, outside this milestone. | It imports `crates/agent-protocol`; decide which desktop features are wanted before replacing its client. The 2.0 viewer already covers development observation; do not recreate the entire dashboard in it. |
+| Legacy agent ARM artifact (`scripts/magik_ci/build.py`, `.github/workflows/rust-arm.yml`) | Retain temporarily, then delete with the last installed consumer. | CI still builds/uploads the old binary. Removing runtime users alone does not remove this dependency. |
+| Distribution artifact processing (`scripts/magik_ci/distribution.py`) | Keep outside 2.0. | It recognizes agent artifacts; production packaging needs an explicit consumer decision, not reuse of development deployment logic. |
+| Legacy installation/startup (`agent-cli/src/host/agent_client.rs`, `/etc/init.d/S00magik-agent`) | Explicit later uninstall. | This milestone stops the process once, without editing boot configuration. An ordinary reboot may restart it. |
+| FPGA signoff, CRT/latch qualification (`agent-cli/src/fpga.rs`, `host/crt_qualification.rs`, `host/latch_v5_qualification.rs`) | Keep hardware/release work outside 2.0; drop obsolete experiment-specific gates. | Never make these prerequisites for normal application deployment. |
+| Catalog/media publication (`agent-cli/src/cli.rs`, `GameDatabaseCommand`, `host/media.rs`) | Keep data publication separate. | The runtime catalog itself is application functionality, not obsolete orchestration. No publication pipeline migration in this milestone. |
+| Main/FPGA, RGB565 presentation and live application data | Preserve. | These are not legacy tooling merely because they predate 2.0. |
+
+## What may be deleted next
+
+Start with unused particle/scene commands, duplicate benchmark entrypoints and
+obsolete local matrices, checking their direct callers before deletion. Do not
+archive their source in another directory; Git preserves it. Move no new feature
+into 2.0 as part of such a deletion unless a current consumer needs it.
+
+The whole old agent cannot yet be uninstalled without resolving desktop and
+production/CI consumers. Successful app development with that process stopped
+establishes independence for the new development path only.
+
+## Evidence caveat
+
+Earlier `legacy_agent_running=false` results used an incorrect full-name match
+against Linux's 15-byte `comm` field. They cannot establish absence. Milestone 3
+corrects that check, verifies the actual executable before its explicit one-shot
+stop, and records fresh before/after evidence. Neither normal delivery nor tests
+automatically stop the old agent.

--- a/magik2/docs/milestone-3.md
+++ b/magik2/docs/milestone-3.md
@@ -34,4 +34,66 @@ in this milestone.
 
 ## Acceptance
 
-Pending implementation and bounded device verification.
+Completed on 5 September 2026 against `192.168.1.117`.
+
+| Check | Result |
+|---|---|
+| Focused host validation | 56 tests passed before the final stop/acceptance additions; affected tests then passed 17/17 in 0.22 s. |
+| Native status regression | One focused Cargo test passed, including compilation of the final stop implementation. |
+| ARM build | Real app build passed (3m11s in the fresh worktree); a subsequent changed-input build during smoke took 73.445 s. Native updates took 6.48 s and 2.69 s. |
+| Correct legacy status | The fixed check reported the old agent running; the earlier negative was incorrect. |
+| Explicit legacy stop | Passed once; observed absence confirmed after acknowledgement. No startup files changed. |
+| Default command | `scripts/magik2 check`: one smoke passed, three measurement/profile cases deselected; 99.26 s including build, upload, launch and cleanup. |
+| Real interaction | Home → Settings → Home passed. Settings screenshot inspected; no setting was changed. All reported paths were Dev. |
+| One optional profile | `check idle --profile`: one case passed, three deselected in 24.32 s. Build reused in 24 ms; ten sampled stacks plus folded output/flamegraph retained. |
+| Brief native observation | One decoded 960×540 frame and matching metrics; old agent absent before/after, same app PID 18235. No restart for this check. |
+| Local hygiene | Python lint/format, tooling scope check and whitespace checks passed. No broad local Cargo assurance. |
+
+The navigation response observations were 330.65 ms to open and 936.62 ms to
+return. They include host RPC, accessibility reads and polling. They are neither
+device frame latency nor a comparative performance baseline, and were not used
+for tuning. The ten idle profile samples establish the pipeline, not hotspots.
+No transfer, motion matrix or Mini benchmark was run. Normal session cleanup
+passed and restored the persistent real development app.
+
+Evidence under ignored `build/magik2-results/`:
+
+- Legacy stop: `20260905T170744Z-6c19226c4753`
+- Default smoke/navigation: `20260905T170849Z-3fc368a1af8e`
+- Profile: `20260905T171058Z-f79a7df9dbd3`
+- Independent stream/final status: `20260905T171304Z-e86527b74417`
+
+A first standalone stream-check invocation lacked the host module path and
+failed before contacting hardware; the corrected invocation passed. The attached
+MCP process still predates the merged LSP startup fix and rejected this worktree;
+that is an existing-session issue, not a missing rebase. Source inspection,
+focused Cargo validation and the actual ARM build supplied validation here.
+
+## Review and retained boundaries
+
+The default command does not run measurement repetitions. Mini's retained
+acceptance harness now selects `--app mini-magik` explicitly, preventing the
+changed default from accidentally deploying the real app during those checks.
+Build/deploy/watch share the existing application registry; no new project
+manifest or matching-version gate was added.
+
+Development keyboard events feed the existing bounded UI action queue. They
+are enabled only by the real app's `magik2` feature; production builds reject
+them. The smoke asserts the Settings main landmark, rather than mistaking the
+Settings button for the open screen, and attempts Back after screenshot failure.
+This exercises application navigation, not a physical controller button.
+
+The new legacy stop is explicit and never called by deploy/check/watch. It
+validates the executable and process birth identity, sends TERM once, waits at
+most three seconds after signalling, and reports failure if still running or
+respawned. It neither escalates to KILL nor edits startup configuration. A future
+reboot can start the old agent again. The corrected status capability triggers
+an automatic service upgrade only when that operation needs it.
+
+The [legacy disposition inventory](legacy-disposition.md) identifies what to
+delete and what still has active consumers. Desktop Analytics and production/CI
+agent packaging are real remaining dependencies; they were not ported. The
+old agent is stopped on this device, not uninstalled across the project.
+
+All planned implementation and bounded acceptance are complete. No further
+hardware runs are needed for this milestone.

--- a/magik2/docs/milestone-3.md
+++ b/magik2/docs/milestone-3.md
@@ -1,0 +1,37 @@
+# Milestone 3: the everyday development path
+
+## Scope and commit plan
+
+1. Make `scripts/magik2` default to real MagiK for build/deploy/check/watch;
+   Mini remains explicit with `--app mini-magik`. Default checks run one smoke
+   journey, not benchmark windows. Print the selected executable/data paths and
+   retained failure evidence. Update root developer guidance.
+2. Exercise Home → Settings → Home using Slint keyboard events and the existing
+   typed application action queue. Retain response timings and a screenshot in
+   the same pytest result, without a second benchmark runner or performance gate.
+3. Correct Linux process-name truncation in the legacy-agent status check, then
+   verify the ordinary workflow while the old agent is absent. No uninstall or
+   persistent startup changes. Add only focused regression checks.
+4. Record acceptance and a source-backed legacy consumer disposition inventory.
+
+## Definition of done
+
+The ordinary CLI targets the Dev app/data explicitly; smoke exercises real
+navigation; a failure points to retained logs; bounded device acceptance records
+legacy-agent absence before and after. Existing idle profiling and viewer paths
+are exercised once only as needed to establish independence. No transfer or
+Mini benchmarks, performance tuning loops, platform changes or broad local
+assurance. Necessary app restarts are authorized.
+
+## Explicit exclusions
+
+Do not port matrices, endurance loops, workflow databases, qualification ladders,
+rollback gates, version matching, historical experiments or separate benchmark
+runners. FPGA production, downloader publication and data releases stay outside
+this development tool. The consumer inventory is a deletion decision list, not
+an implementation backlog. The legacy CLI and installed agent are not uninstalled
+in this milestone.
+
+## Acceptance
+
+Pending implementation and bounded device verification.

--- a/magik2/host/magik2/acceptance.py
+++ b/magik2/host/magik2/acceptance.py
@@ -52,7 +52,12 @@ def run_delivery_matrix(run: Path) -> int:
         with (folder / "command.log").open("w") as output:
             try:
                 result = subprocess.run(
-                    [str(repository / "scripts/magik2"), "deploy"],
+                    [
+                        str(repository / "scripts/magik2"),
+                        "deploy",
+                        "--app",
+                        "mini-magik",
+                    ],
                     cwd=repository,
                     env=env,
                     stdout=output,
@@ -234,7 +239,13 @@ def run_contract_checks(run: Path) -> int:
             env = {**os.environ, "MISTER_MAGIK2_RESULTS": str(folder.resolve())}
             with (folder / "command.log").open("w") as output:
                 result = subprocess.run(
-                    [str(repository / "scripts/magik2"), "check", "motion"],
+                    [
+                        str(repository / "scripts/magik2"),
+                        "check",
+                        "motion",
+                        "--app",
+                        "mini-magik",
+                    ],
                     cwd=repository,
                     env=env,
                     stdout=output,

--- a/magik2/host/magik2/cli.py
+++ b/magik2/host/magik2/cli.py
@@ -76,6 +76,9 @@ def main() -> int:
     subcommands.add_parser("watch")
     subcommands.add_parser("status")
     subcommands.add_parser("stop")
+    subcommands.add_parser(
+        "legacy-stop", help="stop the old agent once; preserve its startup files"
+    )
     for name, command in subcommands.choices.items():
         command.set_defaults(app="magik")
         if name not in {"build", "deploy", "check", "watch"}:
@@ -117,6 +120,10 @@ def main() -> int:
     finally:
         finalize(run, code, int((time.monotonic() - started) * 1000))
         if code:
+            if (run / "pytest.log").exists():
+                print(
+                    f"Test failure: {run.resolve() / 'pytest.log'}", file=os.sys.stderr
+                )
             print(f"Failure details: {run.resolve() / 'run.json'}", file=os.sys.stderr)
             print(
                 f"Device logs (if available): {run.resolve() / 'logs.txt'}",
@@ -156,6 +163,21 @@ def dispatch(arguments, run) -> int:
         )
     if arguments.command == "deploy":
         return deploy(arguments, run)
+    if arguments.command == "legacy-stop":
+        agent, _ = connect_agent(
+            run, {"status", "legacy-stop", "legacy-process-status"}
+        )
+        try:
+            agent.stop_legacy()
+            if agent.status().fields.get("legacy_agent_running") is not False:
+                raise RuntimeError(
+                    "legacy agent is still running or status is unavailable"
+                )
+            append_event(run, {"phase": "legacy-stop", "outcome": "passed"})
+            print("Legacy agent stopped; startup files unchanged.")
+            return 0
+        finally:
+            retain_diagnostics(run, agent)
     if arguments.command == "stop":
         return stop(run)
     if arguments.command == "check":

--- a/magik2/host/magik2/cli.py
+++ b/magik2/host/magik2/cli.py
@@ -70,18 +70,29 @@ def main() -> int:
     )
     check_command = subcommands.add_parser("check")
     check_command.add_argument(
-        "scenario", choices=("smoke", "motion", "idle"), nargs="?"
+        "scenario", choices=("smoke", "motion", "idle"), nargs="?", default="smoke"
     )
     check_command.add_argument("--profile", action="store_true")
     subcommands.add_parser("watch")
     subcommands.add_parser("status")
     subcommands.add_parser("stop")
     for name, command in subcommands.choices.items():
-        command.set_defaults(app="mini-magik")
+        command.set_defaults(app="magik")
         if name not in {"build", "deploy", "check", "watch"}:
             continue
-        command.add_argument("--app", choices=tuple(APPLICATIONS), default="mini-magik")
+        command.add_argument("--app", choices=tuple(APPLICATIONS), default="magik")
     arguments = parser.parse_args()
+    if arguments.command in {"deploy", "check", "watch"} or (
+        arguments.command == "build" and arguments.target == "app"
+    ):
+        print(
+            f"Application: {arguments.app} on {os.environ.get('MISTER_IP', '(not configured)')}"
+        )
+        print(f"Executable: /media/fat/mister-magik2/{arguments.app}")
+        if arguments.app == "magik":
+            print("Data: /media/fat/mister-magik-dev; Main: /media/fat/MiSTer_MagiKDev")
+        else:
+            print("Experiment state: /tmp/mister-magik2")
 
     output_root = Path(os.environ.get("MISTER_MAGIK2_RESULTS", "build/magik2-results"))
     run = create_run(
@@ -105,6 +116,12 @@ def main() -> int:
         print(f"magik2: {error} (result: {run})", file=os.sys.stderr)
     finally:
         finalize(run, code, int((time.monotonic() - started) * 1000))
+        if code:
+            print(f"Failure details: {run.resolve() / 'run.json'}", file=os.sys.stderr)
+            print(
+                f"Device logs (if available): {run.resolve() / 'logs.txt'}",
+                file=os.sys.stderr,
+            )
     return code
 
 
@@ -152,7 +169,9 @@ def dispatch(arguments, run) -> int:
         )
         return 2
     try:
-        agent, status = connect_agent(run, STATUS_CAPABILITIES)
+        agent, status = connect_agent(
+            run, STATUS_CAPABILITIES | {"legacy-process-status"}
+        )
     except (BootstrapError, AgentError, OSError, RuntimeError) as error:
         append_event(run, {"phase": "status", "outcome": "failed", "error": str(error)})
         print(

--- a/magik2/host/magik2/client.py
+++ b/magik2/host/magik2/client.py
@@ -62,6 +62,10 @@ class NativeAgent:
             fields["expected_sha256"] = expected_sha256
         return self._successful("start", fields)
 
+    def stop_legacy(self) -> Mapping[str, object]:
+        """Explicit migration check; no startup files or application processes change."""
+        return self._successful("legacy-stop")
+
     def stop(self) -> Mapping[str, object]:
         return self._successful("stop")
 

--- a/magik2/host/magik2/scenario_runner.py
+++ b/magik2/host/magik2/scenario_runner.py
@@ -21,9 +21,7 @@ from .testing import fresh_session
 
 def pytest_addoption(parser):
     group = parser.getgroup("magik2")
-    group.addoption(
-        "--magik2-app", choices=("mini-magik", "magik"), default="mini-magik"
-    )
+    group.addoption("--magik2-app", choices=("mini-magik", "magik"), default="magik")
     group.addoption(
         "--magik2-device",
         action="store_true",

--- a/magik2/host/magik2/scenario_runner.py
+++ b/magik2/host/magik2/scenario_runner.py
@@ -93,9 +93,13 @@ def application_session(request, magik2_run):
         | {"measurement"}
         | application(request.config.getoption("--magik2-app")).agent_capabilities,
     )
-    ensure_application(
-        agent, status, magik2_run, request.config.getoption("--magik2-app")
-    )
+    try:
+        ensure_application(
+            agent, status, magik2_run, request.config.getoption("--magik2-app")
+        )
+    except Exception:
+        retain_diagnostics(magik2_run, agent)
+        raise
     with managed_session(
         agent, magik2_run, profile_id, "shared application session"
     ) as application:

--- a/magik2/host/tests/test_acceptance.py
+++ b/magik2/host/tests/test_acceptance.py
@@ -59,4 +59,5 @@ def test_cancellation_retains_attempt_and_restores_sources(monkeypatch, tmp_path
     assert result["cases"]["no-op"]["attempts"][0]["exit_code"] == 130
     assert result["restoration"]["exit_code"] == 0
     assert len(calls) == 3
+    assert all(call[0][-2:] == ["--app", "mini-magik"] for call in calls)
     assert rust.read_text() == "original Rust"

--- a/magik2/host/tests/test_cli_defaults.py
+++ b/magik2/host/tests/test_cli_defaults.py
@@ -29,3 +29,24 @@ def test_explicit_mini_failure_points_to_retained_evidence(
     run = next(tmp_path.iterdir())
     assert str(run / "run.json") in output.err
     assert str(run / "logs.txt") in output.err
+
+
+def test_legacy_stop_checks_observed_status_even_after_acknowledgement(
+    monkeypatch, tmp_path
+):
+    from types import SimpleNamespace
+    from unittest.mock import Mock
+    import pytest
+    from magik2.results import create_run
+
+    agent = Mock()
+    agent.status.return_value = SimpleNamespace(fields={"legacy_agent_running": True})
+    monkeypatch.setenv("MISTER_IP", "device")
+    monkeypatch.setattr(cli, "connect_agent", lambda *_: (agent, None))
+    monkeypatch.setattr(cli, "retain_diagnostics", Mock())
+    with pytest.raises(RuntimeError, match="still running"):
+        cli.dispatch(
+            SimpleNamespace(command="legacy-stop"), create_run(tmp_path, "stop", {})
+        )
+    agent.stop_legacy.assert_called_once_with()
+    cli.retain_diagnostics.assert_called_once()

--- a/magik2/host/tests/test_cli_defaults.py
+++ b/magik2/host/tests/test_cli_defaults.py
@@ -1,0 +1,31 @@
+from magik2 import cli
+
+
+def test_everyday_check_is_real_smoke_and_prints_dev_target(
+    monkeypatch, tmp_path, capsys
+):
+    seen = []
+    monkeypatch.setenv("MISTER_MAGIK2_RESULTS", str(tmp_path))
+    monkeypatch.setenv("MISTER_IP", "device")
+    monkeypatch.setattr("sys.argv", ["scripts/magik2", "check"])
+    monkeypatch.setattr(cli, "dispatch", lambda args, _: seen.append(args) or 0)
+    assert cli.main() == 0
+    assert (seen[0].app, seen[0].scenario, seen[0].profile) == ("magik", "smoke", False)
+    output = capsys.readouterr().out
+    assert "/media/fat/mister-magik2/magik" in output
+    assert "/media/fat/mister-magik-dev" in output
+
+
+def test_explicit_mini_failure_points_to_retained_evidence(
+    monkeypatch, tmp_path, capsys
+):
+    monkeypatch.setenv("MISTER_MAGIK2_RESULTS", str(tmp_path))
+    monkeypatch.setattr("sys.argv", ["scripts/magik2", "deploy", "--app", "mini-magik"])
+    monkeypatch.setattr(cli, "dispatch", lambda args, _: 2)
+    assert cli.main() == 2
+    output = capsys.readouterr()
+    assert "/media/fat/mister-magik2/mini-magik" in output.out
+    assert "/media/fat/mister-magik-dev" not in output.out
+    run = next(tmp_path.iterdir())
+    assert str(run / "run.json") in output.err
+    assert str(run / "logs.txt") in output.err

--- a/magik2/host/tests/test_scenarios.py
+++ b/magik2/host/tests/test_scenarios.py
@@ -91,3 +91,49 @@ def test_idle_cannot_reuse_a_previous_completed_window(monkeypatch):
     monkeypatch.setattr(actions.time, "sleep", lambda _: None)
     with pytest.raises(AssertionError, match="previous window"):
         actions.launcher_idle(SimpleNamespace(first_window=object()), agent)
+
+
+def test_navigation_returns_from_settings_when_capture_fails(monkeypatch, tmp_path):
+    state = {"open": False}
+    keys = []
+
+    def press(_, key):
+        keys.append(key)
+        if key == "\n":
+            state["open"] = True
+        elif key in {"\x1b", "\uf729"}:
+            state["open"] = False
+
+    def capture(*_):
+        raise RuntimeError("capture failed")
+
+    monkeypatch.setattr(actions, "_press_key", press)
+    monkeypatch.setattr(actions, "_settings_open", lambda _: state["open"])
+    monkeypatch.setattr(actions, "screenshot", capture)
+    with pytest.raises(RuntimeError, match="capture failed"):
+        actions.launcher_navigation(object(), tmp_path / "settings.png")
+    assert not state["open"]
+    assert keys[-1] == "\x1b"
+
+
+def test_settings_button_is_not_mistaken_for_the_open_screen():
+    from types import SimpleNamespace
+
+    elements = [
+        SimpleNamespace(
+            accessible_label="Settings", accessible_role=SimpleNamespace(name="Button")
+        )
+    ]
+    query = SimpleNamespace(match_inherits=lambda _: query, find_all=lambda: elements)
+    app = SimpleNamespace(
+        first_window=SimpleNamespace(
+            root_element=SimpleNamespace(query_descendants=lambda: query)
+        )
+    )
+    assert not actions._settings_open(app)
+    elements.append(
+        SimpleNamespace(
+            accessible_label="Settings", accessible_role=SimpleNamespace(name="Main")
+        )
+    )
+    assert actions._settings_open(app)

--- a/magik2/scenarios/actions.py
+++ b/magik2/scenarios/actions.py
@@ -159,6 +159,52 @@ def launcher_smoke(application, screenshot_path, expected_sha256):
     return {"sha256": expected_sha256, "screenshot": screenshot_path.name}
 
 
+def _press_key(application, text):
+    from slint_testing import KeyPressedEvent, KeyReleasedEvent
+
+    window = application.first_window
+    if window is None:
+        raise AssertionError("real launcher window is unavailable")
+    window.dispatch_event(KeyPressedEvent(text))
+    window.dispatch_event(KeyReleasedEvent(text))
+
+
+def _settings_open(application):
+    return any(
+        element.accessible_label == "Settings"
+        and element.accessible_role.name == "Main"
+        for element in application.first_window.root_element.query_descendants()
+        .match_inherits("Rectangle")
+        .find_all()
+    )
+
+
+def launcher_navigation(application, screenshot_path):
+    """One bounded UI journey; response times include host RPC and polling."""
+    _press_key(application, "\uf729")  # Slint Key.Home
+    _wait(lambda: not _settings_open(application), "Home did not close Settings")
+    started = time.monotonic()
+    _press_key(application, "\uf700")  # Slint Key.UpArrow: focus Settings
+    _press_key(application, "\n")  # Slint Key.Return
+    try:
+        _wait(lambda: _settings_open(application), "Settings did not open")
+        opened_ms = round((time.monotonic() - started) * 1000, 2)
+        screenshot(application, screenshot_path)
+    finally:
+        # Return without changing a setting, including after screenshot failure.
+        returned = time.monotonic()
+        if _settings_open(application):
+            _press_key(application, "\x1b")  # Slint Key.Escape
+    _wait(lambda: not _settings_open(application), "Settings did not close")
+    return {
+        "workload": "home-settings-home",
+        "open_response_ms": opened_ms,
+        "back_response_ms": round((time.monotonic() - returned) * 1000, 2),
+        "timing_source": "host RPC and accessibility polling; not frame latency",
+        "screenshot": screenshot_path.name,
+    }
+
+
 def launcher_idle(application, agent, *, instrumented=False):
     """Measure the real launcher's ordinary idle loop; no synthetic FPS target."""
     if application.first_window is None:

--- a/magik2/scenarios/test_magik.py
+++ b/magik2/scenarios/test_magik.py
@@ -1,7 +1,12 @@
 """Small real-app checks; the scenario is also its benchmark workload."""
 
 import pytest
-from actions import launcher_smoke, launcher_idle, validate_development_paths
+from actions import (
+    launcher_smoke,
+    launcher_idle,
+    launcher_navigation,
+    validate_development_paths,
+)
 from magik2.results import append_event
 
 
@@ -9,6 +14,7 @@ def test_smoke(application_session):
     app, agent, run, _ = application_session
     result = launcher_smoke(app, run / "smoke.png", agent.expected_sha256)
     result["paths"] = validate_development_paths(agent.metrics().get("context"))
+    result["navigation"] = launcher_navigation(app, run / "settings.png")
     append_event(run, {"phase": "smoke", "outcome": "passed", **result})
 
 

--- a/magik2/scripts/check_tooling_scope.py
+++ b/magik2/scripts/check_tooling_scope.py
@@ -19,6 +19,8 @@ CORE = (
 # These are the explicit integration seams; unrelated app features remain consumer PRs.
 COMPANIONS = (
     "AGENTS.md",
+    "README.md",
+    "apps/mister/ui/launcher.slint",
     "scripts/AGENTS.md",
     "scripts/magik_ci/host.py",
     "apps/mister/Cargo.toml",


### PR DESCRIPTION
## Behavior corrected

Make `scripts/magik2` the everyday real-app development path. Build/deploy/check/watch default to real MagiK and print the Dev executable/data destinations; Mini remains available through `--app mini-magik`. Default `check` runs one smoke journey, with benchmark repetitions and profiling explicitly selected.

The smoke journey now opens Settings and returns through Slint events and the existing bounded application action queue. Keyboard handling is enabled only for the real app's `magik2` feature. The same pytest result retains assertions, screenshots and clearly labelled host response timings. Failed setup retains available device diagnostics, and command failures print their evidence paths.

Fix legacy-agent detection: Linux truncates `comm` to 15 bytes, so the previous full-name comparison falsely reported absence. Add an explicit, bounded `legacy-stop` migration command that validates the executable and birth identity, sends TERM once, and preserves startup files. Ordinary development never calls it automatically.

Review also corrected Mini-specific acceptance invocations and reproduction documentation so the new real-app default cannot change their target. The legacy disposition inventory identifies deletion candidates and active desktop/release consumers; no desktop, release, matrix or historical experiment features are ported here.

## Verification

- Focused host validation: 56 passed before the final additions; 17 affected tests passed afterward.
- Focused native process-name regression and compilation passed; ARM app and service builds passed.
- Actual MiSTer acceptance with the old agent stopped: one default smoke/navigation case, one optional idle profile, and a brief native frame/metrics check. Both pytest invocations deselected the other three cases.
- Screenshot inspected; all reported app data paths were Dev. Stream decoded 960×540 and retained the same app PID, with legacy absence checked before and after.
- Python formatting/lint, tooling scope and whitespace checks passed. No transfer benchmarks, Mini measurements or broad local Cargo assurance were repeated.

[Milestone, review and device evidence](https://github.com/NigelBreslaw/MiSTer-MagiK/blob/nigel/magik2-everyday/magik2/docs/milestone-3.md) · [Legacy feature decisions](https://github.com/NigelBreslaw/MiSTer-MagiK/blob/nigel/magik2-everyday/magik2/docs/legacy-disposition.md)

Limits: navigation timings include host RPC/accessibility polling and are not frame latency. Ten idle profile samples establish the pipeline, not hotspots. Physical controller input was not automated. The old agent is stopped, not uninstalled; a reboot may start it again. A standalone stream invocation initially lacked its local Python module path and failed before device access; the corrected invocation passed. The existing attached MCP session still predates the merged startup fix; ARM/focused Cargo validation supplied assurance.

## Compatibility

Use operation capabilities, not matching versions. Reliable legacy status/stop requests upgrade a service only when that support is missing. Compatible services remain installed. Real-app production builds, platform installation and legacy startup files are preserved.
