### PR TITLE
Retire legacy everyday app workflow entrypoints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ one smoke journey; request idle/motion measurements or profiling explicitly.
 Use the 2.0 exception below. Do not route ordinary app development through 1.0.
 
 For retained platform/release and legacy operations, use typed
-`scripts/agent deliver`, `benchmark`, `diagnose`, and `db report`;
+`scripts/agent deliver platform`, `benchmark`, `diagnose`, and `db report`;
 human device operations use attended `scripts/agent device`. Never use raw
 SSH/SCP, generic remote shells, or ad-hoc SQL. Device, Apple-container, and
 virtualization commands require first-attempt escalation. Retry read-only

--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Use `--app mini-magik` for the fast experiment. The default check is one smoke
 journey; benchmarks and profiles are explicit. See [development setup and
 commands](magik2/README.md). Production installation above is a separate workflow.
 
-See [retired experiment tooling and remaining legacy consumers](docs/tooling-retirement.md)
-for the deletion milestone.
+See [retired tooling and remaining legacy consumers](docs/tooling-retirement.md)
+for the current deletion inventory.
 
 ## Built With Slint
 

--- a/agent-cli/README.md
+++ b/agent-cli/README.md
@@ -1,28 +1,37 @@
 # agent-cli
 
-`agent-cli` is the repository workflow engine behind `scripts/agent`. It owns
-exact-SHA builds, transactional delivery, benchmarks, diagnosis, and attended
-release qualification. Python owns pre-push and CI host assurance.
+`agent-cli` retains platform delivery, specialized qualification, diagnosis,
+and attended device operations. Python owns pre-push and CI host assurance.
 
-The AI-facing commands are:
+Ordinary application development uses the shared [2.0 tooling](../magik2/README.md):
+
+```sh
+scripts/magik2 deploy
+scripts/magik2 check
+scripts/magik2 watch
+scripts/magik2 check idle
+scripts/magik2 check idle --profile
+```
+
+The real app is the default; use `--app mini-magik` for the fast experiment.
+`check` runs one smoke journey. Measurement and profiling are explicit scenarios.
+
+Retained legacy operations require an explicit purpose:
 
 ```text
 scripts/agent plan
-scripts/agent deliver
+scripts/agent deliver platform
+scripts/agent deliver local-main
 scripts/agent deliver game-databases --game-databases-release-dir PATH
-scripts/agent restart-ui
-scripts/agent benchmark
-scripts/agent benchmark particles
 scripts/agent benchmark catalog-lifecycle
-scripts/agent benchmark launch-return
+scripts/agent benchmark input-integrity
 scripts/agent diagnose
-scripts/agent clean
 ```
 
-`restart-ui` sends delivery's acknowledged `mister_magik_suspend` followed by
-`mister_magik_resume`. It does not build, stage, transfer, or replace files, and
-it does not reboot Linux. The resume acknowledgement waits for the fresh launcher
-child to become active.
+Bare `deliver`, `deliver runtime`, `restart-ui`, and bare `benchmark` are removed.
+There are no forwarding aliases. `deliver platform` names the existing platform
+transaction; reconciliation can still select a runtime-only update or no-op.
+It is not the everyday app-development path.
 
 Validation ownership is defined in root `AGENTS.md`. Use `scripts/agent plan`
 for the fast-check preview and `scripts/agent guidance PATH` for source ownership.
@@ -38,7 +47,7 @@ trees.
 build and host-assurance intents exist for CI and release tooling, not as a
 public flag matrix. Commit
 creation belongs to Git; `agent-cli` never stages, commits, or pushes.
-`deliver` uses the exact clean local app commit for the app and manager. Main,
+`deliver platform` uses the exact clean local app commit for the app and manager. Main,
 the scanout kernel plugin, and the latch RBF come only from the latest
 published GitHub platform release. The tag-addressed cache is reused when it
 still verifies against the latest release.
@@ -48,11 +57,9 @@ release directory and invokes only the database transaction. It does not
 resolve platform releases or build, replace, or restart any platform/runtime
 artifact.
 
-`benchmark` profiles the already-installed development app in place. With no
-scenario it runs the screensaver benchmark. A positional scenario selects
-another registered typed workflow. `particles` searches and confirms the
-60 FPS ceiling of both particle presets at 960x540, captures representative
-frames, and restores the original display configuration. `catalog-lifecycle`
+`benchmark SCENARIO` runs an explicitly selected legacy workload on the installed
+platform. These specialized input, catalog, renderer and hardware measurements
+are not interchangeable with the 2.0 smoke/idle scenarios. `catalog-lifecycle`
 performs an isolated full catalog build under `/tmp`, validates every generated
 shard, then removes the fixture and restores the ordinary launcher. Benchmarks
 run through a restricted typed client that rejects delivery requests. They

--- a/agent-cli/src/benchmark.rs
+++ b/agent-cli/src/benchmark.rs
@@ -371,7 +371,7 @@ fn require_clean_installed_commit(
     let reconciliation = crate::deploy::reconcile(repository, &manifest, &head);
     if reconciliation.decision != crate::deploy::DeliveryDecision::NoOp {
         return Err(format!(
-            "benchmark requires delivery reconciliation to be no-op, found {}; run scripts/agent deliver first",
+            "benchmark requires delivery reconciliation to be no-op, found {}; run scripts/agent deliver platform first",
             reconciliation.decision.label()
         )
         .into());
@@ -1707,7 +1707,7 @@ fn require_active_development_runtime(active: &crate::host::ActiveRuntime) -> Ag
         Ok(())
     } else {
         Err(format!(
-            "benchmark requires the active development launcher, found {}; run scripts/agent deliver",
+            "benchmark requires the active development launcher, found {}; run scripts/agent deliver platform",
             active.description()
         )
         .into())
@@ -3861,7 +3861,7 @@ mod tests {
         ] {
             let error = require_active_development_runtime(&active).unwrap_err();
             assert!(error.to_string().contains(&active.description()));
-            assert!(error.to_string().contains("scripts/agent deliver"));
+            assert!(error.to_string().contains("scripts/agent deliver platform"));
         }
         assert!(
             require_active_development_runtime(&crate::host::ActiveRuntime::new(

--- a/agent-cli/src/cli.rs
+++ b/agent-cli/src/cli.rs
@@ -44,13 +44,13 @@ impl Cli {
         }) = &cli.command
         {
             match (target, game_databases_release_dir) {
-                (Some(DeliverTarget::GameDatabases), None) => {
+                (DeliverTarget::GameDatabases, None) => {
                     return Err(clap::Error::raw(
                         clap::error::ErrorKind::MissingRequiredArgument,
                         "deliver game-databases requires --game-databases-release-dir PATH",
                     ));
                 }
-                (Some(DeliverTarget::LocalMain), Some(_)) => {
+                (DeliverTarget::LocalMain, Some(_)) => {
                     return Err(clap::Error::raw(
                         clap::error::ErrorKind::ArgumentConflict,
                         "--game-databases-release-dir is not valid with deliver local-main",
@@ -87,9 +87,10 @@ pub enum Command {
         #[command(subcommand)]
         command: DeviceCommand,
     },
+    /// Deliver the retained platform or database transaction; app development uses scripts/magik2.
     Deliver {
         #[arg(value_enum)]
-        target: Option<DeliverTarget>,
+        target: DeliverTarget,
         #[arg(
             long,
             value_name = "PATH",
@@ -97,10 +98,9 @@ pub enum Command {
         )]
         game_databases_release_dir: Option<PathBuf>,
     },
-    /// Restart the UI through delivery's suspend-and-resume lifecycle.
-    RestartUi,
+    /// Run an explicit legacy qualification workload; everyday measurements use scripts/magik2 check.
     Benchmark {
-        #[arg(value_enum, default_value_t)]
+        #[arg(value_enum)]
         scenario: BenchmarkScenario,
         #[arg(value_enum)]
         arm: Option<ArcadeVelocityScrollArm>,
@@ -154,7 +154,7 @@ pub enum Command {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub enum DeliverTarget {
-    Runtime,
+    Platform,
     LocalMain,
     GameDatabases,
 }
@@ -798,7 +798,7 @@ mod tests {
 
     #[test]
     fn deliver_accepts_only_the_bounded_local_database_input() {
-        assert!(Cli::try_parse_from(["agent-cli", "deliver"]).is_ok());
+        assert!(Cli::try_parse_from(["agent-cli", "deliver"]).is_err());
         assert!(Cli::try_parse_from(["agent-cli", "deliver", "local-main"]).is_ok());
         assert!(
             Cli::try_parse_from([
@@ -815,7 +815,7 @@ mod tests {
             Cli::try_parse_from([
                 "agent-cli",
                 "deliver",
-                "runtime",
+                "platform",
                 "--game-databases-release-dir",
                 "build/game-databases"
             ])
@@ -828,7 +828,7 @@ mod tests {
                 "--game-databases-release-dir",
                 "build/game-databases"
             ])
-            .is_ok()
+            .is_err()
         );
         assert!(
             Cli::try_parse_from([
@@ -848,9 +848,10 @@ mod tests {
     }
 
     #[test]
-    fn restart_ui_is_a_flag_free_command() {
-        assert!(Cli::try_parse_from(["agent-cli", "restart-ui"]).is_ok());
-        assert!(Cli::try_parse_from(["agent-cli", "restart-ui", "--fast"]).is_err());
+    fn retired_app_workflows_are_rejected() {
+        assert!(Cli::try_parse_from(["agent-cli", "restart-ui"]).is_err());
+        assert!(Cli::try_parse_from(["agent-cli", "deliver", "runtime"]).is_err());
+        assert!(Cli::try_parse_from(["agent-cli", "deliver", "platform"]).is_ok());
     }
 
     #[test]
@@ -914,7 +915,7 @@ mod tests {
             "search",
             "streamline",
         ];
-        assert!(Cli::try_parse_from(["agent-cli", "benchmark"]).is_ok());
+        assert!(Cli::try_parse_from(["agent-cli", "benchmark"]).is_err());
         for scenario in accepted {
             assert!(Cli::try_parse_from(["agent-cli", "benchmark", scenario]).is_ok());
         }

--- a/agent-cli/src/delivery.rs
+++ b/agent-cli/src/delivery.rs
@@ -301,37 +301,9 @@ pub fn execute(
         expected_commit,
         None,
         game_databases_release_dir,
-        false,
         reporter,
         DeviceClient::default(),
     )
-}
-
-/// Deliver only when reconciliation remains on the runtime/no-op path. This
-/// lane fails before builds, snapshots, or device mutations if current device
-/// state would otherwise promote the transaction to a platform delivery.
-pub fn execute_runtime_only(
-    repository: &Path,
-    expected_commit: &str,
-    game_databases_release_dir: Option<&Path>,
-    reporter: &mut Reporter<'_>,
-) -> AgentResult<DeliveryExecution> {
-    execute_with_device(
-        repository,
-        expected_commit,
-        None,
-        game_databases_release_dir,
-        true,
-        reporter,
-        DeviceClient::default(),
-    )
-}
-
-/// Restart the UI using delivery's acknowledged suspend-and-resume lifecycle.
-pub fn restart_ui() -> AgentResult<Outcome> {
-    let mut device = DeviceClient::default();
-    device.mutate(crate::NativeDevice::restart_ui)?;
-    Ok(Outcome::Passed)
 }
 
 fn execute_with_device<D: DeliveryDevice>(
@@ -339,7 +311,6 @@ fn execute_with_device<D: DeliveryDevice>(
     expected_commit: &str,
     platform_candidate: Option<crate::platform_ci::Candidate>,
     game_databases_release_dir: Option<&Path>,
-    runtime_only: bool,
     reporter: &mut Reporter<'_>,
     device: D,
 ) -> AgentResult<DeliveryExecution> {
@@ -375,7 +346,6 @@ fn execute_with_device<D: DeliveryDevice>(
         build_attribution: None,
         timing_samples: Vec::new(),
         game_databases_release_dir: game_databases_release_dir.map(Path::to_path_buf),
-        runtime_only,
         stage: repository
             .join("build/agent-deploy/stage")
             .join(expected_commit),
@@ -634,7 +604,6 @@ struct ProcessActions<'a, D = DeviceClient> {
     build_attribution: Option<crate::build::BuildArtifactAttribution>,
     timing_samples: Vec<crate::host::DeliveryTimingSample>,
     game_databases_release_dir: Option<PathBuf>,
-    runtime_only: bool,
     stage: PathBuf,
     device: D,
 }
@@ -820,15 +789,6 @@ fn reconcile_fpga_activation(
     (DeliveryDecision::Platform, Some(assessment.reason()))
 }
 
-fn enforce_delivery_scope(runtime_only: bool, decision: DeliveryDecision) -> AgentResult<()> {
-    if runtime_only && decision == DeliveryDecision::Platform {
-        return Err(
-            "runtime-only delivery refused platform reconciliation before device mutation".into(),
-        );
-    }
-    Ok(())
-}
-
 impl<D: DeliveryDevice> DeliveryActions for ProcessActions<'_, D> {
     fn run(&mut self, phase: Phase) -> AgentResult<()> {
         match phase {
@@ -865,7 +825,6 @@ impl<D: DeliveryDevice> DeliveryActions for ProcessActions<'_, D> {
                     self.decision = decision;
                     self.reconciliation_reason = reason;
                 }
-                enforce_delivery_scope(self.runtime_only, self.decision)?;
                 if self.decision == DeliveryDecision::Platform {
                     self.deployment.kind = DeploymentKind::Platform;
                     self.deployment.ui_scope = UiScope::Production;
@@ -1416,14 +1375,6 @@ mod tests {
     }
 
     #[test]
-    fn runtime_only_scope_rejects_platform_reconciliation() {
-        assert!(enforce_delivery_scope(true, DeliveryDecision::Platform).is_err());
-        assert!(enforce_delivery_scope(true, DeliveryDecision::Runtime).is_ok());
-        assert!(enforce_delivery_scope(true, DeliveryDecision::NoOp).is_ok());
-        assert!(enforce_delivery_scope(false, DeliveryDecision::Platform).is_ok());
-    }
-
-    #[test]
     fn delivery_contains_no_git_mutation_commands() {
         let source = include_str!("delivery.rs");
         for forbidden in ["\"add\"", "\"commit\"", "\"push\"", "\"reset\""] {
@@ -1664,7 +1615,6 @@ mod tests {
             build_attribution: None,
             timing_samples: Vec::new(),
             game_databases_release_dir: None,
-            runtime_only: false,
             stage: PathBuf::from("stage"),
             device,
         }

--- a/agent-cli/src/diagnose.rs
+++ b/agent-cli/src/diagnose.rs
@@ -376,12 +376,12 @@ pub fn correlate(facts: &DeviceFacts, repaired: bool) -> DiagnosticReport {
     } else if !facts.firmware_compatible {
         Some("Install the compatible MiSTer MagiK platform firmware, then rerun diagnosis.".into())
     } else if !facts.scanout_ready || !facts.latch_ready {
-        Some("Run scripts/agent deliver to restore the coherent development platform, then rerun scripts/agent diagnose.".into())
+        Some("Run scripts/agent deliver platform to restore the coherent development platform, then rerun scripts/agent diagnose.".into())
     } else if facts.present_backend == "compatibility-fb0"
         || facts.present_status == "compatibility"
     {
         Some(if facts.latch_failure_state == "platform-incompatible" {
-            "Run scripts/agent deliver to restore the coherent development platform, then rerun scripts/agent diagnose.".into()
+            "Run scripts/agent deliver platform to restore the coherent development platform, then rerun scripts/agent diagnose.".into()
         } else {
             "Use A: Retry latch or B: Continue in compatibility mode on the device, then rerun scripts/agent diagnose.".into()
         })
@@ -570,7 +570,7 @@ mod tests {
             report
                 .next_action
                 .unwrap()
-                .contains("scripts/agent deliver")
+                .contains("scripts/agent deliver platform")
         );
     }
 
@@ -615,7 +615,7 @@ mod tests {
             report
                 .next_action
                 .unwrap()
-                .contains("scripts/agent deliver")
+                .contains("scripts/agent deliver platform")
         );
     }
 

--- a/agent-cli/src/host/mod.rs
+++ b/agent-cli/src/host/mod.rs
@@ -748,16 +748,6 @@ impl NativeDevice {
         .map(|_| ())
     }
 
-    pub(crate) fn restart_ui(&mut self) -> std::result::Result<(), DeviceFailure> {
-        let prepared = self.prepare(DeviceAccess::AGENT_MUTATION)?;
-        let session = connect_with(&prepared.config.connection, 10).map_err(device_failure)?;
-        restart_ui_with(&SshDeployRemote {
-            sess: &session,
-            agent: None,
-        })
-        .map_err(device_failure)
-    }
-
     pub(crate) fn deliver_databases(
         &mut self,
         stage: &Path,
@@ -1310,7 +1300,7 @@ impl NativeDevice {
             parse_active_runtime_status(remote_read(&session, MAIN_STATUS_REMOTE).as_deref());
         if !active.is_development_launcher() {
             return Err(DeviceFailure::Unhealthy(format!(
-                "benchmark requires the active development launcher, found {}; run scripts/agent deliver",
+                "benchmark requires the active development launcher, found {}; run scripts/agent deliver platform",
                 active.description()
             )));
         }
@@ -32018,11 +32008,6 @@ fn resume_runtime_launcher<R: DeployRemote>(remote: &R) -> Result<()> {
     deploy_fifo_command(remote, "mister_magik_resume")
 }
 
-fn restart_ui_with<R: DeployRemote>(remote: &R) -> Result<()> {
-    suspend_runtime_launcher(remote)?;
-    resume_runtime_launcher(remote)
-}
-
 impl MagikDeployReport {
     fn print(&self) {
         let finish_ms = self.swap_ms + self.chmod_size_ms;
@@ -41377,18 +41362,6 @@ H: Handlers=event3 js0"#
         }
         let _ = fs::remove_file(local);
         let _ = fs::remove_file(manifest);
-    }
-
-    #[test]
-    fn restart_ui_only_suspends_then_resumes_the_launcher() {
-        let remote = scripted_deploy_remote(0);
-
-        restart_ui_with(&remote).unwrap();
-
-        let events = remote.events();
-        assert_eq!(events.len(), 2);
-        assert!(events[0].contains("mister_magik_suspend"));
-        assert!(events[1].contains("mister_magik_resume"));
     }
 
     #[test]

--- a/agent-cli/src/main.rs
+++ b/agent-cli/src/main.rs
@@ -123,7 +123,6 @@ fn command_label(command: &CliCommand) -> &'static str {
         CliCommand::Diagnose => "diagnose",
         CliCommand::Device { .. } => "device",
         CliCommand::Deliver { .. } => "deliver",
-        CliCommand::RestartUi => "restart-ui",
         CliCommand::Benchmark { .. } => "benchmark",
         CliCommand::Capture { .. } => "capture",
         CliCommand::Alpha { .. } => "alpha",
@@ -145,7 +144,7 @@ fn dispatch(
 ) -> AgentResult<Outcome> {
     match command {
         CliCommand::Deliver {
-            target: Some(DeliverTarget::GameDatabases),
+            target: DeliverTarget::GameDatabases,
             game_databases_release_dir,
         } => {
             let Some(release_dir) = game_databases_release_dir.as_deref() else {
@@ -156,46 +155,26 @@ fn dispatch(
             return deliver_game_databases(repository, release_dir, reporter);
         }
         CliCommand::Deliver {
-            target: Some(DeliverTarget::LocalMain),
+            target: DeliverTarget::LocalMain,
             game_databases_release_dir: Some(_),
         } => {
             return Err("--game-databases-release-dir is not valid with deliver local-main".into());
         }
         CliCommand::Deliver {
-            target: Some(DeliverTarget::Runtime),
+            target: DeliverTarget::Platform,
             game_databases_release_dir,
         } => {
             return deliver(
                 evidence,
                 repository,
                 game_databases_release_dir.as_deref(),
-                true,
                 reporter,
             );
         }
         CliCommand::Deliver {
-            target: None,
-            game_databases_release_dir: Some(release_dir),
-        } => {
-            return deliver(
-                evidence,
-                repository,
-                Some(release_dir.as_path()),
-                false,
-                reporter,
-            );
-        }
-        CliCommand::Deliver {
-            target: None,
-            game_databases_release_dir: None,
-        } => {
-            return deliver(evidence, repository, None, false, reporter);
-        }
-        CliCommand::Deliver {
-            target: Some(DeliverTarget::LocalMain),
+            target: DeliverTarget::LocalMain,
             ..
         } => return deliver_local_main(repository, reporter),
-        CliCommand::RestartUi => return agent_cli::delivery::restart_ui(),
         CliCommand::Benchmark {
             scenario,
             arm,
@@ -435,17 +414,10 @@ fn deliver(
     evidence: &Evidence,
     repository: &std::path::Path,
     game_databases_release_dir: Option<&std::path::Path>,
-    runtime_only: bool,
     reporter: &mut Reporter<'_>,
 ) -> AgentResult<Outcome> {
     let total_started = Instant::now();
-    let delivery = deliver_inner(
-        evidence,
-        repository,
-        game_databases_release_dir,
-        runtime_only,
-        reporter,
-    );
+    let delivery = deliver_inner(evidence, repository, game_databases_release_dir, reporter);
     reporter.emit(
         EventKind::Progress,
         "cleanup",
@@ -485,7 +457,6 @@ fn deliver_inner(
     _evidence: &Evidence,
     repository: &std::path::Path,
     game_databases_release_dir: Option<&std::path::Path>,
-    runtime_only: bool,
     reporter: &mut Reporter<'_>,
 ) -> AgentResult<agent_cli::delivery::DeliveryExecution> {
     let preflight_started = Instant::now();
@@ -499,16 +470,7 @@ fn deliver_inner(
     })();
     emit_delivery_timing(reporter, "preflight", preflight.is_ok(), preflight_started)?;
     let sha = preflight?;
-    if runtime_only {
-        agent_cli::delivery::execute_runtime_only(
-            repository,
-            &sha,
-            game_databases_release_dir,
-            reporter,
-        )
-    } else {
-        agent_cli::delivery::execute(repository, &sha, game_databases_release_dir, reporter)
-    }
+    agent_cli::delivery::execute(repository, &sha, game_databases_release_dir, reporter)
 }
 
 fn emit_delivery_timing(

--- a/apps/mister/BUILD.md
+++ b/apps/mister/BUILD.md
@@ -3,9 +3,21 @@
 For local macOS UI design and deterministic RGB565 captures, see
 [UI_PREVIEW.md](UI_PREVIEW.md).
 
-Run focused local Rust checks through `scripts/cargo`. Operational builds and
-delivery use `scripts/agent`; do not invoke Apple container, cross, or deployment
-implementation commands directly.
+Run focused local Rust checks through `scripts/cargo`. For everyday application
+builds, deployment, testing and profiling, use the shared [2.0 workflow](../../magik2/README.md):
+
+```sh
+scripts/magik2 deploy
+scripts/magik2 check
+scripts/magik2 watch
+scripts/magik2 check idle --profile
+```
+
+These commands target the development copy. No clean-commit or platform
+qualification gate applies. The remaining sections describe retained legacy
+platform/release builds, not prerequisites for application development.
+
+## Platform/release builds
 
 The typed build state machine is:
 
@@ -29,12 +41,12 @@ $magik-rust-lsp
 git add -- PATH...
 git commit -m "Describe the change"
 git push
-scripts/agent deliver
+scripts/agent deliver platform
 ```
 
 Validation ownership is defined in root `AGENTS.md`; `scripts/agent plan`
 previews the selected fast Python checks and CI boundary.
-`deliver` owns build scope, artifact qualification, transport, activation,
+`deliver platform` owns build scope, artifact qualification, transport, activation,
 rollback, and smoke verification. Human-only fixed scene operation is available
 through `scripts/agent device scene`; it is separate from building and deployment.
 

--- a/apps/mister/src/cpu_profile.rs
+++ b/apps/mister/src/cpu_profile.rs
@@ -1334,7 +1334,7 @@ mod stub {
         if config.enabled {
             crate::ui_errln!(
                 "cpu_profile: MISTER_PPROF=1 ignored — the runtime lacks the `profile` feature; \
-                 install the canonical device runtime with `scripts/agent deliver`"
+                 install the canonical device runtime with `scripts/agent deliver platform`"
             );
         }
         None

--- a/apps/mister/ui_tests/README.md
+++ b/apps/mister/ui_tests/README.md
@@ -1,5 +1,9 @@
 # MiSTer MagiK UI tests
 
+Everyday development uses `scripts/magik2 check` and its shared Python scenarios.
+This retained suite is for explicitly requested legacy qualification; its build
+and qualification ladder are not prerequisites for ordinary development.
+
 This package contains the attended, device-only UI test harness. It is kept
 outside the repository's default pytest discovery path so CI can type-check and
 lint it without launching a MiSTer or requiring the private Slint test wheel.

--- a/docs/arm-performix-mister-compatibility.md
+++ b/docs/arm-performix-mister-compatibility.md
@@ -34,7 +34,7 @@ Streamline and gator sources:
 
 ## Reproduction
 
-The exact installed Dev runtime is delivered through `scripts/agent deliver`.
+The exact installed Dev runtime is delivered through `scripts/agent deliver platform`.
 The authoritative counter entry point is then run through:
 
 ```text

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,4 +1,13 @@
-# Benchmarking policy
+# Legacy platform benchmarking
+
+For everyday application development, use `scripts/magik2 check` for smoke,
+`check idle` for two real-app measurement windows, and `check idle --profile`
+for one separate profile. Mini-MagiK uses `--app mini-magik` and the `motion`
+scenario. These all run through the same Python scenario framework; see
+[development commands](../magik2/README.md).
+
+The specialized legacy workflows below remain separate qualification tools.
+Select a scenario explicitly; bare `scripts/agent benchmark` is removed.
 
 The fixed attribution workloads and evidence gates for the cross-subsystem
 profiling campaign are defined in
@@ -14,7 +23,7 @@ The fixed gate compares a bounded launcher event trace against the exact injecte
 sequence in idle and catalog/CPU/stall scenarios. Intentional UI stalls are input
 correctness stress, not rendering-cadence qualification.
 
-`scripts/agent benchmark [SCENARIO]` is the only agent-facing performance
+`scripts/agent benchmark SCENARIO` selects a retained legacy qualification
 workflow. Scenarios are a closed typed registry rather than a flag matrix. It
 never builds, deploys, or replaces platform files. The fixed `cold-boot`
 scenario may issue one supervised Linux reboot. The isolated
@@ -28,7 +37,7 @@ revision, while pending runtime or platform changes remain a hard failure.
 
 Supported scenarios:
 
-- `screensaver` (the default)
+- `screensaver`
 - `cold-boot`
 - `cold-boot-pprof`
 - `input-integrity`
@@ -48,11 +57,6 @@ Supported scenarios:
 - `agent-observer-attribution`
 - `launcher-response-streamline`
 - `input-latency-lab`
-- `particles`
-- `particle-demo-40k`
-- `particle-capacity`
-- `particle-step`
-- `particle-profile`
 - `catalog-lifecycle`
 - `catalog-resume-validation`
 - `arcade-catalog-prototype-cold`

--- a/docs/device.md
+++ b/docs/device.md
@@ -99,7 +99,7 @@ automatically replays the reboot request.
 ## Agent workflows
 
 Agents use closed typed workflows rather than the operator CLI. Runtime and
-platform changes are committed first and then use `scripts/agent deliver`.
+platform changes are committed first and then use `scripts/agent deliver platform`.
 Committed Main-fork experiments use `scripts/agent deliver local-main`, which
 is Dev-only and replaces only the verified Main/manifest pair from an exact
 clean sibling checkout. The first deployment of reload support may use one

--- a/docs/main-mister-fork.md
+++ b/docs/main-mister-fork.md
@@ -9,7 +9,7 @@ slint/
   Main_MiSTer/         # real GitHub fork of MiSTer-devel/Main_MiSTer
 ```
 
-`scripts/agent deliver` installs one coherent development platform. Main, the
+`scripts/agent deliver platform` installs one coherent development platform. Main, the
 scanout kernel module, and the FPGA latch come from the same latest qualified
 GitHub platform release; the tag-addressed verified archive is reused while
 that release remains latest. The platform manifest binds those components to
@@ -213,7 +213,7 @@ protocol details and device smoke results current in the fork's
 Deploy from this app repo:
 
 ```bash
-scripts/agent deliver
+scripts/agent deliver platform
 ```
 
 For committed Main-only development experiments, use the permanent positional
@@ -254,7 +254,7 @@ An installed Main that advertises supervised local reload is replaced without
 rebooting Linux. The initial commit that introduces that capability necessarily
 uses one bounded Linux reboot. A rollback uses supervised replacement where
 possible and at most one bounded recovery reboot when the failed Main can no
-longer reload itself. Ordinary `scripts/agent deliver` remains the canonical
+longer reload itself. Ordinary `scripts/agent deliver platform` remains the canonical
 way to restore the latest published platform.
 
 Development delivery first compares the installed manifest with the exact clean

--- a/docs/production-readiness.md
+++ b/docs/production-readiness.md
@@ -7,7 +7,7 @@ and an attended release qualification.
 ```text
 git add -- PATH...
 git commit -m "Describe the release candidate"
-scripts/agent deliver
+scripts/agent deliver platform
 scripts/agent release qualify
 ```
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -82,7 +82,7 @@ rebooting or running the installer; incomplete packages fail verification.
 ## Attended device/platform qualification
 
 The pre-push hook and CI must pass for the exact release commit before delivery
-and explicitly requested attended qualification (`scripts/agent deliver`, then
+and explicitly requested attended qualification (`scripts/agent deliver platform`, then
 `scripts/agent release qualify`). Distribution publication does not implicitly
 authorize or schedule these physical-device operations.
 Development delivery builds the app from its clean local commit and never

--- a/docs/tooling-retirement.md
+++ b/docs/tooling-retirement.md
@@ -1,6 +1,51 @@
-# Milestone 4: obsolete experiment orchestration removed
+# Tooling retirement
 
-Completed from main after PR #91. This is the current deletion record following
+## Milestone 5: one everyday application workflow
+
+Based on merged PR #92 (`71ee7eb71`). Ordinary deployment, smoke, observation,
+measurement and profiles use the existing `scripts/magik2` commands for both
+real MagiK and Mini-MagiK. No 2.0 implementation or scenario changed.
+
+Removed `deliver runtime`, `restart-ui`, bare `deliver`, and bare `benchmark`.
+The app-only delivery switch, scope check, restart helpers and exclusive tests
+are deleted. Removed commands fail during parsing; no aliases forward them.
+The existing broader delivery transaction is now explicitly `deliver platform`.
+It still reconciles platform/runtime/no-op decisions, including database input;
+`deliver local-main` and `deliver game-databases` remain separate targets.
+
+Active build/test/profile instructions point to 2.0. Retained platform/recovery
+instructions and diagnostic messages name the explicit platform target. Direct
+caller searches found no automation requiring the removed app-only commands.
+Historical milestone records remain historical, not operational instructions.
+
+### Remaining consumers
+
+- Platform delivery still needs shared runtime building, manifests, transfer,
+  lifecycle and recovery. Removing its app-only entrypoint cannot delete those
+  shared implementations. Production packaging and Main/FPGA are unchanged.
+- Specialized input, catalog, renderer and hardware benchmarks remain explicit.
+  Smoke/idle scenarios do not establish their claims; none were ported or run.
+- Attended UI qualification and its input bridge remain release consumers.
+  Their ladder is explicitly outside ordinary application development.
+- Desktop Analytics, distribution/CI artifacts, catalog/media publication and
+  device startup still depend on legacy components. The installed old agent
+  cannot yet be uninstalled as a consequence of this milestone.
+
+### Verification
+
+Host-only CLI parser tests: 19 passed. Focused delivery tests: 23 passed,
+including retained database/local-Main coverage. Guidance tests: eight passed
+and six subtests. Affected Python lint/format and whitespace checks passed.
+Rust LSP was unavailable; source review and focused Cargo supplied validation.
+No device access, ARM build, reboot, benchmark or new performance claim.
+
+The implementation removes 114 source lines net (including tests and guidance).
+No manifest/protocol version changes, dependencies, compatibility shims or new
+features were introduced. Full assurance remains CI's responsibility.
+
+## Milestone 4: obsolete experiment orchestration removed
+
+Completed from main after PR #91. This is the earlier deletion record following
 [the milestone 3 consumer inventory](../magik2/docs/legacy-disposition.md).
 Nothing was ported into Mini-MagiK or the 2.0 host/service.
 

--- a/scripts/magik_ci/guidance.py
+++ b/scripts/magik_ci/guidance.py
@@ -19,7 +19,7 @@ def authority(path: str) -> tuple[str, str]:
     if path.startswith(("/media/fat/", "/tmp/mister-magik/")):
         return (
             "device-owned runtime state; never copy into Git",
-            "scripts/agent deliver or an attended typed scripts/agent device command",
+            "scripts/agent deliver platform or an attended typed scripts/agent device command",
         )
     if file_name.startswith(".env") or "/.wrangler/" in path:
         return "ignored secret; never stage or print", "none"


### PR DESCRIPTION
Ordinary app development already uses the shared Mini-MagiK/MagiK 2.0 tooling. Remove the duplicate legacy app-only entrypoints and make retained platform operations explicit.

- Delete `deliver runtime`, `restart-ui`, their exclusive helpers and tests, and the implicit `deliver` and `benchmark` defaults.
- Retain the existing platform reconciliation transaction as `deliver platform`, alongside `deliver local-main` and `deliver game-databases`. Specialized benchmarks require an explicit scenario.
- Move active development instructions to `scripts/magik2` and update retained platform/recovery instructions and diagnostic messages.
- Record remaining desktop, production/CI, and attended qualification consumers in `docs/tooling-retirement.md`.

Three commits; 114 source lines removed net. No new 2.0 features, protocol versions, dependencies, or compatibility aliases. Shared platform delivery and the installed old agent remain.

Validation: 19 CLI parser tests, 23 focused delivery tests, and eight guidance tests with six subtests passed. Affected lint/format and whitespace checks passed. Rust LSP was unavailable, so review used source inspection and focused Cargo validation. No device operations or ARM builds were needed; full assurance remains CI's responsibility.
