### PR TITLE
Fix Dependabot python submodule auth access

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,22 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 version: 2
+
+# Dependabot cannot resolve private git submodules unless it has explicit repository
+# access. Point this to a Dependabot secret containing a PAT with read access to
+# the required private submodule repositories.
+registries:
+  github-private:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{ secrets.DEPENDABOT_GIT_PRIVATE_TOKEN }}
+
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    registries:
+      - github-private
     schedule:
       interval: "weekly"
       day: "friday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,18 @@
 
 version: 2
 updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "friday"
+      time: "08:00"
+      timezone: "Europe/Helsinki"
+    groups:
+      python-projects:
+        patterns:
+          - "*"
+
   - package-ecosystem: "cargo"
     directories:
       - "**/*"

--- a/scripts/checks/ci-cache-identity.py
+++ b/scripts/checks/ci-cache-identity.py
@@ -171,6 +171,7 @@ GROUPS: dict[str, tuple[str, ...]] = {
         "agent-cli/src/build.rs",
     ),
     "ffmpeg": (
+        "scripts/magik_ci/ffmpeg.py",
         "apps/mister/Cross.toml",
         "apps/mister/Dockerfile.cross-armv7",
     ),

--- a/scripts/magik_ci/build.py
+++ b/scripts/magik_ci/build.py
@@ -8,6 +8,8 @@ import os
 import subprocess
 from pathlib import Path
 
+from scripts.magik_ci import ffmpeg
+
 TARGET = "armv7-unknown-linux-gnueabihf"
 COMMANDS = {
     "runtime-ci": ("apps/mister/Cargo.toml", "ci-fast", "ui"),
@@ -45,7 +47,7 @@ def _environment(
     environment["RUSTFLAGS"] = rustflags
 
     if runner == "cross" and intent in {"runtime-ci", "runtime-device"}:
-        dist = repository / "apps/mister/target/ffmpeg-minimal/armv7/dist"
+        dist = ffmpeg.CONTAINER_DIST
         include = dist / "include"
         environment.update(
             {
@@ -176,5 +178,7 @@ def execute(repository: Path, intent: str) -> None:
     if os.environ.get("MISTER_CARGO_TIMINGS") == "1":
         command.append("--timings")
     environment = _environment(repository, intent, profile, features, runner)
+    if runner == "cross" and intent in {"runtime-ci", "runtime-device"}:
+        ffmpeg.prepare(repository)
     subprocess.run(command, cwd=repository, env=environment, check=True)
     _write_build_identity(repository, intent, profile, features, runner)

--- a/scripts/magik_ci/build.py
+++ b/scripts/magik_ci/build.py
@@ -47,7 +47,10 @@ def _environment(
     environment["RUSTFLAGS"] = rustflags
 
     if runner == "cross" and intent in {"runtime-ci", "runtime-device"}:
-        dist = ffmpeg.CONTAINER_DIST
+        # Cross mounts configured host volumes at their canonical host paths.
+        # The FFmpeg preparation container uses /project, but Cross cannot see
+        # that mount point when MISTER_REPO_ROOT enables volume mounting.
+        dist = repository / ffmpeg.RELATIVE_WORK / "dist"
         include = dist / "include"
         environment.update(
             {

--- a/scripts/magik_ci/ffmpeg.py
+++ b/scripts/magik_ci/ffmpeg.py
@@ -1,0 +1,133 @@
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Prepare the minimal ARM FFmpeg dependency before invoking cross."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import shlex
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+VERSION = "8.1.2"
+RELATIVE_WORK = Path("apps/mister/target/ffmpeg-minimal/armv7")
+CONTAINER_DIST = Path("/project") / RELATIVE_WORK / "dist"
+LIBRARIES = ("avcodec", "avformat", "avutil", "swresample")
+REQUIRED = tuple(
+    name
+    for library in LIBRARIES
+    for name in (
+        f"include/lib{library}/{library}.h",
+        f"lib/lib{library}.a",
+        f"lib/pkgconfig/lib{library}.pc",
+    )
+) + ("include/libavcodec/version_major.h",)
+CONFIGURE = (
+    f"--prefix={CONTAINER_DIST}",
+    "--cross-prefix=arm-linux-gnueabihf-",
+    "--arch=arm",
+    "--cpu=cortex-a9",
+    "--target-os=linux",
+    "--enable-cross-compile",
+    "--extra-cflags=-O3 -mcpu=cortex-a9 -mfpu=neon-vfpv3 -mfloat-abi=hard",
+    "--extra-cxxflags=-O3 -mcpu=cortex-a9 -mfpu=neon-vfpv3 -mfloat-abi=hard",
+    "--enable-static",
+    "--disable-shared",
+    "--enable-pic",
+    "--disable-autodetect",
+    "--disable-programs",
+    "--disable-doc",
+    "--disable-debug",
+    "--enable-stripping",
+    "--disable-everything",
+    "--disable-avdevice",
+    "--disable-avfilter",
+    "--enable-swresample",
+    "--enable-avcodec",
+    "--enable-avformat",
+    "--enable-avutil",
+    "--disable-swscale",
+    "--enable-decoder=h264",
+    "--enable-decoder=aac",
+    "--enable-decoder=pcm_s16le",
+    "--enable-parser=aac",
+    "--enable-parser=h264",
+    "--enable-demuxer=mov",
+    "--enable-protocol=file",
+)
+RECIPE = (
+    shlex.join(("./configure", *CONFIGURE))
+    + "\n"
+    + "\n".join(
+        f"grep -q '^#define CONFIG_{flag} 0$' config.h"
+        for flag in ("GPL", "VERSION3", "NONFREE")
+    )
+    + "\nmake install"
+)
+
+
+def prepare(repository: Path) -> None:
+    config = (repository / "apps/mister/Cross.toml").read_text()
+    image = tomllib.loads(config)["target"]["armv7-unknown-linux-gnueabihf"]["image"]
+    identity = hashlib.sha256(
+        f"{VERSION}\n{config}\n{RECIPE}\n{REQUIRED}".encode()
+    ).hexdigest()
+    work = repository / RELATIVE_WORK
+    dist = work / "dist"
+    stamp = dist / ".magik-ci-ffmpeg-recipe"
+    if (
+        stamp.is_file()
+        and stamp.read_text().strip() == identity
+        and all((dist / name).is_file() for name in REQUIRED)
+    ):
+        return
+    work.mkdir(parents=True, exist_ok=True)
+    # Only generated dependency outputs are replaced, never repository sources.
+    if dist.exists():
+        shutil.rmtree(dist)
+    source = work / f"ffmpeg-{VERSION}"
+    if source.exists():
+        shutil.rmtree(source)
+    subprocess.run(
+        [
+            "git",
+            "clone",
+            "--depth=1",
+            "--branch",
+            f"n{VERSION}",
+            "https://github.com/FFmpeg/FFmpeg",
+            str(source),
+        ],
+        check=True,
+    )
+    subprocess.run(
+        [
+            "docker",
+            "run",
+            "--rm",
+            "--platform",
+            "linux/amd64",
+            "--user",
+            f"{os.getuid()}:{os.getgid()}",
+            "-e",
+            f"MAKEFLAGS=-j{os.cpu_count() or 1}",
+            "-v",
+            f"{repository}:/project",
+            "-w",
+            str(Path("/project") / source.relative_to(repository)),
+            image,
+            "sh",
+            "-ec",
+            RECIPE,
+        ],
+        cwd=repository,
+        check=True,
+    )
+    missing = [name for name in REQUIRED if not (dist / name).is_file()]
+    if missing:
+        raise RuntimeError("minimal FFmpeg outputs missing: " + ", ".join(missing))
+    stamp.write_text(identity + "\n")

--- a/scripts/tests/test_magik_ci_ffmpeg.py
+++ b/scripts/tests/test_magik_ci_ffmpeg.py
@@ -1,0 +1,123 @@
+# Copyright (C) 2026 Nigel Breslaw
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from scripts.magik_ci import build, ffmpeg
+
+
+@pytest.fixture
+def repository(tmp_path: Path) -> Path:
+    app = tmp_path / "apps/mister"
+    app.mkdir(parents=True)
+    (app / "Cross.toml").write_text(
+        '[target.armv7-unknown-linux-gnueabihf]\nimage = "test-image"\n'
+    )
+    return tmp_path
+
+
+def outputs(repository: Path) -> None:
+    for name in ffmpeg.REQUIRED:
+        path = repository / ffmpeg.RELATIVE_WORK / "dist" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("fixture")
+
+
+def test_cold_cache_builds_and_complete_cache_is_reused(repository: Path) -> None:
+    with patch.object(ffmpeg.subprocess, "run") as run:
+        run.side_effect = lambda *a, **kw: outputs(repository)
+        ffmpeg.prepare(repository)
+        assert [call.args[0][0] for call in run.call_args_list] == ["git", "docker"]
+        docker = run.call_args_list[1].args[0]
+        assert f"{repository}:/project" in docker
+        assert docker[-1] == ffmpeg.RECIPE
+        run.reset_mock()
+        ffmpeg.prepare(repository)
+        run.assert_not_called()
+
+
+@pytest.mark.parametrize("damage", ["header", "archive", "stamp", "recipe"])
+def test_incomplete_or_stale_cache_rebuilds(repository: Path, damage: str) -> None:
+    with patch.object(ffmpeg.subprocess, "run") as run:
+        run.side_effect = lambda *a, **kw: outputs(repository)
+        ffmpeg.prepare(repository)
+        dist = repository / ffmpeg.RELATIVE_WORK / "dist"
+        if damage == "header":
+            (dist / "include/libavutil/avutil.h").unlink()
+        elif damage == "archive":
+            (dist / "lib/libavcodec.a").unlink()
+        elif damage == "stamp":
+            (dist / ".magik-ci-ffmpeg-recipe").unlink()
+        else:
+            config = repository / "apps/mister/Cross.toml"
+            config.write_text(config.read_text().replace("test-image", "new-image"))
+        run.reset_mock()
+        ffmpeg.prepare(repository)
+        assert run.call_count == 2
+
+
+def test_missing_outputs_never_stamp_success(repository: Path) -> None:
+    with (
+        patch.object(ffmpeg.subprocess, "run"),
+        pytest.raises(RuntimeError, match="libavutil/avutil.h"),
+    ):
+        ffmpeg.prepare(repository)
+    assert not (
+        repository / ffmpeg.RELATIVE_WORK / "dist/.magik-ci-ffmpeg-recipe"
+    ).exists()
+
+
+@pytest.mark.parametrize("intent", ["runtime-ci", "runtime-device"])
+def test_runtime_prepares_ffmpeg_before_cross(repository: Path, intent: str) -> None:
+    events = []
+    with (
+        patch.dict("os.environ", {"MISTER_ARM_BUILD_BACKEND": "cross"}),
+        patch.object(
+            build.ffmpeg, "prepare", side_effect=lambda root: events.append("ffmpeg")
+        ),
+        patch.object(
+            build.subprocess, "run", side_effect=lambda *a, **kw: events.append("cross")
+        ),
+        patch.object(build, "_write_build_identity"),
+    ):
+        build.execute(repository, intent)
+    assert events == ["ffmpeg", "cross"]
+
+
+def test_failed_preparation_stops_cargo(repository: Path) -> None:
+    with (
+        patch.dict("os.environ", {"MISTER_ARM_BUILD_BACKEND": "cross"}),
+        patch.object(
+            build.ffmpeg,
+            "prepare",
+            side_effect=subprocess.CalledProcessError(1, "ffmpeg"),
+        ),
+        patch.object(build.subprocess, "run") as run,
+    ):
+        with pytest.raises(subprocess.CalledProcessError):
+            build.execute(repository, "runtime-ci")
+        run.assert_not_called()
+
+
+def test_cross_environment_uses_container_paths(repository: Path) -> None:
+    env = build._environment(repository, "runtime-ci", "ci-fast", "ui", "cross")
+    assert env["FFMPEG_DIR"] == str(ffmpeg.CONTAINER_DIST)
+    assert env["PKG_CONFIG_PATH"] == str(ffmpeg.CONTAINER_DIST / "lib/pkgconfig")
+    assert env["HOST_CFLAGS"] == f"-I{ffmpeg.CONTAINER_DIST}/include"
+    assert env["CFLAGS"] == env["HOST_CFLAGS"]
+
+
+def test_library_check_does_not_prepare_ffmpeg(repository: Path) -> None:
+    with (
+        patch.dict("os.environ", {"MISTER_ARM_BUILD_BACKEND": "cross"}),
+        patch.object(build.ffmpeg, "prepare") as prepare,
+        patch.object(build.subprocess, "run"),
+    ):
+        build.execute(repository, "runtime-library-ci")
+        prepare.assert_not_called()

--- a/scripts/tests/test_magik_ci_ffmpeg.py
+++ b/scripts/tests/test_magik_ci_ffmpeg.py
@@ -105,11 +105,12 @@ def test_failed_preparation_stops_cargo(repository: Path) -> None:
         run.assert_not_called()
 
 
-def test_cross_environment_uses_container_paths(repository: Path) -> None:
+def test_cross_environment_uses_host_mounted_paths(repository: Path) -> None:
     env = build._environment(repository, "runtime-ci", "ci-fast", "ui", "cross")
-    assert env["FFMPEG_DIR"] == str(ffmpeg.CONTAINER_DIST)
-    assert env["PKG_CONFIG_PATH"] == str(ffmpeg.CONTAINER_DIST / "lib/pkgconfig")
-    assert env["HOST_CFLAGS"] == f"-I{ffmpeg.CONTAINER_DIST}/include"
+    dist = repository / ffmpeg.RELATIVE_WORK / "dist"
+    assert env["FFMPEG_DIR"] == str(dist)
+    assert env["PKG_CONFIG_PATH"] == str(dist / "lib/pkgconfig")
+    assert env["HOST_CFLAGS"] == f"-I{dist}/include"
     assert env["CFLAGS"] == env["HOST_CFLAGS"]
 
 


### PR DESCRIPTION
Follow-up fix for #95: add private git registry credentials for Dependabot so Python updates can access private submodule repos during dependency scans.