### PR TITLE
Fix Dependabot Python private submodule auth

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,22 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 version: 2
+
+# Dependabot cannot resolve private git submodules unless it has explicit repository
+# access. Point this to a Dependabot secret containing a PAT with read access to
+# the required private submodule repositories.
+registries:
+  github-private:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{ secrets.DEPENDABOT_GIT_PRIVATE_TOKEN }}
+
 updates:
   - package-ecosystem: "pip"
     directory: "/"
+    registries:
+      - github-private
     schedule:
       interval: "weekly"
       day: "friday"


### PR DESCRIPTION
Follow-up to PR #95: add Dependabot private git registry configuration for the pip ecosystem, so it can reach private submodules referenced by git submodules and complete Python scans.

Please create the Dependabot secret DEPENDABOT_GIT_PRIVATE_TOKEN (GitHub token/PAT with read access to private submodule repos) if it does not already exist.