### PR TITLE
Return authoritative MiSTer framebuffer images directly to Codex

### DIFF
--- a/.github/workflows/magik2.yml
+++ b/.github/workflows/magik2.yml
@@ -19,7 +19,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: python -m pip install pytest ruff==0.11.8
+      - run: python -m pip install uv ruff==0.11.8
+      # These are host-only fixtures; the private on-device test driver is unused.
+      - run: uv export --frozen --project magik2/host --no-emit-project --no-emit-package slint-testing --output-file /tmp/magik2-host-requirements.txt > /dev/null
+      - run: uv pip install --system -r /tmp/magik2-host-requirements.txt
       - run: ruff format --check magik2/host magik2/scenarios magik2/scripts
       - run: ruff check --select E4,E7,E9,F magik2/host magik2/scenarios magik2/scripts
       - run: python -m pytest magik2/host/tests -q

--- a/magik2/AGENTS.md
+++ b/magik2/AGENTS.md
@@ -30,3 +30,9 @@ or invoke `scripts/agent`, `agent-cli`, or `mister/tools/agent`.
   with `--app mini-magik`. Default smoke must not expand into benchmark matrices.
 - `legacy-stop` is an explicit migration operation, never an automatic deployment
   step. Preserve startup files and do not add retry/escalation loops to it.
+
+- Framebuffer images returned by MCP are agent input; do not assume tool output
+  is visible in the user's chat. When asked to show a capture, explicitly embed
+  it in the reply. If needed, decode the same PNG into a temporary local file
+  and use an absolute-path Markdown image embed. Do not recapture for display
+  or commit the temporary image. See `docs/framebuffer-capture.md`.

--- a/magik2/README.md
+++ b/magik2/README.md
@@ -26,6 +26,7 @@ to uv. Keep credentials in the environment/user credential store, never Git.
 scripts/magik2 deploy
 scripts/magik2 check
 scripts/magik2 watch
+scripts/magik2 mcp # stdio MCP server; configure in Codex, not an interactive viewer
 scripts/magik2 check idle
 scripts/magik2 check idle --profile
 scripts/magik2 status
@@ -60,6 +61,13 @@ The agent owns the selected app after disconnect and restores it after test sess
 `stop` confirms Main's acknowledgement and observed launcher readiness.
 No matching-version, clean-commit, platform qualification, or rollback gate is
 part of this development path.
+
+## Screenshots directly into Codex
+
+The [framebuffer capture tool](docs/framebuffer-capture.md) returns a native PNG
+image directly to Codex. It reads authoritative scanout, including application
+composition outside Slint; the existing live viewer remains a preview stream.
+Both real MagiK and Mini-MagiK use the same capture operation. Desktop is unchanged.
 
 ## One scenario system
 

--- a/magik2/agent/Cargo.lock
+++ b/magik2/agent/Cargo.lock
@@ -80,7 +80,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "mister-magik-core"
+version = "0.1.0"
+
+[[package]]
 name = "mister-magik-framebuffer-stream"
+version = "0.1.0"
+
+[[package]]
+name = "mister-magik-latch-contract"
+version = "0.1.0"
+
+[[package]]
+name = "mister-magik-mister-runtime"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "mister-magik-core",
+ "mister-magik-latch-contract",
+ "mister-magik-scanout-contract",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "mister-magik-scanout-contract"
 version = "0.1.0"
 
 [[package]]
@@ -89,6 +113,8 @@ version = "0.1.0"
 dependencies = [
  "libc",
  "mister-magik-framebuffer-stream",
+ "mister-magik-mister-runtime",
+ "mister-magik-scanout-contract",
  "serde",
  "serde_json",
  "sha2",

--- a/magik2/agent/Cargo.toml
+++ b/magik2/agent/Cargo.toml
@@ -15,6 +15,10 @@ all = "deny"
 [dependencies]
 libc = "0.2"
 mister-magik-framebuffer-stream = { path = "../../crates/framebuffer-stream" }
+mister-magik-scanout-contract = { path = "../../mister/platform/contracts/scanout" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.11"
+
+[target.'cfg(target_os = "linux")'.dependencies]
+mister-magik-mister-runtime = { path = "../../mister/platform/runtime", default-features = false }

--- a/magik2/agent/src/capture.rs
+++ b/magik2/agent/src/capture.rs
@@ -151,7 +151,13 @@ pub(crate) fn capture() -> Result<Capture, CaptureError> {
         libc::munmap(mapped, layout.map_bytes as usize);
     }
     let after = fpga.read_magik_latched_fbuf_status().map_err(unavailable)?;
-    if before.active_base != after.active_base
+    if !after.supported()
+        || !after.active_enabled()
+        || !after.magik_owned()
+        || before.active_width != after.active_width
+        || before.active_height != after.active_height
+        || before.active_stride != after.active_stride
+        || before.active_base != after.active_base
         || before.active_sequence != after.active_sequence
         || before.flip_count != after.flip_count
         || before.active_route_epoch != after.active_route_epoch

--- a/magik2/agent/src/capture.rs
+++ b/magik2/agent/src/capture.rs
@@ -1,0 +1,217 @@
+//! One authoritative RGB565 scanout snapshot; no preview or fb0 fallback.
+#[cfg(any(target_os = "linux", test))]
+use mister_magik_scanout_contract::{MAX_HEIGHT, MAX_STRIDE_BYTES, MAX_WIDTH, SLOT_CAPACITY_BYTES};
+use serde::Serialize;
+
+#[derive(Debug)]
+pub(crate) struct CaptureError {
+    pub code: &'static str,
+    pub detail: String,
+}
+
+impl CaptureError {
+    fn new(code: &'static str, detail: impl ToString) -> Self {
+        Self {
+            code,
+            detail: detail.to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Geometry {
+    pub width: usize,
+    pub height: usize,
+    pub stride_bytes: usize,
+}
+
+#[cfg(any(target_os = "linux", test))]
+impl Geometry {
+    fn byte_len(&self) -> Result<usize, CaptureError> {
+        if self.width == 0
+            || self.width > MAX_WIDTH
+            || self.height == 0
+            || self.height > MAX_HEIGHT
+            || self.stride_bytes < self.width * 2
+            || self.stride_bytes > MAX_STRIDE_BYTES
+            || !self.stride_bytes.is_multiple_of(2)
+        {
+            return Err(CaptureError::new(
+                "capture-invalid-geometry",
+                "invalid RGB565 scanout dimensions or stride",
+            ));
+        }
+        self.stride_bytes
+            .checked_mul(self.height)
+            .filter(|len| *len <= SLOT_CAPACITY_BYTES)
+            .ok_or_else(|| {
+                CaptureError::new("capture-invalid-geometry", "scanout exceeds slot capacity")
+            })
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct Capture {
+    #[serde(flatten)]
+    pub geometry: Geometry,
+    pub source: &'static str,
+    pub pixel_format: &'static str,
+    pub frame_sequence: u16,
+    #[serde(skip)]
+    pub pixels: Vec<u8>,
+}
+
+#[cfg(not(target_os = "linux"))]
+pub(crate) fn capture() -> Result<Capture, CaptureError> {
+    Err(CaptureError::new(
+        "capture-unsupported",
+        "MiSTer scanout requires Linux",
+    ))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn capture() -> Result<Capture, CaptureError> {
+    use mister_magik_mister_runtime::fpga::Fpga;
+    use mister_magik_scanout_contract::{DEVICE, EXPECTED_LAYOUT, GET_LAYOUT, ScanoutSlotsLayout};
+    use std::{fs::OpenOptions, io, os::fd::AsRawFd};
+
+    let unavailable = |error: io::Error| CaptureError::new("capture-unavailable", error);
+    let device = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .open(DEVICE)
+        .map_err(unavailable)?;
+    let mut layout = ScanoutSlotsLayout::default();
+    // SAFETY: device is live and layout is the shared repr(C) kernel UAPI buffer.
+    if unsafe { libc::ioctl(device.as_raw_fd(), GET_LAYOUT as libc::c_ulong, &mut layout) } != 0 {
+        return Err(unavailable(io::Error::last_os_error()));
+    }
+    if layout != EXPECTED_LAYOUT {
+        return Err(CaptureError::new(
+            "capture-unsupported",
+            "scanout slot layout is unsupported",
+        ));
+    }
+    let mut fpga = Fpga::open().map_err(unavailable)?;
+    let _guard = fpga.lock_latch_transaction().map_err(unavailable)?;
+    fpga.read_magik_latched_fbuf_capabilities()
+        .map_err(unavailable)?;
+    let before = fpga.read_magik_latched_fbuf_status().map_err(unavailable)?;
+    if !before.supported() || !before.active_enabled() || !before.magik_owned() {
+        return Err(CaptureError::new(
+            "capture-unsupported",
+            "no active MagiK scanout",
+        ));
+    }
+    let geometry = Geometry {
+        width: before.active_width as usize,
+        height: before.active_height as usize,
+        stride_bytes: before.active_stride as usize,
+    };
+    let len = geometry.byte_len()?;
+    let slot = layout
+        .slots
+        .iter()
+        .find(|slot| slot.physical_address == before.active_base)
+        .ok_or_else(|| {
+            CaptureError::new(
+                "capture-unavailable",
+                "active buffer is outside scanout slots",
+            )
+        })?;
+    // SAFETY: layout and geometry were validated against the shared contract.
+    // The kernel's write-combined mapping requires a read/write descriptor.
+    let mapped = unsafe {
+        libc::mmap(
+            std::ptr::null_mut(),
+            layout.map_bytes as usize,
+            libc::PROT_READ | libc::PROT_WRITE,
+            libc::MAP_SHARED,
+            device.as_raw_fd(),
+            slot.mmap_offset_bytes as libc::off_t,
+        )
+    };
+    if mapped == libc::MAP_FAILED {
+        return Err(unavailable(io::Error::last_os_error()));
+    }
+    if mapped.is_null() {
+        // SAFETY: even an unusable null mapping must be released.
+        unsafe {
+            libc::munmap(mapped, layout.map_bytes as usize);
+        }
+        return Err(CaptureError::new(
+            "capture-unavailable",
+            "scanout mapping returned null",
+        ));
+    }
+    // SAFETY: the mapping spans at least len bytes and remains live until the copy finishes.
+    let pixels = unsafe { std::slice::from_raw_parts(mapped.cast::<u8>(), len).to_vec() };
+    // SAFETY: unmap exactly the mapping returned above; pixels now owns its copy.
+    unsafe {
+        libc::munmap(mapped, layout.map_bytes as usize);
+    }
+    let after = fpga.read_magik_latched_fbuf_status().map_err(unavailable)?;
+    if before.active_base != after.active_base
+        || before.active_sequence != after.active_sequence
+        || before.flip_count != after.flip_count
+        || before.active_route_epoch != after.active_route_epoch
+    {
+        return Err(CaptureError::new(
+            "capture-frame-changed",
+            "scanout changed during capture; request another screenshot",
+        ));
+    }
+    Ok(Capture {
+        geometry,
+        source: "fpga-latched-scanout-slots",
+        pixel_format: "rgb565-le",
+        frame_sequence: before.active_sequence,
+        pixels,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_dimensions_and_padded_stride_before_reading() {
+        assert_eq!(
+            Geometry {
+                width: 3,
+                height: 2,
+                stride_bytes: 8
+            }
+            .byte_len()
+            .unwrap(),
+            16
+        );
+        for (width, height, stride_bytes) in [
+            (0, 1, 2),
+            (1, 0, 2),
+            (MAX_WIDTH + 1, 1, 2),
+            (1, MAX_HEIGHT + 1, 2),
+            (3, 1, 4),
+            (1, 1, 3),
+            (1, 1, MAX_STRIDE_BYTES + 2),
+        ] {
+            assert_eq!(
+                Geometry {
+                    width,
+                    height,
+                    stride_bytes
+                }
+                .byte_len()
+                .unwrap_err()
+                .code,
+                "capture-invalid-geometry"
+            );
+        }
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    fn unavailable_capture_never_returns_a_preview() {
+        assert_eq!(capture().unwrap_err().code, "capture-unsupported");
+    }
+}

--- a/magik2/agent/src/lib.rs
+++ b/magik2/agent/src/lib.rs
@@ -1,5 +1,6 @@
 //! Bounded native control framing for the independently owned MagiK 2.0 agent.
 
+mod capture;
 mod main_control;
 mod upload;
 mod wire;
@@ -176,6 +177,7 @@ impl Agent {
             "test-session",
             "metrics-v1",
             "watch-v1",
+            "capture-framebuffer",
             "artifacts-v1",
             "agent-update-v1",
             "request-replay-v1",
@@ -341,6 +343,39 @@ impl Agent {
         let mut body = vec![0; body_length];
         wire::DeadlineReader { stream, deadline }.read_exact(&mut body)?;
 
+        if request.op == "capture-framebuffer" {
+            if !body.is_empty() || !request.fields.is_empty() {
+                return write_frame(
+                    stream,
+                    &response(
+                        &request.id,
+                        "error",
+                        serde_json::json!({"code": "capture-invalid-request", "detail": "capture takes no fields or body"}),
+                    ),
+                    &[],
+                );
+            }
+            return match capture::capture() {
+                Ok(capture) => write_frame(
+                    stream,
+                    &response(
+                        &request.id,
+                        "framebuffer",
+                        serde_json::to_value(&capture).expect("capture metadata"),
+                    ),
+                    &capture.pixels,
+                ),
+                Err(error) => write_frame(
+                    stream,
+                    &response(
+                        &request.id,
+                        "error",
+                        serde_json::json!({"code": error.code, "detail": error.detail}),
+                    ),
+                    &[],
+                ),
+            };
+        }
         if request.op == "watch" {
             return self.watch(stream, &request, &body);
         }

--- a/magik2/docs/framebuffer-capture.md
+++ b/magik2/docs/framebuffer-capture.md
@@ -38,7 +38,8 @@ build/bootstrap; diagnostics and inherited child-process output use stderr.
 Both real MagiK and Mini-MagiK are captured from the currently latched scanout slot.
 The shared platform contracts provide the slot layout and FPGA status primitive.
 The tool holds the platform transaction lock while reading and copying the active
-slot, then checks that its sequence, base, flip count and route epoch stayed stable.
+slot, then checks that its geometry, sequence, base, flip count and route epoch
+stayed stable and that MagiK still owns an enabled scanout.
 There is no dependency on the legacy device agent, Slint screenshots, `watch-frame`
 preview cache, or a raw `/dev/fb0` reader.
 

--- a/magik2/docs/framebuffer-capture.md
+++ b/magik2/docs/framebuffer-capture.md
@@ -33,6 +33,24 @@ Call `capture_framebuffer` with `{}` for raw raster pixels, or
 continuous feed. The server reserves stdout for MCP, including during automatic
 build/bootstrap; diagnostics and inherited child-process output use stderr.
 
+## Showing the image to the user
+
+Receiving an MCP image proves delivery to the agent, not visibility in the chat.
+When the user asks to see a capture, explicitly embed it in the assistant reply;
+do not simply say "shown above" because the tool returned image content.
+
+If the client does not expose the returned image as a reusable attachment, decode
+that same base64 PNG into a temporary local file and embed its absolute path:
+
+```markdown
+![MiSTer MagiK framebuffer](/absolute/temporary/path/capture.png)
+```
+
+This optional presentation copy does not change the in-memory MCP capture path.
+Do not capture again, navigate, restart the app, or commit screenshots just to
+make an existing result visible. Keep agent receipt and user-visible presentation
+as separate acceptance checks; a PNG decoding test only verifies the former.
+
 ## Pixels and presentation
 
 Both real MagiK and Mini-MagiK are captured from the currently latched scanout slot.
@@ -92,10 +110,16 @@ after the Mini-MagiK capture. Hardware evidence details are recorded below.
   including the automatic service build/update. Image inspected directly in Codex.
 - Mini-MagiK: native 960x540 RGB565 scanout, sequence 1; MCP call 2.958 s.
   Image inspected directly in Codex; the installed real app was then restored ready.
-- Acceptance limitation: the real-app image was captured on Home, not the Arcade
-  list. It proves native image delivery from scanout but does not visually verify
-  the Rust-painted Arcade rows. One additional screenshot requires user approval
-  because the two planned successful captures have already been used.
+- With explicit approval for one additional capture, the real app's Arcade view
+  was captured at 960x540, sequence 48. The Rust-painted rows and game preview
+  were visible to the agent. The full MCP call took 11.291 s; this includes
+  connection/preparation, so it is not a standalone capture-duration measurement.
+  No navigation, restart or performance tuning was performed.
+- Presentation correction: the tool image was not visible in the user's chat.
+  The same returned PNG (86,157 bytes) was decoded into a temporary display copy
+  and explicitly embedded in the assistant reply. No new capture was needed.
+  Tool discovery guidance and scoped agent instructions now require this explicit
+  presentation step when the user asks to see an image.
 
 Local validation: 24 agent library tests; focused agent Clippy; typed ARM agent
 build; 40 focused Python tests including real MCP stdio exchange. The unchanged

--- a/magik2/docs/framebuffer-capture.md
+++ b/magik2/docs/framebuffer-capture.md
@@ -1,0 +1,103 @@
+# Framebuffer screenshots directly into Codex
+
+`scripts/magik2 mcp` serves one tool, `capture_framebuffer`, over MCP stdio.
+A call returns a native `image/png` image block containing base64 PNG data, followed
+by short JSON metadata. Codex receives the image directly; there is no screenshot
+file, upload service or separate open-image step. Normal run metadata is retained
+under `MISTER_MAGIK2_RESULTS`; pixels and base64 are never written to those logs.
+
+## Connect Codex
+
+Use Codex's [MCP configuration](https://developers.openai.com/codex/mcp/):
+
+```sh
+codex mcp add magik2-framebuffer --env MISTER_IP=192.168.1.117 -- /absolute/path/to/checkout/scripts/magik2 mcp
+```
+
+Use an absolute path to the checkout/worktree you intend to run. If that worktree
+is removed, update the registration. Reconnect the MCP server in Codex after
+changing its launch configuration. Do not add device passwords to tracked config.
+The launch environment needs `uv` on PATH and the existing private Slint index
+authentication when installing the host environment for the first time.
+
+The server reuses 2.0's device token cache and capability-based connection flow.
+When bootstrap is necessary, provide `MISTER_USER` and `MISTER_PASS` in its launch
+environment, just as for ordinary 2.0 commands. A service without
+`capture-framebuffer` is automatically built and installed through the existing
+native update/bootstrap flow. This may take longer than a screenshot; no matching
+branch, version or build hash is required if the capability is already present.
+The screenshot operation itself does not start, restart, navigate or stop an app.
+
+Call `capture_framebuffer` with `{}` for raw raster pixels, or
+`{"view":"display"}` for an inspection view. Each call returns one image, not a
+continuous feed. The server reserves stdout for MCP, including during automatic
+build/bootstrap; diagnostics and inherited child-process output use stderr.
+
+## Pixels and presentation
+
+Both real MagiK and Mini-MagiK are captured from the currently latched scanout slot.
+The shared platform contracts provide the slot layout and FPGA status primitive.
+The tool holds the platform transaction lock while reading and copying the active
+slot, then checks that its sequence, base, flip count and route epoch stayed stable.
+There is no dependency on the legacy device agent, Slint screenshots, `watch-frame`
+preview cache, or a raw `/dev/fb0` reader.
+
+Raw is the default: RGB565 little-endian pixels become lossless RGB8 PNG pixels
+using bit replication; row padding is excluded. A static framebuffer is valid.
+For 640x240 and 640x288, `display` derives a 640x480 view using the existing
+centred nearest-scanline convention: source row `((2*y+1)*height)//960`.
+It never blends rows. All other geometries are unchanged. Metadata explicitly
+identifies a derived transform, original and output sizes, stride and sequence.
+This is framebuffer evidence, not a measurement of physical CRT/HDMI output.
+
+## Native operation
+
+The authenticated `capture-framebuffer` request takes no fields or binary body.
+Its capability has the same name. A successful `framebuffer` response contains:
+
+- `source`: `fpga-latched-scanout-slots`.
+- `pixel_format`: `rgb565-le`.
+- `width`, `height`, `stride_bytes`, `frame_sequence`.
+- Binary body: exactly `stride_bytes * height` bytes.
+
+Transport remains binary; PNG conversion and base64 encoding happen on the host.
+The current shared scanout layout permits widths up to 1366, heights up to 768
+and even strides up to 2736 bytes. Both ends validate geometry before using it.
+
+Capture has one ten-second host deadline spanning connection and reception,
+including a peer that keeps sending partial data. It is never automatically
+retried. Bootstrap/service preparation happens before that deadline.
+
+Errors distinguish `capture-unsupported`, `capture-unavailable`,
+`capture-invalid-geometry`, `capture-invalid-request` and `capture-frame-changed`.
+A changed frame can be requested again explicitly; it is never returned as a
+successful potentially torn image. An unavailable scanout is an error, not a
+reason to substitute a preview or restart the application. MCP failures contain
+text and `isError`, with no fabricated image.
+
+## Milestone 8 review
+
+Focused validation covers RGB565 and padded stride, exact payload length,
+geometry limits, both CRT heights, unchanged other geometries, no retry,
+connect/partial-read deadlines, and SDK initialization/discovery/invocation.
+The stdio fixture also checks that bootstrap subprocess output cannot corrupt
+MCP and that invalid input/failures return errors without images.
+
+Hardware acceptance used the already-installed applications; no application
+rebuild, benchmark, profile or device reboot was needed. Real MagiK was restored
+after the Mini-MagiK capture. Hardware evidence details are recorded below.
+
+- Real MagiK: native 960x540 RGB565 scanout, sequence 163; MCP call 8.404 s,
+  including the automatic service build/update. Image inspected directly in Codex.
+- Mini-MagiK: native 960x540 RGB565 scanout, sequence 1; MCP call 2.958 s.
+  Image inspected directly in Codex; the installed real app was then restored ready.
+- Acceptance limitation: the real-app image was captured on Home, not the Arcade
+  list. It proves native image delivery from scanout but does not visually verify
+  the Rust-painted Arcade rows. One additional screenshot requires user approval
+  because the two planned successful captures have already been used.
+
+Local validation: 24 agent library tests; focused agent Clippy; typed ARM agent
+build; 40 focused Python tests including real MCP stdio exchange. The unchanged
+scope guard is run against the complete committed PR diff. CI owns broad checks.
+The new dependency lock entries are four existing local Rust crates and the MCP
+SDK's Python dependency graph; no previously locked packages were upgraded.

--- a/magik2/docs/legacy-disposition.md
+++ b/magik2/docs/legacy-disposition.md
@@ -39,3 +39,11 @@ against Linux's 15-byte `comm` field. They cannot establish absence. Milestone 3
 corrects that check, verifies the actual executable before its explicit one-shot
 stop, and records fresh before/after evidence. Neither normal delivery nor tests
 automatically stop the old agent.
+
+## Milestone 8: direct framebuffer images
+
+The 2.0 service now exposes authoritative framebuffer capture through the
+`capture_framebuffer` MCP tool. See [capture setup and protocol](framebuffer-capture.md).
+This adds no dependency on the legacy agent. Desktop migration remains deferred;
+its existing client, capture commands and legacy service/startup dependencies are
+retained. No other decisions in this historical milestone-3 inventory are changed.

--- a/magik2/host/magik2/capture.py
+++ b/magik2/host/magik2/capture.py
@@ -1,0 +1,80 @@
+"""In-memory conversion of authoritative RGB565 captures to PNG."""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from collections.abc import Mapping
+
+
+def capture_png(
+    fields: Mapping[str, object], pixels: bytes, view: str
+) -> tuple[bytes, dict]:
+    if view not in {"raw", "display"}:
+        raise ValueError("view must be raw or display")
+    if (
+        fields.get("source") != "fpga-latched-scanout-slots"
+        or fields.get("pixel_format") != "rgb565-le"
+    ):
+        raise ValueError("capture is not authoritative RGB565 scanout")
+    width, height, stride, sequence = (
+        fields.get(key) for key in ("width", "height", "stride_bytes", "frame_sequence")
+    )
+    if not all(type(value) is int for value in (width, height, stride, sequence)):
+        raise ValueError("capture geometry and sequence must be integers")
+    if not (
+        0 < width <= 1366
+        and 0 < height <= 768
+        and width * 2 <= stride <= 2736
+        and stride % 2 == 0
+        and 0 <= sequence <= 65535
+    ):
+        raise ValueError("invalid capture geometry or sequence")
+    if len(pixels) != stride * height:
+        raise ValueError("capture payload length does not match geometry")
+    rows = []
+    for y in range(height):
+        row = bytearray()
+        for (pixel,) in struct.iter_unpack(
+            "<H", pixels[y * stride : y * stride + width * 2]
+        ):
+            red, green, blue = pixel >> 11, (pixel >> 5) & 63, pixel & 31
+            row.extend(
+                (
+                    (red << 3) | (red >> 2),
+                    (green << 2) | (green >> 4),
+                    (blue << 3) | (blue >> 2),
+                )
+            )
+        rows.append(bytes(row))
+    display = view == "display" and width == 640 and height in {240, 288}
+    output_height = 480 if display else height
+    raster = b"".join(
+        b"\0" + rows[((y * 2 + 1) * height // (output_height * 2)) if display else y]
+        for y in range(output_height)
+    )
+    png = b"\x89PNG\r\n\x1a\n" + _chunk(
+        b"IHDR", struct.pack("!IIBBBBB", width, output_height, 8, 2, 0, 0, 0)
+    )
+    png += _chunk(b"IDAT", zlib.compress(raster)) + _chunk(b"IEND", b"")
+    return png, {
+        "source": fields["source"],
+        "pixel_format": fields["pixel_format"],
+        "width": width,
+        "height": height,
+        "stride_bytes": stride,
+        "frame_sequence": sequence,
+        "view": view,
+        "output_width": width,
+        "output_height": output_height,
+        "transform": "derived-nearest-scanline-4:3" if display else "none",
+    }
+
+
+def _chunk(kind: bytes, payload: bytes) -> bytes:
+    return (
+        struct.pack("!I", len(payload))
+        + kind
+        + payload
+        + struct.pack("!I", zlib.crc32(kind + payload))
+    )

--- a/magik2/host/magik2/cli.py
+++ b/magik2/host/magik2/cli.py
@@ -11,19 +11,18 @@ from pathlib import Path
 
 from .apps import APPLICATIONS, application, repository
 from .bootstrap import BootstrapError, SshBootstrap
-from .build import ensure_arm_application, ensure_arm_agent, ensure_arm_package
+from .build import ensure_arm_agent, ensure_arm_application, ensure_arm_package
 from .client import AgentError, NativeAgent
 from .compatibility import AgentStatus
 from .results import (
     append_event,
     create_run,
-    source_context,
     finalize,
     retain_diagnostics,
+    source_context,
 )
 from .token_store import TokenStore, state_root
 from .viewer import serve
-
 
 STATUS_CAPABILITIES = {"status"}
 STOP_CAPABILITIES = {"status", "lifecycle-v1"}
@@ -51,6 +50,9 @@ def main() -> int:
     started = time.monotonic()
     parser = argparse.ArgumentParser(prog="scripts/magik2")
     subcommands = parser.add_subparsers(dest="command", required=True)
+    subcommands.add_parser(
+        "mcp", help="serve framebuffer screenshots to Codex over stdio"
+    )
     subcommands.add_parser("deploy")
     transfer = subcommands.add_parser(
         "transfer-check", help="measure one saved upload without starting it"
@@ -85,6 +87,10 @@ def main() -> int:
             continue
         command.add_argument("--app", choices=tuple(APPLICATIONS), default="magik")
     arguments = parser.parse_args()
+    if arguments.command == "mcp":
+        from .mcp_capture import main as mcp_main
+
+        return mcp_main()
     if arguments.command in {"deploy", "check", "watch"} or (
         arguments.command == "build" and arguments.target == "app"
     ):

--- a/magik2/host/magik2/client.py
+++ b/magik2/host/magik2/client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import socket
+import time
 import uuid
 from collections.abc import Mapping
 
@@ -61,6 +62,25 @@ class NativeAgent:
         if expected_sha256 is not None:
             fields["expected_sha256"] = expected_sha256
         return self._successful("start", fields)
+
+    def capture_framebuffer(self) -> tuple[Mapping[str, object], bytes]:
+        """One binary capture, with a total ten-second deadline and no retry."""
+        deadline = time.monotonic() + 10
+        request = Envelope(uuid.uuid4().hex, "capture-framebuffer", self.token, {})
+        with socket.create_connection((self.host, self.port), timeout=10) as connection:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("capture deadline exceeded")
+            connection.settimeout(remaining)
+            send_message(connection, request)
+            response, body = receive_message(connection, deadline=deadline)
+        if response.request_id != request.request_id:
+            raise ProtocolError("agent reply request identifier did not match")
+        if response.operation == "error":
+            raise AgentError.from_fields(response.fields)
+        if response.operation != "framebuffer":
+            raise ProtocolError("agent returned an unexpected capture response")
+        return response.fields, body
 
     def stop_legacy(self) -> Mapping[str, object]:
         """Explicit migration check; no startup files or application processes change."""

--- a/magik2/host/magik2/mcp_capture.py
+++ b/magik2/host/magik2/mcp_capture.py
@@ -1,0 +1,111 @@
+"""A single-purpose stdio MCP server for direct framebuffer image delivery."""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import anyio
+from mcp import types
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+
+from .capture import capture_png
+from .cli import connect_agent
+from .results import append_event, create_run, finalize, source_context
+
+server = Server("magik2-framebuffer")
+
+
+@server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="capture_framebuffer",
+            description=(
+                "Capture the currently displayed MiSTer framebuffer as a PNG image. "
+                "Does not navigate or restart the app. May install/update the native tooling service "
+                "when capture support is missing. Raw pixels are the default; display derives a "
+                "4:3 inspection view for 640x240/288 CRT rasters."
+            ),
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "view": {
+                        "type": "string",
+                        "enum": ["raw", "display"],
+                        "default": "raw",
+                    }
+                },
+                "additionalProperties": False,
+            },
+        )
+    ]
+
+
+def capture_image(view: str) -> list[types.ImageContent | types.TextContent]:
+    if not os.environ.get("MISTER_IP"):
+        raise ValueError("MISTER_IP is required for framebuffer capture")
+    started = time.monotonic()
+    run = create_run(
+        Path(os.environ.get("MISTER_MAGIK2_RESULTS", "build/magik2-results")),
+        "capture-framebuffer",
+        source_context(os.environ["MISTER_IP"]),
+    )
+    code = 1
+    try:
+        agent, _ = connect_agent(run, {"status", "capture-framebuffer"})
+        fields, pixels = agent.capture_framebuffer()
+        png, metadata = capture_png(fields, pixels, view)
+        append_event(run, {"phase": "capture", **metadata})
+        code = 0
+        return [
+            types.ImageContent(
+                type="image",
+                mimeType="image/png",
+                data=base64.b64encode(png).decode("ascii"),
+            ),
+            types.TextContent(type="text", text=json.dumps(metadata, sort_keys=True)),
+        ]
+    finally:
+        finalize(run, code, round((time.monotonic() - started) * 1000))
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> types.CallToolResult:
+    if name != "capture_framebuffer":
+        return types.CallToolResult(
+            isError=True, content=[types.TextContent(type="text", text="Unknown tool")]
+        )
+    try:
+        content = await anyio.to_thread.run_sync(
+            capture_image, arguments.get("view", "raw")
+        )
+        return types.CallToolResult(content=content)
+    except (OSError, RuntimeError, ValueError) as error:
+        return types.CallToolResult(
+            isError=True, content=[types.TextContent(type="text", text=str(error))]
+        )
+
+
+def main() -> int:
+    # Preserve one protocol descriptor; inherited build/bootstrap stdout belongs
+    # on stderr too, otherwise automatic service installation corrupts MCP JSON.
+    with os.fdopen(
+        os.dup(sys.stdout.fileno()), "w", encoding="utf-8"
+    ) as protocol_output:
+        os.dup2(sys.stderr.fileno(), sys.stdout.fileno())
+
+        async def serve() -> None:
+            async with stdio_server(stdout=anyio.wrap_file(protocol_output)) as (
+                reader,
+                writer,
+            ):
+                await server.run(reader, writer, server.create_initialization_options())
+
+        anyio.run(serve)
+    return 0

--- a/magik2/host/magik2/mcp_capture.py
+++ b/magik2/host/magik2/mcp_capture.py
@@ -30,7 +30,11 @@ async def list_tools() -> list[types.Tool]:
                 "Capture the currently displayed MiSTer framebuffer as a PNG image. "
                 "Does not navigate or restart the app. May install/update the native tooling service "
                 "when capture support is missing. Raw pixels are the default; display derives a "
-                "4:3 inspection view for 640x240/288 CRT rasters."
+                "4:3 inspection view for 640x240/288 CRT rasters. "
+                "The returned image is input for the agent, not proof that the user can see it. "
+                "When asked to show it in chat, explicitly embed the image in your reply. "
+                "If needed, decode this same PNG to a temporary local file and use an absolute-path "
+                "Markdown image embed. Do not take another capture just to display it."
             ),
             inputSchema={
                 "type": "object",

--- a/magik2/host/magik2/protocol.py
+++ b/magik2/host/magik2/protocol.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import socket
 import struct
+import time
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -18,9 +19,16 @@ class ProtocolError(RuntimeError):
     """The peer sent malformed or unsafe framed data."""
 
 
-def _read_exact(connection: socket.socket, size: int) -> bytes:
+def _read_exact(
+    connection: socket.socket, size: int, deadline: float | None = None
+) -> bytes:
     result = bytearray()
     while len(result) < size:
+        if deadline is not None:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TimeoutError("capture deadline exceeded")
+            connection.settimeout(remaining)
         chunk = connection.recv(size - len(result))
         if not chunk:
             raise ProtocolError("connection closed while reading a framed message")
@@ -48,7 +56,7 @@ class Envelope:
         return encoded
 
     @classmethod
-    def from_json(cls, raw: bytes) -> "Envelope":
+    def from_json(cls, raw: bytes) -> Envelope:
         try:
             parsed = json.loads(raw)
         except json.JSONDecodeError as error:
@@ -72,13 +80,15 @@ def send_message(
         connection.sendall(view[offset : offset + 64 * 1024])
 
 
-def receive_message(connection: socket.socket) -> tuple[Envelope, bytes]:
-    header_size, body_size = struct.unpack("!IQ", _read_exact(connection, 12))
+def receive_message(
+    connection: socket.socket, *, deadline: float | None = None
+) -> tuple[Envelope, bytes]:
+    header_size, body_size = struct.unpack("!IQ", _read_exact(connection, 12, deadline))
     if header_size > MAX_HEADER_BYTES or body_size > MAX_BODY_BYTES:
         raise ProtocolError("peer declared an oversized message")
-    return Envelope.from_json(_read_exact(connection, header_size)), _read_exact(
-        connection, body_size
-    )
+    return Envelope.from_json(
+        _read_exact(connection, header_size, deadline)
+    ), _read_exact(connection, body_size, deadline)
 
 
 def sha256_hex(data: bytes) -> str:

--- a/magik2/host/pyproject.toml
+++ b/magik2/host/pyproject.toml
@@ -3,7 +3,7 @@ name = "mister-magik2-host"
 version = "0.1.0"
 description = "Independent host tooling for the MiSTer MagiK probe"
 requires-python = ">=3.12"
-dependencies = ["paramiko>=4,<5", "slint-testing==0.3", "pytest>=8"]
+dependencies = ["paramiko>=4,<5", "slint-testing==0.3", "pytest>=8", "mcp>=1,<2"]
 
 [[tool.uv.index]]
 name = "slint-private"

--- a/magik2/host/tests/test_capture.py
+++ b/magik2/host/tests/test_capture.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import base64
+import json
+import os
+import struct
+import sys
+import zlib
+from pathlib import Path
+
+import anyio
+import pytest
+from magik2.capture import capture_png
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+
+def fields(width=3, height=1, stride_bytes=8):
+    return {
+        "source": "fpga-latched-scanout-slots",
+        "pixel_format": "rgb565-le",
+        "width": width,
+        "height": height,
+        "stride_bytes": stride_bytes,
+        "frame_sequence": 7,
+    }
+
+
+def decode_png(png):
+    assert png[:8] == b"\x89PNG\r\n\x1a\n"
+    offset, compressed, geometry = 8, b"", None
+    while offset < len(png):
+        length = struct.unpack_from("!I", png, offset)[0]
+        kind = png[offset + 4 : offset + 8]
+        payload = png[offset + 8 : offset + 8 + length]
+        assert (
+            zlib.crc32(kind + payload)
+            == struct.unpack_from("!I", png, offset + 8 + length)[0]
+        )
+        if kind == b"IHDR":
+            geometry = struct.unpack("!IIBBBBB", payload)
+        if kind == b"IDAT":
+            compressed += payload
+        offset += length + 12
+    return geometry, zlib.decompress(compressed)
+
+
+def test_rgb565_conversion_ignores_stride_padding():
+    png, metadata = capture_png(
+        fields(), struct.pack("<4H", 0xF800, 0x07E0, 0x001F, 0xFFFF), "raw"
+    )
+    geometry, pixels = decode_png(png)
+    assert geometry == (3, 1, 8, 2, 0, 0, 0)
+    assert pixels == b"\0\xff\0\0\0\xff\0\0\0\xff"
+    assert metadata["transform"] == "none"
+    assert metadata["frame_sequence"] == 7
+
+
+@pytest.mark.parametrize("height", [240, 288])
+def test_display_view_samples_centred_scanlines_without_blending(height):
+    source = b"".join(struct.pack("<H", y % 32) * 640 for y in range(height))
+    png, metadata = capture_png(fields(640, height, 1280), source, "display")
+    geometry, pixels = decode_png(png)
+    assert geometry[:2] == (640, 480)
+    for y in range(480):
+        blue = ((y * 2 + 1) * height // 960) % 32
+        assert pixels[y * 1921 + 1 : y * 1921 + 4] == bytes(
+            (0, 0, (blue << 3) | (blue >> 2))
+        )
+    assert metadata["height"] == height
+    assert metadata["transform"] == "derived-nearest-scanline-4:3"
+
+
+def test_display_leaves_other_geometries_unchanged():
+    assert (
+        capture_png(fields(), bytes(8), "display")[0]
+        == capture_png(fields(), bytes(8), "raw")[0]
+    )
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"width": 0},
+        {"width": 1367},
+        {"height": 769},
+        {"stride_bytes": 5},
+        {"stride_bytes": 2738},
+        {"height": True},
+        {"frame_sequence": -1},
+        {"source": "preview"},
+        {"pixel_format": "rgb888"},
+    ],
+)
+def test_invalid_capture_metadata_is_rejected(change):
+    with pytest.raises(ValueError):
+        capture_png(fields() | change, bytes(8), "raw")
+
+
+@pytest.mark.parametrize("size", [0, 7, 9])
+def test_payload_must_match_geometry_exactly(size):
+    with pytest.raises(ValueError, match="payload length"):
+        capture_png(fields(), bytes(size), "raw")
+
+
+def test_mcp_stdio_discovery_image_and_errors(tmp_path):
+    # Real SDK/stdio session; only the device connection is replaced. Child
+    # process output simulates build/bootstrap chatter and must stay off stdout.
+    script = """
+import subprocess
+from magik2 import mcp_capture
+class Agent:
+    def capture_framebuffer(self):
+        return {"source":"fpga-latched-scanout-slots", "pixel_format":"rgb565-le", "width":1, "height":1, "stride_bytes":2, "frame_sequence":9}, b"\\x00\\xf8"
+def connect(*args):
+    subprocess.run(["echo", "bootstrap output"], check=True)
+    return Agent(), None
+mcp_capture.connect_agent = connect
+mcp_capture.main()
+"""
+
+    async def run():
+        params = StdioServerParameters(
+            command=sys.executable,
+            args=["-c", script],
+            env={
+                **os.environ,
+                "MISTER_IP": "fixture",
+                "MISTER_MAGIK2_RESULTS": str(tmp_path),
+                "PYTHONPATH": str(Path(__file__).resolve().parents[1]),
+            },
+        )
+        with anyio.fail_after(10):
+            async with stdio_client(params) as (reader, writer):
+                async with ClientSession(reader, writer) as session:
+                    await session.initialize()
+                    assert [
+                        tool.name for tool in (await session.list_tools()).tools
+                    ] == ["capture_framebuffer"]
+                    result = await session.call_tool("capture_framebuffer", {})
+                    assert not result.isError
+                    image, metadata = result.content
+                    assert image.type == "image" and image.mimeType == "image/png"
+                    assert (
+                        decode_png(base64.b64decode(image.data, validate=True))[1]
+                        == b"\0\xff\0\0"
+                    )
+                    assert json.loads(metadata.text)["frame_sequence"] == 9
+                    error = await session.call_tool(
+                        "capture_framebuffer", {"view": "invalid"}
+                    )
+                    assert error.isError and all(
+                        part.type == "text" for part in error.content
+                    )
+
+    anyio.run(run)
+    assert not list(tmp_path.rglob("*.png"))
+    assert all("data" not in p.read_text() for p in tmp_path.rglob("events.jsonl"))
+
+
+def test_mcp_capture_error_is_text_without_an_image(monkeypatch):
+    from magik2 import mcp_capture
+
+    def fail(view):
+        raise TimeoutError("capture deadline exceeded")
+
+    monkeypatch.setattr(mcp_capture, "capture_image", fail)
+    result = anyio.run(mcp_capture.call_tool, "capture_framebuffer", {})
+    assert result.isError
+    assert [part.type for part in result.content] == ["text"]
+    assert "deadline" in result.content[0].text

--- a/magik2/host/tests/test_client.py
+++ b/magik2/host/tests/test_client.py
@@ -4,7 +4,6 @@ import socket
 import threading
 
 import pytest
-
 from magik2.client import AgentError, NativeAgent
 from magik2.protocol import Envelope, receive_message, send_message
 
@@ -100,3 +99,43 @@ def test_lost_reply_reuses_the_same_request_identifier_once() -> None:
     thread.join()
     assert len(request_ids) == 2
     assert request_ids[0] == request_ids[1]
+
+
+def test_capture_error_is_not_retried():
+    port, thread = one_reply({"code": "capture-unavailable"}, "error")
+    with pytest.raises(AgentError, match="capture-unavailable"):
+        NativeAgent("127.0.0.1", "token", port).capture_framebuffer()
+    thread.join()
+
+
+def test_capture_transport_failure_has_one_attempt(monkeypatch):
+    attempts = []
+
+    def fail(*args, **kwargs):
+        attempts.append(kwargs["timeout"])
+        raise ConnectionRefusedError("offline")
+
+    monkeypatch.setattr(socket, "create_connection", fail)
+    with pytest.raises(ConnectionRefusedError):
+        NativeAgent("offline", "token").capture_framebuffer()
+    assert attempts == [10]
+
+
+def test_capture_deadline_includes_connect_time(monkeypatch):
+    from magik2 import client
+
+    clock = iter([100, 111])
+    monkeypatch.setattr(client.time, "monotonic", lambda: next(clock))
+
+    class Connection:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            pass
+
+    monkeypatch.setattr(
+        socket, "create_connection", lambda *args, **kwargs: Connection()
+    )
+    with pytest.raises(TimeoutError, match="deadline"):
+        NativeAgent("fixture", "token").capture_framebuffer()

--- a/magik2/host/tests/test_protocol.py
+++ b/magik2/host/tests/test_protocol.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import socket
 
 import pytest
-
 from magik2.compatibility import AgentStatus, needs_install
 from magik2.protocol import (
     Envelope,
@@ -56,3 +55,20 @@ def test_capabilities_not_build_identity_select_agent() -> None:
     )
     assert not needs_install(older, {"status", "upload"})
     assert needs_install(older, {"frames"})
+
+
+def test_total_deadline_expires_even_when_peer_keeps_sending(monkeypatch):
+    from magik2 import protocol
+
+    clock = iter([0, 9, 11])
+    monkeypatch.setattr(protocol.time, "monotonic", lambda: next(clock))
+
+    class SlowPeer:
+        def settimeout(self, seconds):
+            assert seconds > 0
+
+        def recv(self, size):
+            return b"x"
+
+    with pytest.raises(TimeoutError, match="deadline"):
+        protocol._read_exact(SlowPeer(), 4, deadline=10)

--- a/magik2/host/uv.lock
+++ b/magik2/host/uv.lock
@@ -1,6 +1,43 @@
 version = 1
 revision = 3
 requires-python = ">=3.12"
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/56/a8120250d128bed162cd73c76d45f6ef9991f3e068f62a8ee060afa3104a/annotated_types-0.8.0.tar.gz", hash = "sha256:13b2beaad985e05e2d6407ee4c4f35590b11f8d693a258a561055cac8f64cab7", size = 15893, upload-time = "2026-07-23T20:16:13.995Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/91/8acff4f5e50511b911bbccb72b8628a49c68ce14148cd9f6431094859a90/annotated_types-0.8.0-py3-none-any.whl", hash = "sha256:f072f4d804ea359e4eaf198b1af7a8b0943881a87f31bb764f8bf219bb9419e0", size = 13427, upload-time = "2026-07-23T20:16:12.938Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a9/d2/f4d173e22df740bc37b1db102b386ba719b66e95b0f0d751f556b387e6d2/anyio-4.15.1.tar.gz", hash = "sha256:9f28306018cbd6d329e64a36d58256edff76dd996fe423bc957326e578b82a94", size = 276966, upload-time = "2026-09-05T10:42:39.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b8/4bd346e22b28902df4d651910f5242c28d84e4a5c2435ca5c3f797ed7e2e/anyio-4.15.1-py3-none-any.whl", hash = "sha256:6152fdbbf9a77fdec97731721bebf7c4c44f7c29b424b0065826173efc7ed101", size = 132079, upload-time = "2026-09-05T10:42:37.923Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
 
 [[package]]
 name = "bcrypt"
@@ -66,6 +103,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/f6/688d2cd64bfd0b14d805ddb8a565e11ca1fb0fd6817175d58b10052b6d88/bcrypt-5.0.0-cp39-abi3-win32.whl", hash = "sha256:64d7ce196203e468c457c37ec22390f1a61c85c6f0b8160fd752940ccfb3a683", size = 153725, upload-time = "2025-09-25T19:50:34.384Z" },
     { url = "https://files.pythonhosted.org/packages/9f/b9/9d9a641194a730bda138b3dfe53f584d61c58cd5230e37566e83ec2ffa0d/bcrypt-5.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:64ee8434b0da054d830fa8e89e1c8bf30061d539044a39524ff7dec90481e5c2", size = 150912, upload-time = "2025-09-25T19:50:35.69Z" },
     { url = "https://files.pythonhosted.org/packages/27/44/d2ef5e87509158ad2187f4dd0852df80695bb1ee0cfe0a684727b01a69e0/bcrypt-5.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:f2347d3534e76bf50bca5500989d6c1d05ed64b440408057a37673282c654927", size = 144953, upload-time = "2025-09-25T19:50:37.32Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
@@ -154,6 +200,15 @@ wheels = [
 ]
 
 [[package]]
+name = "click"
+version = "8.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
@@ -213,6 +268,61 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -231,10 +341,63 @@ wheels = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.29.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/48/0bb26fdfe7ac16875f534a101ce2405eae192bdef37e7451f2f4507c13ec/mcp-1.29.1.tar.gz", hash = "sha256:1967ba4c315f7a375146209949f45950d18b0efd2f913d7cf3400bc723ee5f04", size = 646823, upload-time = "2026-08-24T18:30:41.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/04/d6b4fb82eefe9e81807aabca1ac98f460ae0883974b83a997aaa20c52545/mcp-1.29.1-py3-none-any.whl", hash = "sha256:b6310eeb59153300c4ab8b9aec4c52f4819a2d6a8e429eb43d908bed7c783648", size = 224653, upload-time = "2026-08-24T18:30:39.573Z" },
+]
+
+[[package]]
 name = "mister-magik2-host"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "mcp" },
     { name = "paramiko" },
     { name = "pytest" },
     { name = "slint-testing" },
@@ -247,6 +410,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mcp", specifier = ">=1,<2" },
     { name = "paramiko", specifier = ">=4,<5" },
     { name = "pytest", specifier = ">=8" },
     { name = "slint-testing", specifier = "==0.3", index = "https://testing.slint.dev/simple/" },
@@ -313,12 +477,130 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/ef/fc4f868f4e2cee79f863883abffceff107875f569b848507319842d2a681/pydantic-2.13.5.tar.gz", hash = "sha256:51a9c5f7b2f8e636f04c6cada605d9b6a3bf1348fdf945a3d8869b19bba0ee08", size = 845750, upload-time = "2026-08-28T14:04:00.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/47/c95ffc2009878c7aac0c5e08528022dcb885933252a88b5f170058014464/pydantic-2.13.5-py3-none-any.whl", hash = "sha256:346a034f080da3755d8e9cb5e00e8b07de1d39e4f6e2c87d8ab7cafa0b269a73", size = 472589, upload-time = "2026-08-28T14:03:59.136Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/f9/8a06bea35ef8daf588f707784c973a7046e0034c8d8cfb08828eeffb8b75/pydantic_core-2.46.5.tar.gz", hash = "sha256:10416c15b8839ecc4ef4d0885da76da6fd0f67333a0eb8aff6d93c4b8f2910fc", size = 472262, upload-time = "2026-08-28T10:01:31.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3f/76358795aa7a8c6d4f36e2cb828ad1c90ee118e1393a9281664f5aade9d4/pydantic_core-2.46.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:b9fe6fb92520e3fd61f2e49000b6911b188824f089b75973ea06d6267f0b476d", size = 2076516, upload-time = "2026-08-28T09:58:21.576Z" },
+    { url = "https://files.pythonhosted.org/packages/db/50/26b091836076ce4cb2fac264186936acc069e0595772cfd02a563bc4761a/pydantic_core-2.46.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a39ac25a9a2fa4072efdb429833c4a4c8009a51ff9eea3eeae131713cd27991e", size = 1922874, upload-time = "2026-08-28T09:58:23.766Z" },
+    { url = "https://files.pythonhosted.org/packages/09/f0/2a8ce3849e299d44e2d2c196b6082643a3235565a735cb51db7a6261f614/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4fdc8b93a41521988916eeaa271173fcca7fa0803d62f87675aac8dcec1c8e29", size = 1951772, upload-time = "2026-08-28T09:58:25.435Z" },
+    { url = "https://files.pythonhosted.org/packages/87/46/ac0dc8bdd9e6048183a14eb127764e7ad9240021c17513074a4711b0e31e/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b98134087d9de723658d17a42c7d0da8d6e2ef08015dee7dc93889047315f5e4", size = 2031832, upload-time = "2026-08-28T09:58:27.102Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/339de5bef7be36301a2231eaa52e62163742c2281f11b5f4892bc79785cd/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e652ab17569c94bff5475520f907b7148b8c24036a8ebbe5cf7cf7493d28579a", size = 2208645, upload-time = "2026-08-28T09:58:28.948Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/a0/9ff22b797724262da14427abaed4dd1d864a139693fc5e7809114376a716/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d925f3d9afd05a8c0fb3a1031463a8d59ebe5e2afad297e29c78be19e13b4e62", size = 2265935, upload-time = "2026-08-28T09:58:30.625Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/a4/eb9409ec0736e50aa70a412f16c204ed149516846912f7e6724d4c73ee53/pydantic_core-2.46.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0fc5be0abd4a407e200d844b404e33639a554e7bd0d448e7b9ae181be4789ac2", size = 2066284, upload-time = "2026-08-28T09:58:32.289Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/02/7f6156ffc926857f1c37c07d9a388682865a81830ab6a1b637082c25e399/pydantic_core-2.46.5-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:816ff0a6550ffc06c098ccd2e0698600f9aa7da192a79eaa6f9af504a35db869", size = 2105889, upload-time = "2026-08-28T09:58:33.986Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b1/e781d357ebe09fc929f995700f1b3503e8897f1cece183ecb1300d4d67e9/pydantic_core-2.46.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c7ea57fc63aa7da93a1bd2d644e6577befae10c52c4e36377635eea1056a74f5", size = 2158006, upload-time = "2026-08-28T09:58:35.647Z" },
+    { url = "https://files.pythonhosted.org/packages/70/0a/644597d84ab400e50609c192120b85c9681c22d3a20461b9060a79be0a7a/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:efd62a42486f1bda5d24cb4f63d15a3c7768375fe83d36f9417b4ad7a2fb20b3", size = 2158408, upload-time = "2026-08-28T09:58:37.38Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ee/ca3b7b3a4b3769ffe9ce9432a7c9be755de9593a46d3b0d54d0409323e44/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:2bc9419666990c06d7397831f2126a1ecc3594aaa3ff7de5bf2d066802f4e07b", size = 2309609, upload-time = "2026-08-28T09:58:39.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/52/39fa1f451486019524ca685020390e7ca351832fd874530ba30c8628e6dc/pydantic_core-2.46.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:18a09e1e1011b462f2e32774f25859ef1223d5c2b0546a633cf56654710721e0", size = 2342618, upload-time = "2026-08-28T09:58:40.89Z" },
+    { url = "https://files.pythonhosted.org/packages/81/5e/468fc630568c61dcef3cd47ad32ffbeed9af643f49208d1ea86ab4f890c4/pydantic_core-2.46.5-cp312-cp312-win32.whl", hash = "sha256:5cb482e9e84c851f4e623fe4acc1ced89168cf1fe18f7089db4548c8f5bbb65b", size = 1939475, upload-time = "2026-08-28T09:58:42.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/c9/4c19f41b84cf6b622a72fbeed7665b25d47a187d68d47d0d430c07f23268/pydantic_core-2.46.5-cp312-cp312-win_amd64.whl", hash = "sha256:5e81740c09e310f5aa5cbd3e434a01c154d4bef93241c7877b39f211d2b78ba8", size = 2043140, upload-time = "2026-08-28T09:58:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/af/dd/0c1a050299147c746e5256db16d645ab5efd4f78c59937d581a0524e74a2/pydantic_core-2.46.5-cp312-cp312-win_arm64.whl", hash = "sha256:f7b0ec93a2893de856652154d73b7ba622f26fa97726487dcac373de5f4c6084", size = 1997729, upload-time = "2026-08-28T09:58:46.13Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/37/5abe39a8372a61d3dc3c1338fc504281c01b32fdb3169cd7187153b56d3e/pydantic_core-2.46.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b7ca9034437b6022f941f4857459562ee00a560b97e7cce8a0ec5a74fc6766e0", size = 2075885, upload-time = "2026-08-28T09:58:47.856Z" },
+    { url = "https://files.pythonhosted.org/packages/21/43/6323b1f8b217780454c61304bcd2b38ae4762f50754414124603ccc90bb2/pydantic_core-2.46.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f332f0e72a5a0400141f830744e141bf9f97917878dbe968669e8a7fefea78ff", size = 1922768, upload-time = "2026-08-28T09:58:49.58Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/a3/c05ca796e1197618a774b01e596aeedfefc2f7d8c01ae3054e910b120e8a/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:193375f3548919d3f0b60936ca113ada3e38f264f91b9b8e0508efaad57be931", size = 1951241, upload-time = "2026-08-28T09:58:51.511Z" },
+    { url = "https://files.pythonhosted.org/packages/68/32/33bc39ac705c52cffc908e8389f9754fdb208aea5c69cceddf4eb3ce99af/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:79bdfa52f843137045b2d081cc05c120ba6665d29b7559c2c47690906f39279f", size = 2031975, upload-time = "2026-08-28T09:58:53.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/70/2333e885c0f6a67bc105c5916965dac9b57f2718ee20d81d1a06a4ebdc13/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:24922243639cbdac66c75fcb6fd6495a9cb52b213d62f9a0d16f0310b1ff8038", size = 2208542, upload-time = "2026-08-28T09:58:55.017Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/ea/296debfb4264207bbda5936133892e027c0a58875ad53ebd512fba8ec3a2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c76fe65e607be28c7fd4d56fc3c42b1583aa058ce3408b7ad0fd540171d31f9f", size = 2264692, upload-time = "2026-08-28T09:58:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/9e4de77a6271e07a76d2d58b11c091a979c191ed2939bf80067568b369d2/pydantic_core-2.46.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7b393a8b3da82f5c1fc0751e6d01ac6c55b93c18226a60bdfba4a724efafd1", size = 2066633, upload-time = "2026-08-28T09:58:58.531Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/db/f9e9d0c97445987b2084823d5c240de88087338f04fc2cfaa2df186b8049/pydantic_core-2.46.5-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:7ac031912d54f3d83ef3b3eb98dfabc1608802e2202263d25957eeed40b94761", size = 2105235, upload-time = "2026-08-28T09:59:00.421Z" },
+    { url = "https://files.pythonhosted.org/packages/07/c5/79169b047b3b2c3e99e04bc76372af9637e0bf6db638274fa927df96369e/pydantic_core-2.46.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:837b396ca3d7b74091ca623f6cbd8351bd42d670a79c2683e79fb089f06a2de5", size = 2157367, upload-time = "2026-08-28T09:59:02.442Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b5/ba6057afb7c291bd449f51b867f95aef2072941c4ce4e5c31d6ffd132d3b/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:5ee239d575f80b08eca11f6e20f90c4c695de7825c67eefe6091fbf20dda648e", size = 2158420, upload-time = "2026-08-28T09:59:04.2Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/28/2057abecaafdc22912afa819603a51f0a62d40643b7c4871c51721fea9be/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:e80675d75ae2cd14372cb65cad5400d9347a3d3f6c13000183f22dfd027283ed", size = 2309588, upload-time = "2026-08-28T09:59:06.048Z" },
+    { url = "https://files.pythonhosted.org/packages/71/9d/881156dc404e27479c4246128d73538464cab4a239bec61995e227644c30/pydantic_core-2.46.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:9c4b71f10dd532fb7a5cbc8f58707779e64f03a258c2bf8bfbaecfcd9970b519", size = 2341866, upload-time = "2026-08-28T09:59:08.539Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/38/d66f443a259f84d13babdceae568e572b0ed26da17ca5d0a649ebb110a67/pydantic_core-2.46.5-cp313-cp313-win32.whl", hash = "sha256:97bf8de4d541598c94a59344eeb988a94c08ff76b5723c41f6567ec18c7892ea", size = 1938580, upload-time = "2026-08-28T09:59:10.402Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/1e/1d5371213f4cc9a7ed70c0bfcc7911de22311ee99a662a56077d7292d2ac/pydantic_core-2.46.5-cp313-cp313-win_amd64.whl", hash = "sha256:15f4a94963c95accac15b7b657bb177d3ad82bb90b0d0526d9a9b85079925db5", size = 2041980, upload-time = "2026-08-28T09:59:12.396Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/48/4222d90b1c67568bace4dec6dca6271449c66de3595d72b6d098f5fde597/pydantic_core-2.46.5-cp313-cp313-win_arm64.whl", hash = "sha256:d22a945598fb91236b4dd793a6e42e4f3dd7740bb5aace5ebd7d4c08d13bb575", size = 1997213, upload-time = "2026-08-28T09:59:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/8a/14596f2a8367da50cf7cbac48169ee5d9c8e11d486a3b527082384630c72/pydantic_core-2.46.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:c1c43ad4339643d70ebb8124e1305a7dab423001eff58bb41a0f731adbc98355", size = 2074081, upload-time = "2026-08-28T09:59:16.141Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/d5/d8a4eb6d6c7f66b91dd37c576d76e9e60fba900caf5372c17bcf949febc2/pydantic_core-2.46.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1a353f84de772f423b5ffb11d7ae352fbbef0f446f3c0b0af0f8236d7233606e", size = 1920497, upload-time = "2026-08-28T09:59:18.065Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/26/092079428f86e927e030b2c0ced87df69dbb1c875cdeaa67bf42ea2be746/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5086029a57366b8cf81b130a43908738095c270c21a8d7f0e8bdfdb89718e2f3", size = 1952130, upload-time = "2026-08-28T09:59:20.476Z" },
+    { url = "https://files.pythonhosted.org/packages/08/c3/8ec0e290a9ebaebd64047bf5fda94be835c6b1551b02437e4b76778fbcd7/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:46c25dda9d092a06c08db76ffe0a197107904d0dfac653f7d5306bbcd6d6119c", size = 2026371, upload-time = "2026-08-28T09:59:22.227Z" },
+    { url = "https://files.pythonhosted.org/packages/01/72/4fd20ad520fb8da0157f95b27a7eb05a72790ef08138e7701ac972c342ea/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:37ea7b83c935e5b0d68c9449b82651accf78a10828b2c02b2f2d9e9496446c21", size = 2202822, upload-time = "2026-08-28T09:59:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/31/b0/d16e0771206b29314f0d52198b720be21e8a99ab2bf11e3bc0d7c9cebdff/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e64e88d5585bea9ce95861079de72006c7fa6d3df4e3a3b65ba31eb979c15c9f", size = 2262756, upload-time = "2026-08-28T09:59:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/9b/59634b7ac631c63b2a37760eb6943af3e29573d6b59a4abc5e7f019d4cee/pydantic_core-2.46.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d510bac3ee52247af28ed4bb18a1e799f040ac60fd2bf5ccd4c92f1fbe786f", size = 2068352, upload-time = "2026-08-28T09:59:29.044Z" },
+    { url = "https://files.pythonhosted.org/packages/08/7c/570abb1ad2155348dc754ea91be22e5aaa18eb6d69a6068f7c6f2679a6ed/pydantic_core-2.46.5-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:a2a5e1d0ff29adddc9f6d6821a66302e4493f8ca898b715b6b1182c2c201ea0a", size = 2104777, upload-time = "2026-08-28T09:59:30.95Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/25/5bf74adc65a1ac5b7be3f6cb0bcb5433615c1598a801c19d830d84c98ded/pydantic_core-2.46.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:03b9666e41e35d8909852ba191a0607520f81b74eaf12ccf8737005dbb313821", size = 2156312, upload-time = "2026-08-28T09:59:32.604Z" },
+    { url = "https://files.pythonhosted.org/packages/90/6a/2ef38830675e050121040618135564ed56b860b45433b02d9b4ebece46f3/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:a91c17edf6eea2402cb5457b4c89e99bc5ed1004aa34c4adf1d4258c1a5c22c2", size = 2150067, upload-time = "2026-08-28T09:59:34.453Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ef/a7dbb03a14a64c2a4621f989c615ed9a892535a6cad938fc27079f919d80/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b49924c73a235e969511bf2aabdff3beebf9820931f646c80274d5d780010c47", size = 2304516, upload-time = "2026-08-28T09:59:36.194Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f8/6bb4c4b80e8a6fde1904c64a51c62a1d04fcdfa3ea521a66b2ddefa1d885/pydantic_core-2.46.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:2cbd9a5eff05e51c447c34dfa4632145b26b09120cf04bd0c871e44c1a5e1c9a", size = 2335223, upload-time = "2026-08-28T09:59:37.931Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/80/f46b8c681195190b2c1f1c7c0a81abce60663e987613e09ef64d433dd96b/pydantic_core-2.46.5-cp314-cp314-win32.whl", hash = "sha256:2d5d76654becf5efd62c9e51c3756c67b49498b0c9a40884934c40807adbd074", size = 1934827, upload-time = "2026-08-28T09:59:39.836Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/3c/60674207246bc0a4009d2391b7c7251c7159f279c8d2ab8aae8ef46f3dee/pydantic_core-2.46.5-cp314-cp314-win_amd64.whl", hash = "sha256:fa10ef4112775900e7a0661068635eb67b2ab824fbde764de6e0e21982a93db0", size = 2042648, upload-time = "2026-08-28T09:59:41.792Z" },
+    { url = "https://files.pythonhosted.org/packages/69/0c/117c562c7c1babdf44576b72a5e496906506c93690387ecfbca7c729ae2e/pydantic_core-2.46.5-cp314-cp314-win_arm64.whl", hash = "sha256:045ab3b6d308439e32b81cc173bba5b9018bc6ed896afd0c65b3b009b1699af5", size = 1989652, upload-time = "2026-08-28T09:59:43.702Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/66/9336ae58f9eb68c41d121894e52c4c89eccb07eb8f602a04ee9c3f37736a/pydantic_core-2.46.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8816f3d218beb4b787de5c9759c259b8fa61f9dec42dc7811f320a33771778b7", size = 2065829, upload-time = "2026-08-28T09:59:45.364Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/02/bc19b47a96c2d3109760711acf22369e56bd7e405ca52f7ade164d2ead57/pydantic_core-2.46.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:bce57638e08ac148e5778cce7feb968307a727d66f8e2274a543d0cf0c9ad6a3", size = 1905716, upload-time = "2026-08-28T09:59:47.18Z" },
+    { url = "https://files.pythonhosted.org/packages/52/a4/70b47c0509923dd98ccfed04fb3e32ea3849c82a0ff2205bb41009b43c00/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:976e1128455aa595ea04c79ccfedff1aaeab96ee013fcc916bed120c4f0ad94f", size = 1934216, upload-time = "2026-08-28T09:59:49.241Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ab/aa03b65f7bb198585edf806b906c3223ecf1795543e39e23aec4cce27ad2/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b891faeedeafba41b2983e5001a81b6a915b69544c7e7570d1989ce1c36ac7", size = 2010635, upload-time = "2026-08-28T09:59:51.692Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8b/0da06343f30b84ec549aafd309c6456223d5dc8bd36af504c573faad561d/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5f194189415698233dd1114a093a9b56e61e2c57e11b469be3b0506f46f0771c", size = 2209369, upload-time = "2026-08-28T09:59:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5b/844c4defaa34a3df66eb9257087d121d70c201298b96abdf9f492fc2f1bf/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:82a36973cf8a2ef5406f4fe2edbf8ed0c99629535d959e0b100c76a32535a111", size = 2253238, upload-time = "2026-08-28T09:59:55.484Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/64/a4e536cb16d7f61a7fd3120b46c577fc7fa7325992f69c4f52bc786d77d8/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cdbb78909f52b981d3b2d56b97328d71eb0b974c36bd77c920123a7ebb192829", size = 2065740, upload-time = "2026-08-28T09:59:58.038Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/75/aaa38c6bc2d085f6605b34eabdc6a8a4e0b2e61fc9c8e6e52b28e97b3125/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:52e24eacdb536cade636aa90fb851835222becff8484b7001fdc78cb0290f2aa", size = 2087425, upload-time = "2026-08-28T09:59:59.898Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ae/fcab4cfc39aba3689e1d20c8b5250ad280957022c09af2ed9cd585602a5e/pydantic_core-2.46.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:37ae34309d7bd8c0d61ab839668058f2a7962ea1fc51d105d2db228fe0618034", size = 2139306, upload-time = "2026-08-28T10:00:03.057Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f4/f1d03a4bc9d9acbc62f4d742b8a319af52f71885079868b2ff8e48a651ee/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:0cdbada856a1c69a7624a64d3d9aefe79300bd6ef827b43a4f265010b9b55184", size = 2144589, upload-time = "2026-08-28T10:00:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/83/f3/7a53bb1356de514a4cd295f25b6ac39237895620c0462d2592b76c16e114/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:545f26c504b27c3758439a5e6d9349931f0a04f855668d5fe323c89e82300a38", size = 2288882, upload-time = "2026-08-28T10:00:07.931Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/94/5a81583660c175c59d49ffb09f4b3a44debeaf86a19fca664ae1cdd9ee32/pydantic_core-2.46.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:ff218293c9c806138dca139765e3b067621be52bcd93cdc14c7711be7ddc90a9", size = 2335210, upload-time = "2026-08-28T10:00:10.177Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9f/5d685c2693b972d1a59c998586e8823712b66603aeff47ee60a4bdaafd37/pydantic_core-2.46.5-cp314-cp314t-win32.whl", hash = "sha256:97cf3eb53a8cccacf9d46686a0926186c9bfb5574f2ed66d3639d5fe117cd3a9", size = 1921180, upload-time = "2026-08-28T10:00:12.35Z" },
+    { url = "https://files.pythonhosted.org/packages/70/12/5c94ee16d65a37a15f9e869f5e6256df111154491173801a4c5e800ab548/pydantic_core-2.46.5-cp314-cp314t-win_amd64.whl", hash = "sha256:d2f9fc07a8042a8f95925b35c4f04f469707c981fc33245b6ca187cf5d2dd290", size = 2020515, upload-time = "2026-08-28T10:00:14.774Z" },
+    { url = "https://files.pythonhosted.org/packages/63/19/67830dda664e6bdf9285ee2e40f355d0d7d6b92aa0c42e8d217bb8d33d36/pydantic_core-2.46.5-cp314-cp314t-win_arm64.whl", hash = "sha256:acf8a67ba51f4ca9ddbd0e6b3000a65ac51ab734661778b3e7ba64d99a710f2f", size = 1989276, upload-time = "2026-08-28T10:00:16.984Z" },
+    { url = "https://files.pythonhosted.org/packages/df/dd/053c2e4303f791f3b8f8a14ab0b22008e8eb21d868c0c90b4f9be705b76a/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:013d6f3483d81e02e7c328831808f336c8596ee33b4bd4026b9ffb1e960b8942", size = 2062540, upload-time = "2026-08-28T10:01:00.318Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/dd/a18df751a5e37dd51bfad7f68e766999125bebe68c9e1d10a493ad01bd63/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:e9c134bb666dd54b778b9fc0d2b50cbb7f979b9e3716f26a88c9ab3b6fc1dd0f", size = 1902040, upload-time = "2026-08-28T10:01:02.529Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/13/01d40f9d07ce8a779fd6e0bd8ad4fba91309500dd67b869e2e219d261a6d/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:347ec774390c87326a2e4929d58d3f7e8763a104d5d35f4cd595a4c952366433", size = 1967479, upload-time = "2026-08-28T10:01:05.004Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/04/c81d4841331c2178b6fb09ae225425e110ed72d990c9fe556c4ec03d1013/pydantic_core-2.46.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e24d8f05fa2d28513d94e877e9c75ad66175376209b3977f916e240e623193c", size = 2111034, upload-time = "2026-08-28T10:01:07.345Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/ca/31c57507b13119d7d3cfa1576dad2911a4861e3be07b579395f4e9d393f9/pydantic_settings-2.15.0.tar.gz", hash = "sha256:694b793e84f766ba76a90ebdefc01d0a9a045dab0382bee70393da93712ad117", size = 261253, upload-time = "2026-08-07T09:24:57.419Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/a4/2bffa9f8e804325a09867f0e9d30795c80ea9f8d62560bd1b6ad6220eb2f/pydantic_settings-2.15.0-py3-none-any.whl", hash = "sha256:0ba092c291c94baceb5eff768aa0d56400a457585bc0175925a5a5510303da42", size = 69413, upload-time = "2026-08-07T09:24:55.839Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -373,6 +655,153 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dotenv"
+version = "1.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "2026.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/be/2e8974163072e7bab7df1a5acd54c4498e75e35d6d18b864d3a9d5dadc92/rpds_py-2026.6.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a0811d33247c3d6128a3001d763f2aa056bb3425204335400ac54f89eec3a0d0", size = 343691, upload-time = "2026-06-30T07:15:14.96Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/73/319dfa745dd668efe89309141ded489126461fcecd2b8f3a3cda185129b6/rpds_py-2026.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:538949e262e46caa31ac01bdb3c1e8f642622922cacbabbae6a8445d9dc33eaf", size = 338542, upload-time = "2026-06-30T07:15:16.267Z" },
+    { url = "https://files.pythonhosted.org/packages/21/63/4239893be1c4d09b709b1a8f6be4188f0870084ff547f46606b8a75f1b03/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:55927d532399c2c646100ff7feb48eaa940ad70f42cd68e1328f3ded9f81ca24", size = 368180, upload-time = "2026-06-30T07:15:17.62Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/ca/9c5de382225234ceb37b1844ebdb140db12b2a278bb9efe2fcd19f6c82ce/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f56f1695bc5c0871cbc33dc0130fcf503aab0c57dcc5a6700a4f49eba4f2652e", size = 375067, upload-time = "2026-06-30T07:15:18.952Z" },
+    { url = "https://files.pythonhosted.org/packages/87/dc/863f69d1bf04ade34b7fe0d59b9fdf6f0135fe2d7cbca74f1d665589559d/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:270b293dae9058fc9fcedab50f13cebf46fb8ed1d1d54e0521a9da5d6b211975", size = 490509, upload-time = "2026-06-30T07:15:20.434Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/ef/eac16a12048b45ec7c7fa94f2be3438a5f26bf9cc8580b18a1cfd609b7f6/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:127565fead0a10943b282957bd5447804ff3160ad79f2ad2635e6d249e380680", size = 382754, upload-time = "2026-06-30T07:15:21.831Z" },
+    { url = "https://files.pythonhosted.org/packages/04/8f/d2f3f532616be4d06c316ef119683e832bd3d41e112bf3a88f4151c95b17/rpds_py-2026.6.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecabd69db66de867690f9797f2f8fa27ba501bbc24540cbdbdc649cd15888ba6", size = 366189, upload-time = "2026-06-30T07:15:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/29/41a7b0e98a4b44cd676ab7598419623373eb43b20be68c084935c1a8cf88/rpds_py-2026.6.3-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:58eadac9cd119677b60e1cf8ac4052f35949d71b8a9e5556efccbe82533cf22a", size = 377750, upload-time = "2026-06-30T07:15:24.659Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/05/ecda0bec46f9a1565090bcdc941d023f6a25aff85fda28f89f8d19878152/rpds_py-2026.6.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7491ee23305ac3eb59e492b6945881f5cd77a6f731061a3f25b77fd40f9e99a4", size = 395576, upload-time = "2026-06-30T07:15:25.987Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a8/6ed52f03ee6cb854ce78785cc9a9a672eb880e83fd7224d471f667d151f1/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c99f7e8ccb3dd6e3e4bfeac657a7b208c9bac8075f4b078c02d7404c34107fa", size = 543807, upload-time = "2026-06-30T07:15:27.356Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/d6/156c0d3eea27ba09b92562ba2364ba124c0a061b199e17eac637cd25a5e2/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:62698275682bf121181861295c9181e789030a2d516071f5b8f3c23c170cd0fc", size = 611187, upload-time = "2026-06-30T07:15:28.931Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/31/774212ed989c62f7f310220089f9b0a3fb8f40f5443d1727abd5d9f52bc9/rpds_py-2026.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a214c993455f99a89aaeadc9b21241900037adc9d97203e374d75513c5911822", size = 573030, upload-time = "2026-06-30T07:15:30.553Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/50/22f73127a41f1ce4f87fe39aadfb9a126345801c274aa93ae88456249327/rpds_py-2026.6.3-cp312-cp312-win32.whl", hash = "sha256:501f9f04a588d6a09179368c57071301445191767c64e4b52a6aa9871f1ef5ed", size = 202185, upload-time = "2026-06-30T07:15:32.027Z" },
+    { url = "https://files.pythonhosted.org/packages/04/3a/f0ee4d4dde9d3b69dedf1b5f74e7a40017046d55052d173e418c6a94f960/rpds_py-2026.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:2c958bf94822e9290a40aaf2a822d4bc5c88099093e3948ad6c571eca9272e5f", size = 220394, upload-time = "2026-06-30T07:15:33.359Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/83/3382fe37f809b59f02aac04dbc4e765b480b46ee0227ed516e3bdc4d3dfc/rpds_py-2026.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:22bffe6042b9bcb0822bcd1955ec00e245daf17b4344e4ed8e9551b976b63e96", size = 215753, upload-time = "2026-06-30T07:15:34.778Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/9e/b818ee580026ec578138e961027a68820c40afeb1ec8f6819b54fb99e196/rpds_py-2026.6.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:3cfe765c1da0072636ca06628261e0ea05688e160d5c8a03e0217c3854037223", size = 343012, upload-time = "2026-06-30T07:15:36.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6b/686d9dc4359a8f163cfbbf89ee0b4e586431de22fe8248edb63a8cf50d49/rpds_py-2026.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f4d78253f6996be4901669ad25319f842f740eccf4d58e3c7f3dd39e6dde1d8f", size = 338203, upload-time = "2026-06-30T07:15:37.462Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/9b/069aa329940f8207615e091f5eedbbd40e1e15eac68a0790fd05ccdf796c/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54f45a148e28767bf343d33a684693c70e451c6f4c0e9904709a723fafbdfc1f", size = 367984, upload-time = "2026-06-30T07:15:39.008Z" },
+    { url = "https://files.pythonhosted.org/packages/14/db/34c203e4becff3703e4d3bc121842c00b8689197f398161203a880052f4e/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:842e7b070435622248c7a2c44ae53fa1440e073cc3023bc919fed570884097a7", size = 374815, upload-time = "2026-06-30T07:15:40.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/7d/8071067d2cc453d916ad836e828c943f575e8a44612537759002a1e07381/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8020133a74bd81b4572dd8e4be028a6b1ebcd70e6726edc3918008c08bee6ee6", size = 490545, upload-time = "2026-06-30T07:15:41.729Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/42/da06c5aa8f0484ff07f270787434204d9f4535e2f8c3b51ed402267e63c3/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cdc7e35386f3847df728fbcb5e887e2d79c19e2fa1eba9e51b6621d23e3243af", size = 382828, upload-time = "2026-06-30T07:15:43.327Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d7/fe978efc2ae50abe48eb7464668ea99f53c010c60aeebb7b35ad27f23661/rpds_py-2026.6.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:acac386b453c2516111b50985d60ce46e7fadb5ea71ae7b25f4c946935bf27cf", size = 365678, upload-time = "2026-06-30T07:15:44.992Z" },
+    { url = "https://files.pythonhosted.org/packages/69/9d/1d8922e1990b2a6eb532b6ff53d3e73d2b3bbffc84116c75826bee73dfc6/rpds_py-2026.6.3-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:425560c6fa0415f27261727bb20bd097568485e5eb0c121f1949417d1c516885", size = 377811, upload-time = "2026-06-30T07:15:46.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/3d/198dceafb4fb034a6a47347e1b0735d34e0bd4a50be4e898d408ee66cb14/rpds_py-2026.6.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a550fb4950a06dde3beb4721f5ad4b25bf4513784665b0a8522c792e2bd822a4", size = 395382, upload-time = "2026-06-30T07:15:47.955Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f1/13968e49655d40b6b19d8b9140296bbc6f1d86b3f0f6c346cf9f1adddf4b/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4f4bca01b63096f606e095734dd56e74e175f94cfbf24ff3d63281cec61f7bb7", size = 543832, upload-time = "2026-06-30T07:15:49.33Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ab/289bcb1b90bd3e40a2900c561fa0e2087345ecbb094f0b870f2345142b7c/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ccffae9a092a00deb7efd545fe5e2c33c33b88e7c054337e9a74c179347d0b7d", size = 611011, upload-time = "2026-06-30T07:15:50.847Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/16/5043105e679436ccfbc8e5e0dd2d663ed18a8b8113515fd06a5e5d77c83e/rpds_py-2026.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1cf01971c4f2c5553b772a542e4aaf191789cd331bc2cd4ff0e6e65ba49e1e97", size = 572431, upload-time = "2026-06-30T07:15:52.394Z" },
+    { url = "https://files.pythonhosted.org/packages/85/ed/adab103321c0a6565d5ae1c2998349bc3ee175b82ccc5ae8fc04cc413075/rpds_py-2026.6.3-cp313-cp313-win32.whl", hash = "sha256:8c3d1e9c15b9d51ca0391e13da1a25a0a4df3c58a37c9dc368e0736cf7f69df0", size = 201710, upload-time = "2026-06-30T07:15:53.894Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ed/a03b09668e74e5dabbf2e211f6468e1820c0552f7b0500082da31841bf7b/rpds_py-2026.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:9250a9a0a6fd4648b3f868da8d91a4c52b5811a62df58e753d50ae4454a36f80", size = 219454, upload-time = "2026-06-30T07:15:55.25Z" },
+    { url = "https://files.pythonhosted.org/packages/27/17/b8642c12930b71bc2b25831f6708ccf0f75abcd11883932ec9ce54ba3a78/rpds_py-2026.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:900a67df3fd1660b035a4761c4ce73c382ea6b35f90f9863c36c6fd8bf8b09bb", size = 215063, upload-time = "2026-06-30T07:15:56.573Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/36/7fbe9dcdaf857fb3f63c2a2284b62492d95f5e8334e947e5fb6e7f68c9be/rpds_py-2026.6.3-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:931908d9fc855d8f74783377822be318edb6dcb19e47169dc038f9a1bf60b06e", size = 344510, upload-time = "2026-06-30T07:15:57.921Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/54/f785cc3d3f60839ca57a5af4927a9f347b07b2799c373fc20f7949f87c7e/rpds_py-2026.6.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d7469697dce35be237db177d42e2a2ee26e6dcc5fc052078a6fefabd288c6edd", size = 339495, upload-time = "2026-06-30T07:15:59.238Z" },
+    { url = "https://files.pythonhosted.org/packages/63/ef/d4cdaf309e6b095b43597103cf8c0b951d6cca2acce68c474f75ec12e0c7/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bcfbcf66006befb9fd2aeaa9e01feaf881b4dc330a02ba07d2322b1c11be7b5d", size = 369454, upload-time = "2026-06-30T07:16:01.021Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4a/9559a68b7ee15db09d7981212e8c2e219d2a1d6d4faa0391d813c3496a36/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:847927daf4cffbd4e90e42bc890069897101edd015f956cb8721b3473372edda", size = 374583, upload-time = "2026-06-30T07:16:02.287Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/75/8964aa7d2c6e8ac43eba8eb6e6b0fdda1f46d39f2fc3e6aa9f2cb17f485d/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:aca6c1ef08a82bfe327cc156da694660f599923e2e6665b6d81c9c2d0ac9ffc8", size = 492919, upload-time = "2026-06-30T07:16:03.723Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/97/6908094ac804115e65aedfd90f1b5fee4eebebd3f6c4cfc5419939267565/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ae50181a047c871561212bb97f7932a2d45fb53e947bd9b57ebad85b529cbc53", size = 383725, upload-time = "2026-06-30T07:16:05.305Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/9c/0d1fdc2e7aba23e290d603bc494e97bd205bae262ce33c6b32a69768ed5e/rpds_py-2026.6.3-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dc319e5a1de4b6913aac94bf6a2f9e847371e0a140a43dd4991db1a09bc2d504", size = 367255, upload-time = "2026-06-30T07:16:07.086Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/fe/f0209ca4a9ed074bc8acb44dfd0e81c3122e94c9689f5645b7973a866719/rpds_py-2026.6.3-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e4316bf32babbed84e691e352faf967ce2f0f024174a8643c37c94a1080374fc", size = 379060, upload-time = "2026-06-30T07:16:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/8d/f1cc54c616b9d8897de8738aac148d20afca93f68187475fe194d09a71b9/rpds_py-2026.6.3-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8c6e5a2f750cc71c3e3b11d71661f21d6f9bc6cebc6564b1466417a1ec03ec77", size = 395960, upload-time = "2026-06-30T07:16:09.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/04/aafff00f73aeca2945f734f1d483c64ab8f472d0864ab02377fd8e89c3b2/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4470ce197d4090875cf6affbf1f853338387428df97c4fb7b7106317b8214698", size = 545356, upload-time = "2026-06-30T07:16:11.816Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/cc/e229663b9e4ddac5a4acbe9085dd80a71af2a5d356b8b39d6bff233f24b0/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea964164cc9afa72d4d9b23cc28dafae93693c0a53e0b42acbff15b22c3f9ddd", size = 612319, upload-time = "2026-06-30T07:16:13.586Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7a/8a0e6d3e6cd066af108b71b43122c3fe158dd9eb86acac626593a2582eb1/rpds_py-2026.6.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:639c8929aa0afe81be836b04de888460d6bed38b9c54cfc18da8f6bfabf5af5d", size = 573508, upload-time = "2026-06-30T07:16:15.23Z" },
+    { url = "https://files.pythonhosted.org/packages/87/03/2a69ab618a789cf6cf85c86bb844c62d090e700ab1a2aa676b3741b6c516/rpds_py-2026.6.3-cp314-cp314-win32.whl", hash = "sha256:882076c00c0a608b131187055ddc5ae29f2e7eaf870d6168980420d58528a5c8", size = 202504, upload-time = "2026-06-30T07:16:16.893Z" },
+    { url = "https://files.pythonhosted.org/packages/85/62/a3892ba945f4e24c78f352e5de3c7620d8479f73f211406a97263d13c7d2/rpds_py-2026.6.3-cp314-cp314-win_amd64.whl", hash = "sha256:0be972be84cfcaf46c8c6edf690ca0f154ac17babf1f6a955a51579b34ad2dc5", size = 220380, upload-time = "2026-06-30T07:16:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e7/c2bd44dc831931815ad11ebb5f430b5a0a4d3caa9de837107876c30c3432/rpds_py-2026.6.3-cp314-cp314-win_arm64.whl", hash = "sha256:2a9c6f195058cb45335e8cc3802745c603d716eb96bc9625950c1aac71c0c703", size = 215976, upload-time = "2026-06-30T07:16:19.654Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9c/fff7b74bce9a091ec9a012a03f9ff5f69364eaf9451060dfc4486da2ffdd/rpds_py-2026.6.3-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:f90938e92afda60266da758ee7d363447f7f0138c9559f9e1811629580582d90", size = 346840, upload-time = "2026-06-30T07:16:21.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/77bcb1168b33704908295533d27f10eb811e9e3e193e8993dc99572211d3/rpds_py-2026.6.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec829541c45bca16e61c7ae50c20501f213605beb75d1aba91a6ee37fbbb56a4", size = 340282, upload-time = "2026-06-30T07:16:22.875Z" },
+    { url = "https://files.pythonhosted.org/packages/87/3c/7a9081c7c9e645b39efe19e4ffbeccd80add246327cd9b888aecffd72317/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afd70d95892096cdb26f15a00c45907b17817577aa8d1c76b2dcc2788391f9e9", size = 370403, upload-time = "2026-06-30T07:16:24.415Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/69/af47021eb7dad6ff3396cb001c08f0f3c4d06c20253f75be6421a59fe6b7/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29dfa0533a5d4c94d4dfa1b694fcb56c9c63aad8330ffdd816fd225d0a7a162f", size = 376055, upload-time = "2026-06-30T07:16:26.111Z" },
+    { url = "https://files.pythonhosted.org/packages/81/fc/a3bcf517084396a6dd258c592567a3c011ba4557f2fde23dceaf26e74f2e/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:af05d726809bff6b141be124d4c7ce998f9c9c7f30edb1f46c07aa103d540b41", size = 494419, upload-time = "2026-06-30T07:16:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/eb/13d529d1788135425c7bf207f8463458ca5d92e43f3f701365b83e9dffc1/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9826217f048f620d9a712672818bf231442c1b35d96b227a07eabd11b4bb6945", size = 384848, upload-time = "2026-06-30T07:16:29.183Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/f4/b7ac49f30013aba8f7b9566b1dd07e81de95e708c1374b7bacc5b9bc5c9c/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:536bceea4fa4acf7e1c61da2b5786304367c816c8895be71b8f537c480b0ea1f", size = 371369, upload-time = "2026-06-30T07:16:30.912Z" },
+    { url = "https://files.pythonhosted.org/packages/31/86/6260bafa622f788b07ddec0e52d810305c8b9b0b8c27f58a2ab04bf62b4f/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:bc0011654b91cc4fb2ae701bec0a0ba1e552c0714247fa7af6c59e0ccfa3a4e1", size = 379673, upload-time = "2026-06-30T07:16:32.486Z" },
+    { url = "https://files.pythonhosted.org/packages/19/c3/03f1ee79a047b48daeca157c89a18509cde22b6b951d642b9b0af1be660a/rpds_py-2026.6.3-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:539d75de9e0d536c84ff18dfeb805398e58227001ce09231a26a08b9aed1ee0e", size = 397500, upload-time = "2026-06-30T07:16:34.471Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/95/8ed0cd8c377dca12aea498f119fe639fc474d1461545c39d2b5872eb1c0f/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:166cf54d9f44fc6ceb53c7860258dde44a81406646de79f8ed3234fca3b6e538", size = 545978, upload-time = "2026-06-30T07:16:36.45Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/f2/0eb57f0eaa83f8fc152a7e03de968ab77e1f00732bebc892b190c6eebde7/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:d34c20167764fbcf927194d532dd7e0c56772f0a5f943fa5ef9e9afbba8fb9db", size = 613350, upload-time = "2026-06-30T07:16:38.213Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/de/e0674bdbc3ef7634989b3f854c3f34bc1f587d36e5bfdc5c378d57034619/rpds_py-2026.6.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ea7bb13b7c9a29791f87a0387ba7d3ad3a6d783d827e4d3f27b40a0ff44495e2", size = 576486, upload-time = "2026-06-30T07:16:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/f6/21101359743cd136ada781e8210a85769578422ba460672eea0e29739200/rpds_py-2026.6.3-cp314-cp314t-win32.whl", hash = "sha256:6de4744d05bd1aa1be4ed7ea1189e3979196808008113bbbf899a460966b925e", size = 201068, upload-time = "2026-06-30T07:16:41.316Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/b2/9574d4d44f7760c2aa32d92a0a4f41698e33f5b204a0bf5c9758f52c79d5/rpds_py-2026.6.3-cp314-cp314t-win_amd64.whl", hash = "sha256:c7b9a2f8f4d8e90af72571d3d495deebdd7e3c75451f5b41719aee166e940fc2", size = 220600, upload-time = "2026-06-30T07:16:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/08/ae/f23a2697e6ee6340a578b0f136be6483657bef0c6f9497b752bb5c0964bb/rpds_py-2026.6.3-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:e059c5dde6452b44424bd1834557556c226b57781dee1227af23518459722b13", size = 344726, upload-time = "2026-06-30T07:16:44.5Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/63/e7b3a1a5358dd32c930a1062d8e15b67fd6e8922e81df9e91706d66ee5c8/rpds_py-2026.6.3-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2f7c26fbc5acd2522b95d4177fe4710ffd8e9b20529e703ffbf8db4d93903f05", size = 339587, upload-time = "2026-06-30T07:16:46.255Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/64/10a85681916ca55fffb91b0a211f84e34297c109243484dd6394660a8a7c/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3086b538543802f84c843911242db20447de00d8752dd0efc936dbcf02218ba", size = 369585, upload-time = "2026-06-30T07:16:48.101Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c2/baf95c7c38823e12ba34407c5f5767a89e5cf2233895e56f608167ae9493/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:8f2e5c5ee828d42cb11760761c0af6507927bec42d0ad5458f97c9203b054617", size = 375479, upload-time = "2026-06-30T07:16:49.93Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/94/0aad06c72d65101e11d33528d438cda99a39ce0da99466e156158f2541d3/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ed0c1e5d10cdc7135537988c74a0188da68e2f3c30813ba3744ab1e42e0480f9", size = 492418, upload-time = "2026-06-30T07:16:51.641Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/17/de3f5a479a1f056535d7489819639d8cd591ea6281d700390b43b1abd745/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c2642a7603ec0b16ed77da4555db3b4b472341904873788327c0b0d7b95f1bb", size = 384123, upload-time = "2026-06-30T07:16:53.622Z" },
+    { url = "https://files.pythonhosted.org/packages/46/7d/bf09bd1b145bb2671c03e1e6d1ab8651858d90d8c7dfeadd85a37a934fd8/rpds_py-2026.6.3-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8e4320744c1ffdd95a603def63344bfab2d33edeab301c5007e7de9f9f5b3885", size = 367351, upload-time = "2026-06-30T07:16:55.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ea/1bb734f314b8be319149ddee80b18bd41372bdcfbdf88d28131c0cd37719/rpds_py-2026.6.3-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:a9f4645593036b81bbdb36b9c8e0ea0d1c3fee968c4d59db0344c14087ef143a", size = 378827, upload-time = "2026-06-30T07:16:56.841Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/93/d9611e5b25e26df9a3649813ed66193ace9347a7c7fc4ab7cf70e94851c0/rpds_py-2026.6.3-cp315-cp315-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e55d236be29255554da47abe5c577637db7c24a02b8b46f0ca9524c855801868", size = 395966, upload-time = "2026-06-30T07:16:58.557Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/cb/99d77e16e5534ae1d90629bbe419ba6ee170833a6a85e3aa1cc41726fbbc/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:24e9c5386e16669b674a69c156c8eeefcb578f3b3397b713b08e6d60f3c7b187", size = 545680, upload-time = "2026-06-30T07:17:00.164Z" },
+    { url = "https://files.pythonhosted.org/packages/59/15/11a29755f790cef7a2f755e8e14f4f0c33f39489e1893a632a2eee59672b/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_i686.whl", hash = "sha256:c60924535c75f1566b6eb75b5c31a48a43fef04fa2d0d201acbad8a9969c6107", size = 611853, upload-time = "2026-06-30T07:17:01.962Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/0c27547e21644da938fb530f7e1a8148dd24d02db07e7a5f2567a17ce710/rpds_py-2026.6.3-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:38a2fea2787428f811719ceb9114cb78964a3138838320c29ac39526c79c16ba", size = 573715, upload-time = "2026-06-30T07:17:03.693Z" },
+    { url = "https://files.pythonhosted.org/packages/29/71/4d8fcf700931815594bce892255bbd973b94efaf0fc1932b0590df18d886/rpds_py-2026.6.3-cp315-cp315-win32.whl", hash = "sha256:d483fe17f01ad64b7bf7cc38fcefff1ca9fb83f8c2b2542b68f97ffe0611b369", size = 202864, upload-time = "2026-06-30T07:17:05.746Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/62/b577562de0edbb55b2be85ce5fd09c33e386b9b13eee09833af4240fd5c4/rpds_py-2026.6.3-cp315-cp315-win_amd64.whl", hash = "sha256:67e3a721ffc5d8d2210d3671872298c4a84e4b8035cfe42ffd7cde35d772b146", size = 220430, upload-time = "2026-06-30T07:17:07.471Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/d6d0b2509825141eef60669a5739eec88dbc6a48053d6c92993a5704defe/rpds_py-2026.6.3-cp315-cp315-win_arm64.whl", hash = "sha256:6e84adbcf4bf841aed8116a8264b9f50b4cb3e7bd89b516122e616ac56ca269e", size = 215877, upload-time = "2026-06-30T07:17:09.008Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/f3ea278f0afd615c1d0f19cb69043a41526e2bb600c2b536eb192218eb27/rpds_py-2026.6.3-cp315-cp315t-macosx_10_12_x86_64.whl", hash = "sha256:ae6dd8f10bd17aad820876d24caec9efdafd80a318d16c0a48edb5e136902c6b", size = 346933, upload-time = "2026-06-30T07:17:10.762Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/29/9907bdf1c5346763cf10b7f6852aad86652168c259def904cbe0082c5864/rpds_py-2026.6.3-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:bdbd97738551fca3917c1bd7188bec1920bb520104f28e7e1007f9ceb17b7690", size = 340274, upload-time = "2026-06-30T07:17:12.266Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/2c/8e03767b5778ef25cebf74a7a91a2c3806f8eced4c92cb7406bbe060756d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b95977e7211527ab0ba576e286d023389fbeeb32a6b7b771665d333c60e5342", size = 370763, upload-time = "2026-06-30T07:17:14.107Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e1/df2a7e1ba2efd796af26194250b8d42c821b46592311595162af9ef0528d/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d15fde0e6fb0d88a60d221204873743e5d9f0b7d29165e62cd86d0413ad74ba6", size = 376467, upload-time = "2026-06-30T07:17:15.76Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/de/8a0814d1946af29cb068fb259aa8622f856df1d0bab58429448726b537f5/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a136d453475ac0fcbda502ef1e6504bd28d6d904700915d278deeab0d00fe140", size = 496689, upload-time = "2026-06-30T07:17:17.308Z" },
+    { url = "https://files.pythonhosted.org/packages/df/f3/f19e0c852ba13694f5a79f3b719331051573cb5693feacf8a88ffffc3a71/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f826877d462181e5eb1c26a0026b8d0cab05d99844ecb6d8bf3627a2ca0c0442", size = 385340, upload-time = "2026-06-30T07:17:18.928Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ae/7ec3a9d2d4351f99e37bcb06b6b6f954512646bfdbf9742e1de727865daf/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:79486287de1730dbaff3dbd124d0ca4d2ef7f9d29bf2544f1f93c09b5bcbbd12", size = 372179, upload-time = "2026-06-30T07:17:20.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/9cee911dff2aaa9a5a8354f6610bf2e6a616de9197c5fff4f54f82585f1e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_31_riscv64.whl", hash = "sha256:808345f53cb952433ca2816f1604ff3515608a81784954f38d4452acfe8e61d5", size = 379993, upload-time = "2026-06-30T07:17:22.212Z" },
+    { url = "https://files.pythonhosted.org/packages/83/6b/7c2a07ba88d1e9a936612f7a5d067467ed03d971d5a06f7d309dff044a7e/rpds_py-2026.6.3-cp315-cp315t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1967debc37f64f2c4dc90a7f563aec558b471966e12adcac4e1c4240496b6ebf", size = 398909, upload-time = "2026-06-30T07:17:23.66Z" },
+    { url = "https://files.pythonhosted.org/packages/97/0b/776ffcb66783637b0031f6d58d6fb55913c8b5abf00aeecd46bf933fb477/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:f0840b5b17057f7fd918b76183a4b5a0635f43e14eb2ce60dce1d4ee4707ea00", size = 546584, upload-time = "2026-06-30T07:17:25.264Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/ba3bc04d7092bd553c9b2b195624992d2cc4f3de1f380b7b93cbee67bd79/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_i686.whl", hash = "sha256:faa679d19a6696fd54259ad321251ad77a13e70e03dd834daa762a44fb6196ef", size = 614357, upload-time = "2026-06-30T07:17:26.888Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/71/14edf065f04630b1a8472f7653cad03f6c478bcf95ea0e6aed55451e33ea/rpds_py-2026.6.3-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:23a439f31ccbeff1574e24889128821d1f7917470e830cf6544dced1c662262a", size = 576533, upload-time = "2026-06-30T07:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/76/65002b08596c389105720a8c0d22298b8dc25a4baf89b2ce431343c8b1de/rpds_py-2026.6.3-cp315-cp315t-win32.whl", hash = "sha256:913ca42ccad3f8cc6e292b587ae8ae49c8c823e5dce51a736252fc7c7cdfa577", size = 201204, upload-time = "2026-06-30T07:17:30.193Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/97/d855d6b3c322d1f27e26f5241c42016b56cf01377ea8ed348285f54652f0/rpds_py-2026.6.3-cp315-cp315t-win_amd64.whl", hash = "sha256:ae3d4fe8c0b9213624fdce7279d70e3b148b682ca20719ebd193a23ebfa47324", size = 220719, upload-time = "2026-06-30T07:17:31.788Z" },
+]
+
+[[package]]
 name = "slint-testing"
 version = "0.3"
 source = { registry = "https://testing.slint.dev/simple/" }
@@ -381,4 +810,64 @@ dependencies = [
 ]
 wheels = [
     { url = "https://testing.slint.dev/simple/slint-testing/slint_testing-0.3-py3-none-any.whl", hash = "sha256:91c05d4f3faf528df26beb197cce668c7a61e97ac00b46eb0cc09666dbdcfe9f" },
+]
+
+[[package]]
+name = "sse-starlette"
+version = "3.4.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "starlette" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2b/54/6767bb789b2f2fed6e0f953df949cd39dc263a384c1b65a95232598621d6/sse_starlette-3.4.11.tar.gz", hash = "sha256:1bae716c02f3e6f294be41ff333220692dae7c3cbab077c900f159676719dade", size = 34972, upload-time = "2026-09-05T12:11:04.607Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/6a/2ba3ed4a69babf3afdddf7d8314a48d87562c0a442206bbc2a1b50d5efc0/sse_starlette-3.4.11-py3-none-any.whl", hash = "sha256:c7b2244bdff016fe7f64e10075e89a3e6bbf899649cc89b0fe884b5545042453", size = 17122, upload-time = "2026-09-05T12:11:03.195Z" },
+]
+
+[[package]]
+name = "starlette"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/26/b09b8010994eccc3c09092e6b34058f36a460eea2d4c3e8b910c695975a0/typing_inspection-0.4.4.tar.gz", hash = "sha256:547274fa6b0a561ccf549cc9524b999a578e737d015d8709d021f9d0d13bea47", size = 76928, upload-time = "2026-08-12T12:37:25.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/67/81/4add07e5172b7ac40d8ed5ff580409a7801a4fe26d529bdd915401dabfbe/typing_inspection-0.4.4-py3-none-any.whl", hash = "sha256:65b8397ba37ccbce054456aaccddfc91e6e3083c92824df348d96ca832f3f147", size = 14750, upload-time = "2026-08-12T12:37:24.648Z" },
+]
+
+[[package]]
+name = "uvicorn"
+version = "0.52.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]


### PR DESCRIPTION
## Behavior corrected

Codex can request the currently displayed MiSTer framebuffer through `scripts/magik2 mcp` and receive a native base64 PNG image. Both installed applications use the same authoritative scanout operation. Desktop and legacy capture remain unchanged.

The service uses existing FPGA/layout primitives, sends binary RGB565 and rejects unavailable or changing scanout. The host converts to lossless PNG and optionally derives the existing CRT 4:3 inspection view. Capture has one ten-second transport deadline and no automatic retry. The SDK-based stdio adapter isolates build/bootstrap output from MCP JSON.

An image reaching the agent does not establish that it is visible to the user. Tool discovery guidance and scoped agent instructions now require an explicit image embed when asked to show a capture. If necessary, the agent reuses the returned PNG as a temporary display copy; no recapture is needed.

## Verification

- Agent library tests, focused Clippy and typed ARM agent build passed.
- Focused Python tests cover MCP initialization/discovery/image invocation, PNG pixel validation, error responses, stdout isolation, stride/geometry and total-deadline/no-retry behavior. All 18 capture tests passed again after the guidance change.
- The unchanged tooling scope guard and mandatory pre-push Python gate passed.
- Hardware images from real MagiK Home and Mini-MagiK were inspected by the agent. The user then authorized an additional capture of the real app's Arcade view: the Rust-painted rows and game preview are visible. The same PNG was explicitly embedded in chat after tool output proved invisible to the user.
- No application rebuild, benchmark, profile or device reboot was needed. Real MagiK was restored after Mini acceptance; the Arcade capture required no navigation or restart.

Setup, protocol and detailed acceptance record: `magik2/docs/framebuffer-capture.md`. No image bytes or credentials are committed. All CI passed before the final guidance-only update; the latest checks are rerunning.

## Compatibility

Only capture requires the new `capture-framebuffer` capability. Existing capability-based bootstrap/update is reused; compatible services are retained regardless of branch, identity or build hash. No protocol version increment, Desktop migration, platform redesign or legacy retirement is included.
