### PR TITLE
Bound MagiK build container retention and add storage cleanup

### DIFF
--- a/magik2/README.md
+++ b/magik2/README.md
@@ -62,6 +62,15 @@ The agent owns the selected app after disconnect and restores it after test sess
 No matching-version, clean-commit, platform qualification, or rollback gate is
 part of this development path.
 
+## Local build storage
+
+Build containers stay warm for two hours, with at most four idle containers
+across checkouts. Cleanup runs during builds; active builds and host caches
+are preserved. Use `scripts/magik2 storage report` to inspect usage and
+`scripts/magik2 storage clean --apply` to apply retention without a device
+connection. See [build storage](docs/build-storage.md) for previews, ownership,
+concurrency, and the separate legacy/BuildKit maintenance procedure.
+
 ## Screenshots directly into Codex
 
 The [framebuffer capture tool](docs/framebuffer-capture.md) returns a native PNG

--- a/magik2/docs/build-storage.md
+++ b/magik2/docs/build-storage.md
@@ -1,0 +1,112 @@
+# Apple Container build storage
+
+MagiK 2 retains at most **four idle build containers across checkouts** for
+**two hours after their last build use**. It checks retention at build start
+and finish, including cached-artifact builds. Active builds are exempt. There
+is no background timer: the last warm containers can remain past expiry until
+the next build or explicit cleanup.
+
+```sh
+scripts/magik2 storage report
+scripts/magik2 storage report --json
+scripts/magik2 storage clean
+scripts/magik2 storage clean --apply
+scripts/magik2 storage clean --all-idle
+scripts/magik2 storage clean --all-idle --apply
+```
+
+`report` and `clean` without `--apply` only inspect resources and establish
+coordination locks; they do not delete anything. `--all-idle` ignores the age
+and count limits for managed containers. Images still require two hours of
+non-use and no container or active-build reference. All commands are host-only:
+no `MISTER_IP`, device connection, bootstrap, or deployment is required. Apple
+Container must be installed and running. Agent callers require the usual
+first-attempt sandbox escalation for Apple Container operations.
+
+Reports show ownership, workspace existence, activity, last use, and deletion
+eligibility. `logical_bytes` is virtual disk capacity; `allocated_bytes` counts
+allocated file blocks, which can be shared by APFS clones. Neither is a promise
+of recoverable space. Applied cleanup reports the measured filesystem free-space
+change, which can also include concurrent disk activity. Apple-wide image,
+container, and volume totals are included in JSON disk accounting.
+
+## Coordination and preservation
+
+Containers carry versioned ownership labels, canonical checkout identity,
+recipe identity, and the shared state directory. Metadata and OS locks live
+under `build-storage` within the existing MagiK state root (normally
+`~/.local/state/mister-magik2`). All worktrees should use the same
+`MISTER_MAGIK2_STATE` override if one is configured. Containers from another
+state root or management version are protected, and cannot be silently adopted.
+
+A checkout lease spans input/cache validation, FFmpeg preparation, compilation,
+and artifact publication. Same-checkout builds serialize; other checkouts may
+compile concurrently. Lifecycle operations coordinate image preparation and
+container creation/deletion. Cleanup never waits for an active checkout lease.
+It also checks guest processes immediately before deleting a running container,
+because guest compilation can survive a disconnected host command. New
+containers use Apple's init process to reap children. Unknown state, mismatched
+identity, unreadable metadata, or failed process inspection prevents deletion.
+
+Source files, package `target` directories (including FFmpeg), and shared host
+Cargo registry/git caches remain mounted from the host. Cleanup never removes
+these directories, shared BuildKit, legacy images, or named volumes. Failed
+build containers get the same retention period as successful builds. Automatic
+cleanup failures are emitted as storage warnings without replacing the build
+result. Explicit storage commands exit nonzero on incomplete inspection or
+failed deletion, and report completed actions alongside failures. Ambiguous
+mutations are reconciled against inventory, never blindly replayed.
+
+Unlabeled old `magik2-*` containers appear as migration candidates. They are
+excluded from automatic cleanup; updating the tooling creates a separately
+named managed container instead of taking over an old one.
+
+## Initial and occasional maintenance
+
+Use a quiet build window for legacy resources and the shared image builder.
+These resources do not participate in the new build-lease protocol.
+
+1. Save `container system df --format json`, `container list --all --format json`,
+   `container image list`, `container volume list`, `df -k`, and allocated sizes
+   under `~/Library/Application Support/com.apple.container`.
+2. Match legacy containers to their exact workspace mounts and toolchain image.
+   Inspect host build clients and guest processes. Recheck immediately before
+   `container stop NAME` and `container delete NAME`; skip active or uncertain
+   resources. Do not infer idleness just from a missing checkout directory.
+3. When no image build or builder worker is active, use `container builder stop`
+   followed by `container builder delete` to discard BuildKit cache. Future
+   image builds recreate it. Never reset the shared builder automatically.
+4. Delete obsolete images individually with `container image delete REFERENCE`,
+   checking all container references/digests first. Keep the current checkout's
+   `magik2-build` recipe image and required Apple runtime images. Avoid a global
+   image prune that also removes unrelated users' resources.
+5. Before `container volume delete NAME`, verify the volume is unreferenced and
+   contains only regenerable scratch state. For Quartus, inspect it read-only
+   using a disposable container. Preserve the host-installed toolchain and
+   downloaded installers. Do not remove a volume whose contents are uncertain.
+6. Record the final inventory and actual free-space change. Never delete
+   Apple's internal snapshots, content blobs, or sparse disk files directly.
+
+Removed legacy images require downloads/rebuilds when those workflows are next
+used. Removed Quartus scratch roots require chroot regeneration; this does not
+remove the separately mounted host installation.
+
+## Validation and initial cleanup evidence — 2026-09-07
+
+The initial cleanup removed five verified idle legacy MagiK 2 containers,
+the idle BuildKit cache, two inspected Quartus scratch volumes, and seven
+obsolete/unused MagiK, Quartus, and Ubuntu image references. The current MagiK 2
+toolchain and a newer container belonging to another task were retained. Host
+source trees, Cargo caches, build outputs, and the Quartus installation were
+preserved.
+
+Filesystem available space increased from **33,706,856,448 bytes** to
+**63,623,061,504 bytes**: **29,916,205,056 bytes (27.86 GiB)** measured across the
+cleanup window. This is an observed host free-space change, not a sum of file
+sizes or a guarantee for other machines.
+
+A disposable real Apple Container verified warm reuse, active host-lease
+protection, protection of a surviving guest workload, two-hour expiry, and
+preservation of host-mounted cache/output markers. Host tests cover age/count
+retention, ownership and metadata failures, interrupted builds, image references,
+CLI previews/JSON, and subprocess-level locking. No device deployment is needed.

--- a/magik2/host/magik2/build.py
+++ b/magik2/host/magik2/build.py
@@ -152,82 +152,29 @@ def write_build_cache(cache_file: Path, fingerprint: str, artifact: Path) -> Non
         temporary.unlink(missing_ok=True)
 
 
-def prepare_container(repository: Path, runner: Callable = subprocess.run) -> str:
-    recipe = repository / "magik2/build/Containerfile"
-    recipe_id = hashlib.sha256(recipe.read_bytes()).hexdigest()[:12]
-    image = f"magik2-build:{recipe_id}"
-    name = (
-        "magik2-"
-        + hashlib.sha256(str(repository.resolve()).encode()).hexdigest()[:12]
-        + "-"
-        + recipe_id
-    )
-    result = runner(
-        ["container", "list", "--all", "--format", "json"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-    containers = json.loads(result.stdout)
-    existing = next((entry for entry in containers if entry["id"] == name), None)
-    if existing:
-        mounts = existing["configuration"]["mounts"]
-        if not any(
-            mount["destination"] == "/workspace"
-            and Path(mount["source"]).resolve() == repository.resolve()
-            for mount in mounts
-        ):
-            raise RuntimeError("build container belongs to another checkout")
-        if existing["status"]["state"] != "running":
-            runner(["container", "start", name], check=True)
-        return name
-    if runner(
-        ["container", "image", "inspect", image], check=False, capture_output=True
-    ).returncode:
-        runner(
-            [
-                "container",
-                "build",
-                "--tag",
-                image,
-                "--file",
-                str(recipe),
-                str(recipe.parent),
-            ],
-            check=True,
-        )
-    cache = Path(
-        os.environ.get(
-            "MISTER_MAGIK2_BUILD_CACHE", str(Path.home() / ".cache/mister-magik2/cargo")
-        )
-    )
-    mounts = ["--volume", f"{repository.resolve()}:/workspace"]
-    for component in ("registry", "git"):
-        path = cache / component
-        path.mkdir(parents=True, exist_ok=True)
-        mounts += ["--volume", f"{path}:/root/.cargo/{component}"]
-    runner(
-        [
-            "container",
-            "run",
-            "--detach",
-            "--name",
-            name,
-            "--cpus",
-            "4",
-            "--memory",
-            "4g",
-            *mounts,
-            image,
-            "sleep",
-            "infinity",
-        ],
-        check=True,
-    )
-    return name
-
-
 def ensure_arm_package(
+    package: Path,
+    cache_file: Path,
+    *,
+    runner: Callable = subprocess.run,
+    prepare: Callable | None = None,
+) -> BuildResult:
+    # Injectable preparation keeps pure build tests independent of Apple Container.
+    if prepare is not None:
+        return _ensure_arm_package(package, cache_file, runner=runner, prepare=prepare)
+    from .storage import Storage
+
+    storage = Storage(runner=runner)
+    with storage.build_session(package.resolve().parents[1]):
+        return _ensure_arm_package(
+            package,
+            cache_file,
+            runner=runner,
+            prepare=lambda repository, _: storage.prepare(repository),
+        )
+
+
+def _ensure_arm_package(
     package: Path,
     cache_file: Path,
     *,
@@ -276,7 +223,7 @@ def ensure_arm_package(
             fingerprint=fingerprint,
         )
     repository = package.resolve().parents[1]
-    name = (prepare or prepare_container)(repository, runner)
+    name = prepare(repository, runner)
     environment = []
     if app and app.name == "magik":
         from .ffmpeg import prepare_ffmpeg

--- a/magik2/host/magik2/cli.py
+++ b/magik2/host/magik2/cli.py
@@ -86,7 +86,24 @@ def main() -> int:
         if name not in {"build", "deploy", "check", "watch"}:
             continue
         command.add_argument("--app", choices=tuple(APPLICATIONS), default="magik")
+    storage = subcommands.add_parser(
+        "storage", help="inspect and clean local build storage"
+    )
+    storage_commands = storage.add_subparsers(dest="storage_command", required=True)
+    report = storage_commands.add_parser(
+        "report", help="report allocation and cleanup eligibility"
+    )
+    report.add_argument("--json", action="store_true")
+    clean = storage_commands.add_parser(
+        "clean", help="preview retention cleanup unless --apply"
+    )
+    clean.add_argument("--apply", action="store_true")
+    clean.add_argument("--all-idle", action="store_true")
     arguments = parser.parse_args()
+    if arguments.command == "storage":
+        from .storage import run_storage
+
+        return run_storage(arguments, repository())
     if arguments.command == "mcp":
         from .mcp_capture import main as mcp_main
 

--- a/magik2/host/magik2/storage.py
+++ b/magik2/host/magik2/storage.py
@@ -1,0 +1,650 @@
+"""Host-only Apple Container ownership, build leases and bounded idle retention."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import math
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import contextmanager, ExitStack
+from pathlib import Path
+
+from .token_store import state_root
+
+IDLE_SECONDS = 2 * 60 * 60
+MAX_IDLE = 4
+LABEL = "io.mister-magik.build."
+VERSION = "1"
+
+
+def checkout_key(repository: Path) -> str:
+    return hashlib.sha256(str(repository.resolve()).encode()).hexdigest()[:12]
+
+
+def recipe_key(repository: Path) -> str:
+    return hashlib.sha256(
+        (repository / "magik2/build/Containerfile").read_bytes()
+    ).hexdigest()[:12]
+
+
+def container_name(repository: Path, recipe: str) -> str:
+    # A new namespace avoids silently adopting legacy containers without leases.
+    return f"magik2-v1-{checkout_key(repository)}-{recipe}"
+
+
+@contextmanager
+def file_lock(path: Path, *, blocking: bool = True):
+    """Never unlink lock files: waiters must continue to lock the same inode."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a+") as handle:
+        try:
+            fcntl.flock(handle, fcntl.LOCK_EX | (0 if blocking else fcntl.LOCK_NB))
+        except BlockingIOError:
+            yield False
+            return
+        try:
+            yield True
+        finally:
+            fcntl.flock(handle, fcntl.LOCK_UN)
+
+
+def atomic_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, delete=False) as output:
+        temporary = Path(output.name)
+        json.dump(value, output)
+    try:
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def allocation(path: Path) -> dict:
+    """Per-file accounting, not an estimate of uniquely freeable APFS blocks."""
+    logical = allocated = 0
+
+    def raise_error(error):
+        raise error
+
+    for directory, _, files in os.walk(path, onerror=raise_error):
+        for filename in files:
+            stat = (Path(directory) / filename).stat()
+            logical += stat.st_size
+            allocated += stat.st_blocks * 512
+    return {"logical_bytes": logical, "allocated_bytes": allocated}
+
+
+def guest_idle(output: str) -> bool:
+    """Only the known init/sleeper tree, this inspection and zombies are idle."""
+    rows = [line.split(None, 3) for line in output.splitlines() if line.strip()]
+    if not rows or any(len(row) != 4 for row in rows):
+        raise ValueError("unrecognized guest process inventory")
+    processes = [
+        (int(pid), int(ppid), state, command) for pid, ppid, state, command in rows
+    ]
+    roots = {pid: command for pid, _, _, command in processes}
+    if roots.get(1) not in {"sleep", ".cz-init"}:
+        return False
+    for pid, ppid, state, command in processes:
+        if state.startswith("Z"):
+            continue
+        if command == "ps" and ppid == 0:
+            continue
+        if pid == 1 and command in {"sleep", ".cz-init"}:
+            continue
+        if command == "sleep" and pid == 2 and ppid == 1 and roots.get(1) == ".cz-init":
+            continue
+        return False
+    return True
+
+
+class Storage:
+    def __init__(
+        self,
+        *,
+        root: Path | None = None,
+        runner=subprocess.run,
+        clock=time.time,
+        data_root: Path | None = None,
+    ):
+        self.root = root if root is not None else state_root() / "build-storage"
+        self.runner = runner
+        self.clock = clock
+        self.data_root = (
+            data_root or Path.home() / "Library/Application Support/com.apple.container"
+        )
+
+    def lifecycle(self):
+        return file_lock(self.root / "lifecycle.lock")
+
+    def checkout_lock(self, repository: Path, *, blocking: bool = True):
+        return file_lock(
+            self.root / "locks" / f"{checkout_key(repository)}.lock", blocking=blocking
+        )
+
+    def command(self, *args: str):
+        return self.runner(
+            ["container", *args], check=True, capture_output=True, text=True, timeout=30
+        )
+
+    def containers(self) -> list[dict]:
+        entries = json.loads(self.command("list", "--all", "--format", "json").stdout)
+        if not isinstance(entries, list):
+            raise ValueError("invalid container inventory")
+        return entries
+
+    def images(self) -> dict[str, str]:
+        entries = json.loads(self.command("image", "list", "--format", "json").stdout)
+        return {
+            entry["configuration"]["name"].removeprefix("docker.io/library/"): entry[
+                "configuration"
+            ]["descriptor"]["digest"]
+            for entry in entries
+        }
+
+    def owned(self, entry: dict) -> tuple[Path, str] | None:
+        config = entry["configuration"]
+        labels = config.get("labels", {})
+        if labels.get(LABEL + "version") != VERSION:
+            return None
+        if labels.get(LABEL + "state") != str(self.root.resolve()):
+            return None
+        repository = Path(labels[LABEL + "checkout"])
+        recipe = labels[LABEL + "recipe"]
+        if (
+            not repository.is_absolute()
+            or str(repository.resolve()) != str(repository)
+            or not re.fullmatch(r"[0-9a-f]{12}", recipe)
+            or entry["id"] != container_name(repository, recipe)
+            or config["image"]["reference"].removeprefix("docker.io/library/")
+            != f"magik2-build:{recipe}"
+            or not any(
+                m["destination"] == "/workspace" and m["source"] == str(repository)
+                for m in config["mounts"]
+            )
+        ):
+            raise ValueError(f"invalid ownership for {entry['id']}")
+        return repository, recipe
+
+    def record_path(self, name: str) -> Path:
+        if not re.fullmatch(r"magik2-v1-[0-9a-f]{12}-[0-9a-f]{12}", name):
+            raise ValueError("invalid managed container identity")
+        return self.root / "containers" / f"{name}.json"
+
+    def last_used(self, entry: dict) -> float:
+        record = json.loads(self.record_path(entry["id"]).read_text())
+        if (
+            record["id"] != entry["id"]
+            or record["creation_date"] != entry["configuration"]["creationDate"]
+            or record["version"] != VERSION
+        ):
+            raise ValueError("container metadata identity mismatch")
+        return self.timestamp(record["last_used"])
+
+    def timestamp(self, value) -> float:
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not math.isfinite(value)
+            or value < 0
+            or value > self.clock()
+        ):
+            raise ValueError("invalid last-use timestamp")
+        return float(value)
+
+    def touch(self, entry: dict) -> None:
+        ownership = self.owned(entry)
+        if ownership is None:
+            raise ValueError("cannot record an unmanaged container")
+        _, recipe = ownership
+        now = self.clock()
+        atomic_json(
+            self.record_path(entry["id"]),
+            {
+                "version": VERSION,
+                "id": entry["id"],
+                "creation_date": entry["configuration"]["creationDate"],
+                "last_used": now,
+            },
+        )
+        atomic_json(
+            self.root / "images" / f"{recipe}.json",
+            {
+                "version": VERSION,
+                "reference": f"magik2-build:{recipe}",
+                "digest": entry["configuration"]["image"]["descriptor"]["digest"],
+                "last_used": now,
+            },
+        )
+
+    def idle(self, entry: dict) -> bool:
+        state = entry["status"]["state"]
+        if state == "stopped":
+            return True
+        if state != "running":
+            raise ValueError(f"uncertain container state: {state}")
+        return guest_idle(
+            self.command(
+                "exec", entry["id"], "ps", "-eo", "pid=,ppid=,stat=,comm="
+            ).stdout
+        )
+
+    def prepare(self, repository: Path) -> str:
+        """Called with the checkout lease held; image creation shares the lifecycle lock."""
+        repository = repository.resolve()
+        recipe = recipe_key(repository)
+        name = container_name(repository, recipe)
+        image = f"magik2-build:{recipe}"
+        with self.lifecycle():
+            existing = next((e for e in self.containers() if e["id"] == name), None)
+            if existing:
+                if self.owned(existing) != (repository, recipe):
+                    raise RuntimeError("build container ownership mismatch")
+                if not self.idle(existing):
+                    raise RuntimeError(
+                        "build container still has an active guest process"
+                    )
+                if existing["status"]["state"] == "stopped":
+                    self.command("start", name)
+            else:
+                if image not in self.images():
+                    self.runner(
+                        [
+                            "container",
+                            "build",
+                            "--tag",
+                            image,
+                            "--file",
+                            str(repository / "magik2/build/Containerfile"),
+                            str(repository / "magik2/build"),
+                        ],
+                        check=True,
+                    )
+                cache = Path(
+                    os.environ.get(
+                        "MISTER_MAGIK2_BUILD_CACHE",
+                        str(Path.home() / ".cache/mister-magik2/cargo"),
+                    )
+                ).expanduser()
+                mounts = ["--volume", f"{repository}:/workspace"]
+                for component in ("registry", "git"):
+                    path = cache / component
+                    path.mkdir(parents=True, exist_ok=True)
+                    mounts += ["--volume", f"{path}:/root/.cargo/{component}"]
+                self.command(
+                    "run",
+                    "--detach",
+                    "--init",
+                    "--name",
+                    name,
+                    "--label",
+                    f"{LABEL}version={VERSION}",
+                    "--label",
+                    f"{LABEL}state={self.root.resolve()}",
+                    "--label",
+                    f"{LABEL}checkout={repository}",
+                    "--label",
+                    f"{LABEL}recipe={recipe}",
+                    "--cpus",
+                    "4",
+                    "--memory",
+                    "4g",
+                    *mounts,
+                    image,
+                    "sleep",
+                    "infinity",
+                )
+            entry = next(e for e in self.containers() if e["id"] == name)
+            self.touch(entry)
+        return name
+
+    @contextmanager
+    def build_session(self, repository: Path):
+        repository = repository.resolve()
+        try:
+            with self.checkout_lock(repository):
+                with self.lifecycle():
+                    atomic_json(
+                        self.root / "leases" / f"{checkout_key(repository)}.json",
+                        {
+                            "repository": str(repository),
+                            "recipe": recipe_key(repository),
+                        },
+                    )
+                self.automatic_cleanup(repository)
+                try:
+                    yield self
+                finally:
+                    try:
+                        with self.lifecycle():
+                            for entry in self.containers():
+                                if entry["id"] == container_name(
+                                    repository, recipe_key(repository)
+                                ):
+                                    self.touch(entry)
+                    except Exception as error:
+                        self.warn(error)
+        finally:
+            # Include failure/interrupt paths, after releasing the build lease.
+            self.automatic_cleanup(repository)
+
+    @staticmethod
+    def warn(error) -> None:
+        print(f"magik2 storage warning: {error}", file=sys.stderr)
+
+    def automatic_cleanup(self, repository: Path) -> None:
+        try:
+            result = self.inspect(repository, apply=True, measure=False)
+            for error in result["errors"]:
+                self.warn(error)
+        except Exception as error:
+            self.warn(error)
+
+    def delete_container(self, entry: dict) -> None:
+        """No blind mutation retries; uncertain results are reconciled then reported."""
+        name = entry["id"]
+        try:
+            if entry["status"]["state"] == "running":
+                self.command("stop", name)
+            self.command("delete", name)
+        except Exception as error:
+            remaining = self.containers()
+            if any(e["id"] == name for e in remaining):
+                raise RuntimeError(
+                    f"{name}: deletion incomplete; inspect before retrying: {error}"
+                ) from error
+        if any(e["id"] == name for e in self.containers()):
+            raise RuntimeError(f"{name}: still present after deletion")
+        self.record_path(name).unlink(missing_ok=True)
+
+    def inspect(
+        self,
+        repository: Path,
+        *,
+        apply: bool = False,
+        all_idle: bool = False,
+        measure: bool = True,
+    ) -> dict:
+        result = {
+            "idle_seconds": IDLE_SECONDS,
+            "max_idle": MAX_IDLE,
+            "apply": apply,
+            "containers": [],
+            "images": [],
+            "errors": [],
+        }
+        before = shutil.disk_usage(self.data_root).free if measure else None
+        with self.lifecycle(), ExitStack() as leases:
+            entries = self.containers()
+            idle = []
+            locked = {}
+            for entry in entries:
+                row = {
+                    "id": entry["id"],
+                    "ownership": "unmanaged",
+                    "activity": "unknown",
+                    "workspace": None,
+                    "workspace_exists": None,
+                    "last_used": None,
+                    "eligible": False,
+                    "reason": "unmanaged",
+                    "removed": False,
+                }
+                result["containers"].append(row)
+                try:
+                    config = entry["configuration"]
+                    workspace = next(
+                        (
+                            m["source"]
+                            for m in config["mounts"]
+                            if m["destination"] == "/workspace"
+                        ),
+                        None,
+                    )
+                    row.update(
+                        workspace=workspace,
+                        workspace_exists=Path(workspace).exists()
+                        if workspace
+                        else None,
+                    )
+                    if measure and re.fullmatch(r"[A-Za-z0-9_.-]+", entry["id"]):
+                        row.update(
+                            allocation(self.data_root / "containers" / entry["id"])
+                        )
+                    ownership = self.owned(entry)
+                    if ownership is None:
+                        if LABEL + "version" in config.get("labels", {}):
+                            row.update(
+                                ownership="other-manager",
+                                reason="different management version or state root",
+                            )
+                        elif entry["id"].startswith("magik2-"):
+                            row.update(
+                                ownership="migration-candidate",
+                                reason="unlabeled legacy container",
+                            )
+                        row["activity"] = entry["status"]["state"]
+                        continue
+                    row["ownership"] = "managed"
+                    owner, _ = ownership
+                    if owner not in locked:
+                        locked[owner] = leases.enter_context(
+                            self.checkout_lock(owner, blocking=False)
+                        )
+                    if not locked[owner]:
+                        row.update(activity="active", reason="build lease held")
+                        continue
+                    row["last_used"] = self.last_used(entry)
+                    if not self.idle(entry):
+                        row.update(activity="active", reason="guest workload")
+                        continue
+                    row.update(activity="idle", reason="retained for reuse")
+                    idle.append((row, entry))
+                except Exception as error:
+                    row.update(activity="unknown", reason=str(error))
+                    result["errors"].append(f"{entry['id']}: {error}")
+            idle.sort(key=lambda pair: (pair[0]["last_used"], pair[0]["id"]))
+            retained = []
+            for row, entry in idle:
+                if (
+                    all_idle
+                    or not row["workspace_exists"]
+                    or self.clock() - row["last_used"] >= IDLE_SECONDS
+                ):
+                    row.update(
+                        eligible=True,
+                        reason="all idle"
+                        if all_idle
+                        else "checkout missing"
+                        if not row["workspace_exists"]
+                        else "idle expiry",
+                    )
+                else:
+                    retained.append((row, entry))
+            for row, _ in retained[: max(0, len(retained) - MAX_IDLE)]:
+                row.update(eligible=True, reason="idle count limit")
+            if apply:
+                for row, entry in idle:
+                    if not row["eligible"]:
+                        continue
+                    try:
+                        # Locks remain held through this final inventory and guest check.
+                        fresh = next(
+                            (e for e in self.containers() if e["id"] == entry["id"]),
+                            None,
+                        )
+                        if (
+                            fresh is None
+                            or fresh["configuration"] != entry["configuration"]
+                            or not self.idle(fresh)
+                        ):
+                            raise RuntimeError(
+                                "container changed or became active; skipped"
+                            )
+                        self.delete_container(fresh)
+                        row["removed"] = True
+                    except Exception as error:
+                        result["errors"].append(f"{entry['id']}: {error}")
+            # Re-inventory after deletions; even unknown containers protect their images.
+            planned_removals = {row["id"] for row, _ in idle if row["eligible"]}
+            current = (
+                self.containers()
+                if apply
+                else [entry for entry in entries if entry["id"] not in planned_removals]
+            )
+            try:
+                self.inspect_images(
+                    repository, current, result, apply=apply, checkout_locks=locked
+                )
+            except Exception as error:
+                result["errors"].append(f"image inspection: {error}")
+            if measure:
+                try:
+                    result["disk_usage"] = json.loads(
+                        self.command("system", "df", "--format", "json").stdout
+                    )
+                    result["accounting_path"] = str(self.data_root)
+                    result["allocation"] = allocation(self.data_root)
+                except Exception as error:
+                    result["errors"].append(f"disk accounting: {error}")
+        if measure:
+            result["free_bytes_before"] = before
+            result["free_bytes_after"] = shutil.disk_usage(self.data_root).free
+            result["free_bytes_change"] = result["free_bytes_after"] - before
+        return result
+
+    def inspect_images(
+        self,
+        repository: Path,
+        entries: list,
+        result: dict,
+        *,
+        apply: bool,
+        checkout_locks: dict,
+    ):
+        images = self.images()
+        protected = {
+            e["configuration"]["image"]["descriptor"]["digest"] for e in entries
+        }
+        image_rows = {
+            ref: {
+                "reference": ref,
+                "digest": digest,
+                "ownership": "unmanaged",
+                "last_used": None,
+                "eligible": False,
+                "removed": False,
+                "reason": "not managed by this state root",
+            }
+            for ref, digest in sorted(images.items())
+        }
+        result["images"].extend(image_rows.values())
+        protected_recipes = {recipe_key(repository)}
+        # A build may hold a lease before its container exists (e.g. cache check).
+        # Corrupt lease records block image deletion rather than guessing ownership.
+        for path in sorted((self.root / "leases").glob("*.json")):
+            lease = json.loads(path.read_text())
+            owner = Path(lease["repository"])
+            if (
+                not owner.is_absolute()
+                or path.stem != checkout_key(owner)
+                or not re.fullmatch(r"[0-9a-f]{12}", lease["recipe"])
+            ):
+                raise ValueError("invalid build lease metadata")
+            if owner in checkout_locks:
+                if not checkout_locks[owner]:
+                    protected_recipes.add(lease["recipe"])
+            else:
+                with self.checkout_lock(owner, blocking=False) as acquired:
+                    if not acquired:
+                        protected_recipes.add(lease["recipe"])
+        for path in sorted((self.root / "images").glob("*.json")):
+            try:
+                record = json.loads(path.read_text())
+                ref = record["reference"]
+                if (
+                    record["version"] != VERSION
+                    or not re.fullmatch(r"[0-9a-f]{12}", path.stem)
+                    or ref != f"magik2-build:{path.stem}"
+                ):
+                    raise ValueError("invalid managed image record")
+                last_used = self.timestamp(record["last_used"])
+                if ref not in images:
+                    continue
+                if images[ref] != record["digest"]:
+                    raise ValueError("image digest changed; skipped")
+                eligible = (
+                    path.stem not in protected_recipes
+                    and images[ref] not in protected
+                    and self.clock() - last_used >= IDLE_SECONDS
+                )
+                row = image_rows[ref]
+                row.update(
+                    ownership="managed",
+                    last_used=last_used,
+                    eligible=eligible,
+                    reason="unused expiry"
+                    if eligible
+                    else "referenced, current, or recently used",
+                )
+                if apply and eligible:
+                    try:
+                        self.command("image", "delete", ref)
+                    except Exception:
+                        if ref in self.images():
+                            raise
+                    if ref in self.images():
+                        raise RuntimeError("image still present after deletion")
+                    row["removed"] = True
+                    path.unlink()
+            except Exception as error:
+                result["errors"].append(f"{path.name}: {error}")
+
+
+def run_storage(arguments, repository: Path) -> int:
+    try:
+        result = Storage().inspect(
+            repository,
+            apply=getattr(arguments, "apply", False),
+            all_idle=getattr(arguments, "all_idle", False),
+        )
+    except Exception as error:
+        result = {"containers": [], "images": [], "errors": [str(error)]}
+    if getattr(arguments, "json", False):
+        print(json.dumps(result, indent=2))
+    else:
+        print(
+            "Apple Container storage (allocated bytes may share APFS blocks; logical bytes are virtual capacity)"
+        )
+        print(
+            "Policy: two hours, four idle containers; cleanup runs during builds, without a background timer."
+        )
+        for row in result["containers"]:
+            print(
+                f"{row['id']}: {row['ownership']}, {row['activity']}; {row['reason']}; "
+                f"eligible={row['eligible']} removed={row['removed']} allocated={row.get('allocated_bytes', 'unknown')} "
+                f"logical={row.get('logical_bytes', 'unknown')} last_used={row['last_used']} "
+                f"workspace={row['workspace']} exists={row['workspace_exists']}"
+            )
+        for row in result["images"]:
+            print(
+                f"{row['reference']}: {row['ownership']}; {row['reason']}; eligible={row['eligible']} removed={row['removed']}"
+            )
+        if "free_bytes_change" in result:
+            print(
+                f"Allocation: {result.get('allocation')}; free-space change: {result['free_bytes_change']} bytes"
+            )
+        if not getattr(arguments, "apply", False):
+            print(
+                "Preview only. Use storage clean --apply to remove eligible managed resources."
+            )
+        for error in result["errors"]:
+            print(f"magik2 storage: {error}", file=sys.stderr)
+    return 2 if result["errors"] else 0

--- a/magik2/host/tests/test_storage.py
+++ b/magik2/host/tests/test_storage.py
@@ -1,0 +1,524 @@
+from __future__ import annotations
+
+import copy
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from magik2 import storage
+from magik2.storage import (
+    IDLE_SECONDS,
+    LABEL,
+    Storage,
+    atomic_json,
+    container_name,
+    guest_idle,
+    recipe_key,
+)
+
+
+class ContainerHost:
+    """Model the external lifecycle, including workloads surviving host disconnects."""
+
+    def __init__(self):
+        self.entries = []
+        self.images = {}
+        self.processes = {}
+        self.calls = []
+        self.fail = None
+        self.ambiguous_delete = False
+
+    def __call__(self, command, **kwargs):
+        self.calls.append(command)
+        args = command[1:]
+        if self.fail and args[: len(self.fail)] == self.fail:
+            raise subprocess.TimeoutExpired(command, 30)
+        output = ""
+        if args[:2] == ["list", "--all"]:
+            output = json.dumps(self.entries)
+        elif args[:2] == ["image", "list"]:
+            output = json.dumps(
+                [
+                    {
+                        "configuration": {
+                            "name": "docker.io/library/" + ref,
+                            "descriptor": {"digest": digest},
+                        }
+                    }
+                    for ref, digest in self.images.items()
+                ]
+            )
+        elif args[0] == "exec":
+            output = self.processes.get(
+                args[1], "1 0 Ss .cz-init\n2 1 S sleep\n9 0 R ps\n"
+            )
+        elif args[0] == "stop":
+            next(e for e in self.entries if e["id"] == args[1])["status"]["state"] = (
+                "stopped"
+            )
+        elif args[0] == "start":
+            next(e for e in self.entries if e["id"] == args[1])["status"]["state"] = (
+                "running"
+            )
+        elif args[0] == "delete":
+            self.entries[:] = [e for e in self.entries if e["id"] != args[1]]
+            if self.ambiguous_delete:
+                raise subprocess.TimeoutExpired(command, 30)
+        elif args[:2] == ["image", "delete"]:
+            del self.images[args[2]]
+        elif args[0] == "run":
+            labels = dict(
+                args[i + 1].split("=", 1)
+                for i, arg in enumerate(args)
+                if arg == "--label"
+            )
+            repository = Path(labels[LABEL + "checkout"])
+            recipe = labels[LABEL + "recipe"]
+            item = entry(repository, recipe)
+            item["configuration"]["labels"] = labels
+            self.entries.append(item)
+        elif args[0] == "build":
+            ref = args[args.index("--tag") + 1]
+            self.images[ref] = "sha256:" + ref.split(":")[1]
+        elif args[:2] == ["system", "df"]:
+            output = "{}"
+        else:
+            raise AssertionError(command)
+        return SimpleNamespace(stdout=output, stderr="", returncode=0)
+
+
+def entry(repository, recipe, *, managed=True):
+    image = f"magik2-build:{recipe}"
+    return {
+        "id": container_name(repository, recipe),
+        "configuration": {
+            "creationDate": "2026-09-07T00:00:00Z",
+            "labels": {
+                LABEL + "version": "1",
+                LABEL + "checkout": str(repository.resolve()),
+                LABEL + "recipe": recipe,
+            }
+            if managed
+            else {},
+            "image": {"reference": image, "descriptor": {"digest": "sha256:" + recipe}},
+            "mounts": [
+                {"source": str(repository.resolve()), "destination": "/workspace"}
+            ],
+        },
+        "status": {"state": "running"},
+    }
+
+
+@pytest.fixture
+def setup(tmp_path, monkeypatch):
+    repository = tmp_path / "repo"
+    (repository / "magik2/build").mkdir(parents=True)
+    (repository / "magik2/build/Containerfile").write_text("FROM ubuntu:20.04\n")
+    data = tmp_path / "apple"
+    data.mkdir()
+    now = [100_000.0]
+    host = ContainerHost()
+    host.images[f"magik2-build:{recipe_key(repository)}"] = "sha256:" + recipe_key(
+        repository
+    )
+    manager = Storage(
+        root=tmp_path / "state", runner=host, clock=lambda: now[0], data_root=data
+    )
+    monkeypatch.setenv("MISTER_MAGIK2_BUILD_CACHE", str(tmp_path / "cargo"))
+    return manager, host, repository, now
+
+
+def add(setup, name="other", *, age=0, managed=True, recipe=None):
+    manager, host, repository, now = setup
+    owner = repository.parent / name
+    owner.mkdir(exist_ok=True)
+    item = entry(owner, recipe or recipe_key(repository), managed=managed)
+    if managed:
+        item["configuration"]["labels"][LABEL + "state"] = str(manager.root.resolve())
+    host.entries.append(item)
+    (manager.data_root / "containers" / item["id"]).mkdir(parents=True)
+    host.images[item["configuration"]["image"]["reference"]] = item["configuration"][
+        "image"
+    ]["descriptor"]["digest"]
+    if managed:
+        manager.touch(item)
+        path = manager.record_path(item["id"])
+        data = json.loads(path.read_text())
+        data["last_used"] -= age
+        atomic_json(path, data)
+    return item
+
+
+def test_warm_reuse_preserves_mounts_and_uses_init(setup):
+    manager, host, repo, now = setup
+    with manager.build_session(repo):
+        name = manager.prepare(repo)
+    now[0] += 10
+    with manager.build_session(repo):
+        assert manager.prepare(repo) == name
+    runs = [c for c in host.calls if c[1] == "run"]
+    assert len(runs) == 1 and "--init" in runs[0]
+    assert f"{repo.resolve()}:/workspace" in runs[0]
+    assert any(c.endswith(":/root/.cargo/registry") for c in runs[0])
+    assert manager.last_used(host.entries[0]) == now[0]
+
+
+def test_stopped_container_restarts_and_busy_guest_blocks_reuse(setup):
+    manager, host, repo, _ = setup
+    with manager.build_session(repo):
+        name = manager.prepare(repo)
+    host.entries[0]["status"]["state"] = "stopped"
+    with manager.build_session(repo):
+        manager.prepare(repo)
+    assert ["container", "start", name] in host.calls
+    host.processes[name] = "1 0 Ss .cz-init\n2 1 S sleep\n42 0 R rustc\n43 0 R ps\n"
+    with pytest.raises(RuntimeError, match="active guest"):
+        with manager.build_session(repo):
+            manager.prepare(repo)
+
+
+def test_expiry_missing_checkout_and_lru(setup):
+    manager, host, repo, now = setup
+    expired = add(setup, "expired", age=IDLE_SECONDS)
+    missing = add(setup, "missing")
+    Path(missing["configuration"]["labels"][LABEL + "checkout"]).rmdir()
+    warm = [add(setup, f"warm{i}", age=100 - i) for i in range(5)]
+    preview = manager.inspect(repo, measure=False)
+    assert {r["id"] for r in preview["containers"] if r["eligible"]} == {
+        expired["id"],
+        missing["id"],
+        warm[0]["id"],
+    }
+    assert not any(c[1] in {"stop", "delete"} for c in host.calls)
+    result = manager.inspect(repo, apply=True, measure=False)
+    assert not result["errors"]
+    assert {e["id"] for e in host.entries} == {e["id"] for e in warm[1:]}
+
+
+def test_all_idle_preserves_active_unknown_and_unmanaged(setup):
+    manager, host, repo, _ = setup
+    add(setup, "idle")
+    busy = add(setup, "busy")
+    host.processes[busy["id"]] = "1 0 Ss sleep\n55 0 S cargo\n56 0 R ps\n"
+    unmanaged = add(setup, "legacy", managed=False)
+    bad = add(setup, "corrupt")
+    manager.record_path(bad["id"]).write_text("broken")
+    result = manager.inspect(repo, apply=True, all_idle=True, measure=False)
+    assert {e["id"] for e in host.entries} == {busy["id"], unmanaged["id"], bad["id"]}
+    assert len(result["errors"]) == 1
+    assert (
+        next(r for r in result["containers"] if r["id"] == unmanaged["id"])["ownership"]
+        == "migration-candidate"
+    )
+
+
+@pytest.mark.parametrize(
+    "change", ["ownership", "creation", "future", "nan", "missing", "state"]
+)
+def test_uncertain_identity_or_metadata_never_deleted(setup, change):
+    manager, host, repo, now = setup
+    item = add(setup, age=IDLE_SECONDS)
+    record = manager.record_path(item["id"])
+    if change == "ownership":
+        item["configuration"]["mounts"][0]["source"] = "/different"
+    elif change == "creation":
+        item["configuration"]["creationDate"] = "replacement"
+    elif change == "missing":
+        record.unlink()
+    elif change == "state":
+        item["status"]["state"] = "starting"
+    else:
+        data = json.loads(record.read_text())
+        data["last_used"] = now[0] + 10 if change == "future" else float("nan")
+        atomic_json(record, data)
+    result = manager.inspect(repo, apply=True, all_idle=True, measure=False)
+    assert result["errors"] and len(host.entries) == 1
+
+
+def test_inspection_failure_and_failed_deletion_protect_resources(setup):
+    manager, host, repo, _ = setup
+    item = add(setup, age=IDLE_SECONDS)
+    for command in (["exec"], ["stop"], ["delete"]):
+        host.fail = command
+        result = manager.inspect(repo, apply=True, measure=False)
+        assert result["errors"] and host.entries
+    assert manager.record_path(item["id"]).exists()
+
+
+def test_ambiguous_successful_deletion_is_reconciled_once(setup):
+    manager, host, repo, _ = setup
+    item = add(setup, age=IDLE_SECONDS)
+    host.ambiguous_delete = True
+    result = manager.inspect(repo, apply=True, measure=False)
+    assert not result["errors"] and not host.entries
+    assert sum(c[1] == "delete" for c in host.calls) == 1
+    assert not manager.record_path(item["id"]).exists()
+
+
+def test_final_activity_recheck_catches_new_guest_work(setup, monkeypatch):
+    manager, host, repo, _ = setup
+    add(setup, age=IDLE_SECONDS)
+    calls = iter([True, False])
+    monkeypatch.setattr(manager, "idle", lambda _: next(calls))
+    result = manager.inspect(repo, apply=True, measure=False)
+    assert result["errors"] and host.entries
+    assert not any(c[1] == "stop" for c in host.calls)
+
+
+def test_image_age_digest_current_recipe_and_unknown_references(setup):
+    manager, host, repo, now = setup
+    old = add(setup, recipe="a" * 12)
+    old_ref = old["configuration"]["image"]["reference"]
+    host.entries.clear()
+    now[0] += IDLE_SECONDS
+    # An unmanaged alias reference protects the same digest.
+    alias = copy.deepcopy(old)
+    alias["configuration"]["labels"] = {}
+    alias["configuration"]["image"]["reference"] = "keep:alias"
+    host.entries.append(alias)
+    manager.inspect(repo, apply=True, measure=False)
+    assert old_ref in host.images
+    host.entries.clear()
+    host.images[old_ref] = "sha256:replacement"
+    assert manager.inspect(repo, apply=True, measure=False)["errors"]
+    host.images[old_ref] = old["configuration"]["image"]["descriptor"]["digest"]
+    assert not manager.inspect(repo, apply=True, measure=False)["errors"]
+    assert old_ref not in host.images
+    assert f"magik2-build:{recipe_key(repo)}" in host.images
+
+
+def test_failed_and_interrupted_builds_touch_and_run_final_cleanup(setup, monkeypatch):
+    manager, host, repo, now = setup
+    for error in (RuntimeError("compile failed"), KeyboardInterrupt()):
+        cleanup = []
+        monkeypatch.setattr(
+            manager, "automatic_cleanup", lambda _: cleanup.append(True)
+        )
+        with pytest.raises(type(error)):
+            with manager.build_session(repo):
+                manager.prepare(repo)
+                now[0] += 10
+                raise error
+        assert len(cleanup) == 2
+        assert manager.last_used(host.entries[0]) == now[0]
+
+
+def test_cleanup_warning_does_not_mask_build_failure(setup, monkeypatch, capsys):
+    manager, host, repo, _ = setup
+    host.fail = ["list"]
+    with pytest.raises(RuntimeError, match="original failure"):
+        with manager.build_session(repo):
+            raise RuntimeError("original failure")
+    assert "storage warning" in capsys.readouterr().err
+
+
+def test_cache_hit_still_holds_lease_and_cleans_twice(setup, monkeypatch):
+    from magik2 import build
+
+    manager, host, repo, _ = setup
+    package = repo / "magik2/agent"
+    package.mkdir(parents=True)
+    calls = []
+    monkeypatch.setattr(storage, "Storage", lambda **_: manager)
+    monkeypatch.setattr(manager, "automatic_cleanup", lambda _: calls.append("clean"))
+
+    def cache_hit(*args, **kwargs):
+        with manager.checkout_lock(repo, blocking=False) as acquired:
+            assert not acquired
+        return "cached artifact"
+
+    monkeypatch.setattr(build, "_ensure_arm_package", cache_hit)
+    assert (
+        build.ensure_arm_package(package, package / "cache.json") == "cached artifact"
+    )
+    assert calls == ["clean", "clean"]
+    assert not any(c[1] == "run" for c in host.calls)
+
+
+def test_guest_process_parser_fails_closed():
+    assert guest_idle("1 0 Ss sleep\n3 1 Z rustc <defunct>\n4 0 R ps\n")
+    assert not guest_idle("1 0 Ss sleep\n8 0 S sleep\n9 0 R ps\n")
+    assert not guest_idle("1 0 Ss bash\n9 0 R ps\n")
+    assert not guest_idle("1 0 Ss .cz-init\n2 1 S sleep\n7 1 S sleep\n9 0 R ps\n")
+    with pytest.raises(ValueError):
+        guest_idle("")
+    with pytest.raises(ValueError):
+        guest_idle("unexpected output")
+
+
+def test_real_process_lease_serializes_checkout_and_survives_waiters(setup):
+    manager, host, repo, _ = setup
+    item = add(setup, age=IDLE_SECONDS)
+    owner = Path(item["configuration"]["labels"][LABEL + "checkout"])
+    lock = manager.root / "locks" / f"{storage.checkout_key(owner)}.lock"
+    code = "from pathlib import Path; import sys; from magik2.storage import file_lock\nwith file_lock(Path(sys.argv[1])):\n print('locked', flush=True)\n sys.stdin.readline()\n"
+    env = dict(os.environ, PYTHONPATH=str(Path(storage.__file__).parents[1]))
+    child = subprocess.Popen(
+        [sys.executable, "-c", code, str(lock)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    try:
+        assert child.stdout.readline().strip() == "locked"
+        with manager.checkout_lock(owner, blocking=False) as acquired:
+            assert not acquired
+        with manager.checkout_lock(repo, blocking=False) as acquired:
+            assert acquired
+        result = manager.inspect(repo, apply=True, all_idle=True, measure=False)
+        assert not result["errors"] and host.entries
+        assert result["containers"][0]["reason"] == "build lease held"
+    finally:
+        child.kill()
+        child.wait(timeout=5)
+        child.stdin.close()
+        child.stdout.close()
+    with manager.checkout_lock(owner, blocking=False) as acquired:
+        assert acquired
+    assert not manager.inspect(repo, apply=True, all_idle=True, measure=False)["errors"]
+    assert not host.entries
+
+
+def test_cli_json_preview_and_no_device_configuration(setup, monkeypatch, capsys):
+    from magik2 import cli
+
+    manager, host, repo, _ = setup
+    add(setup, age=IDLE_SECONDS)
+    monkeypatch.delenv("MISTER_IP", raising=False)
+    monkeypatch.setattr(storage, "Storage", lambda: manager)
+    monkeypatch.setattr(cli, "repository", lambda: repo)
+    monkeypatch.setattr(
+        cli,
+        "create_run",
+        lambda *_: pytest.fail("storage should not create a device run"),
+    )
+    monkeypatch.setattr(sys, "argv", ["scripts/magik2", "storage", "report", "--json"])
+    assert cli.main() == 0
+    result = json.loads(capsys.readouterr().out)
+    assert result["containers"][0]["eligible"]
+    assert not any(c[1] in {"stop", "delete"} for c in host.calls)
+    monkeypatch.setattr(
+        sys, "argv", ["scripts/magik2", "storage", "clean", "--all-idle", "--apply"]
+    )
+    assert cli.main() == 0
+    assert not host.entries
+    capsys.readouterr()
+    host.fail = ["list"]
+    monkeypatch.setattr(sys, "argv", ["scripts/magik2", "storage", "report", "--json"])
+    assert cli.main() == 2
+    assert json.loads(capsys.readouterr().out)["errors"]
+
+
+def test_two_recipes_in_same_checkout_are_both_eligible(setup):
+    manager, host, repo, _ = setup
+    add(setup, "shared", age=IDLE_SECONDS)
+    add(setup, "shared", age=IDLE_SECONDS, recipe="b" * 12)
+    result = manager.inspect(repo, apply=True, measure=False)
+    assert not result["errors"] and not host.entries
+
+
+def test_different_state_root_cannot_adopt_or_delete_container(setup):
+    manager, host, repo, _ = setup
+    with manager.build_session(repo):
+        name = manager.prepare(repo)
+    other = Storage(
+        root=manager.root.parent / "other-state",
+        runner=host,
+        clock=manager.clock,
+        data_root=manager.data_root,
+    )
+    result = other.inspect(repo, apply=True, all_idle=True, measure=False)
+    assert host.entries and not result["containers"][0]["eligible"]
+    with pytest.raises(RuntimeError, match="ownership mismatch"):
+        with other.build_session(repo):
+            other.prepare(repo)
+    assert host.entries[0]["id"] == name
+
+
+def test_pending_build_lease_protects_image_before_container_creation(setup):
+    manager, host, repo, now = setup
+    future = repo.parent / "future"
+    (future / "magik2/build").mkdir(parents=True)
+    (future / "magik2/build/Containerfile").write_text("FROM pending\n")
+    recipe = recipe_key(future)
+    item = add(setup, "future", recipe=recipe)
+    host.entries.clear()
+    now[0] += IDLE_SECONDS
+    with manager.build_session(future):
+        result = manager.inspect(repo, apply=True, measure=False)
+        assert not result["errors"]
+        assert item["configuration"]["image"]["reference"] in host.images
+    # A stale unlocked lease does not indefinitely pin its image.
+    result = manager.inspect(repo, apply=True, measure=False)
+    assert not result["errors"]
+    assert item["configuration"]["image"]["reference"] not in host.images
+
+
+def test_recent_unreferenced_image_retained_until_two_hours(setup):
+    manager, host, repo, now = setup
+    item = add(setup, recipe="c" * 12)
+    host.entries.clear()
+    ref = item["configuration"]["image"]["reference"]
+    now[0] += IDLE_SECONDS - 1
+    assert not manager.inspect(repo, apply=True, measure=False)["errors"]
+    assert ref in host.images
+    now[0] += 1
+    assert not manager.inspect(repo, apply=True, measure=False)["errors"]
+    assert ref not in host.images
+
+
+def test_image_inventory_failure_preserves_partial_cleanup_results(setup):
+    manager, host, repo, _ = setup
+    item = add(setup, age=IDLE_SECONDS)
+    host.fail = ["image", "list"]
+    result = manager.inspect(repo, apply=True, measure=False)
+    assert result["errors"]
+    assert result["containers"][0]["removed"]
+    assert not any(e["id"] == item["id"] for e in host.entries)
+
+
+def test_same_checkout_waiter_blocks_until_owner_releases(setup):
+    manager, _, repo, _ = setup
+    lock = manager.root / "locks" / f"{storage.checkout_key(repo)}.lock"
+    env = dict(os.environ, PYTHONPATH=str(Path(storage.__file__).parents[1]))
+    code = "from pathlib import Path; import sys; from magik2.storage import file_lock\nprint('waiting', flush=True)\nwith file_lock(Path(sys.argv[1])):\n print('acquired', flush=True)\n"
+    with manager.checkout_lock(repo):
+        child = subprocess.Popen(
+            [sys.executable, "-c", code, str(lock)],
+            stdout=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+        assert child.stdout.readline().strip() == "waiting"
+        assert child.poll() is None
+    try:
+        output, _ = child.communicate(timeout=5)
+        assert output.strip() == "acquired" and child.returncode == 0
+    finally:
+        if child.poll() is None:
+            child.kill()
+            child.wait(timeout=5)
+
+
+def test_preview_includes_images_freed_by_planned_container_removal(setup):
+    manager, host, repo, now = setup
+    item = add(setup, recipe="d" * 12)
+    now[0] += IDLE_SECONDS
+    preview = manager.inspect(repo, measure=False)
+    candidate = next(
+        r
+        for r in preview["images"]
+        if r["reference"] == item["configuration"]["image"]["reference"]
+    )
+    assert candidate["eligible"] and not candidate["removed"] and host.entries
+    applied = manager.inspect(repo, apply=True, measure=False)
+    candidate = next(
+        r for r in applied["images"] if r["reference"] == candidate["reference"]
+    )
+    assert candidate["removed"] and not applied["errors"]


### PR DESCRIPTION
## Behavior corrected

MagiK 2 left a persistent Apple Container VM behind for every checkout and recipe, including deleted worktrees. Builds now keep at most four idle containers for two hours, cleaning at build start and finish while preserving host Cargo caches and artifacts. Checkout leases, ownership labels, final guest-process checks, and image-reference protection prevent cleanup from interrupting builds.

Adds host-only `scripts/magik2 storage report [--json]` and preview-first `storage clean [--all-idle] [--apply]`. Legacy containers, other management state roots, shared BuildKit, and named volumes remain outside automatic cleanup. There is no background timer, so expired resources can remain until another build or explicit cleanup.

The documented initial maintenance recovered 29,916,205,056 bytes (27.86 GiB) of measured filesystem free space while preserving the current toolchain image and another task's newer container.

## Verification

- 106 MagiK 2 host tests passed, including subprocess locking, cache-hit cleanup, expiry/LRU, surviving guest workloads, metadata failures, image protection, and preview/apply agreement.
- Ruff 0.11.8 formatting and configured lint checks passed; tooling scope and pre-commit checks passed.
- Disposable real Apple Container checks passed for warm reuse, active lease protection, surviving guest work, expiry, and host-mounted cache/output preservation. The initial live check exposed Apple's `.cz-init` name; idle recognition was corrected and the check passed on rerun.
- The public JSON report ran successfully against the cleaned host. Maintenance details and validation evidence are in `magik2/docs/build-storage.md`.

No device deployment or hardware acceptance was performed; this change is host-only. Disk-allocation totals can include shared APFS blocks; reported recovery is the actual observed free-space change across the maintenance window.

## Compatibility

Build, deploy, and bootstrap paths using the existing host builder receive bounded retention. Existing unlabeled containers are reported as migration candidates and are never silently adopted or deleted. Compatible device agents and native protocol behavior are unchanged. Use the same shared `MISTER_MAGIK2_STATE` override across worktrees when configured.
