### PR TITLE
Integrate measured Cortex-A9 rendering optimisations

### DIFF
--- a/apps/mister/build.rs
+++ b/apps/mister/build.rs
@@ -15,7 +15,6 @@ fn main() {
     println!("cargo:rerun-if-changed=Cargo.toml");
     println!("cargo:rerun-if-changed=src/particle_neon.c");
     println!("cargo:rerun-if-changed=src/arcade_list_neon.c");
-    println!("cargo:rerun-if-changed=src/orientation_transition_neon.c");
     println!("cargo:rerun-if-changed=src/crt_backdrop_neon.c");
     println!("cargo:rerun-if-changed=../../mister/platform/runtime/c_build_support.rs");
     println!("cargo:rerun-if-changed=../../.git/HEAD");
@@ -59,7 +58,6 @@ fn main() {
         particle_neon
             .file("src/particle_neon.c")
             .file("src/arcade_list_neon.c")
-            .file("src/orientation_transition_neon.c")
             .file("src/crt_backdrop_neon.c")
             .flag("-std=c11")
             .flag("-O3")

--- a/apps/mister/src/launcher_runtime/orientation_transition.rs
+++ b/apps/mister/src/launcher_runtime/orientation_transition.rs
@@ -461,6 +461,9 @@ impl OrientationTransitionRuntime {
             self.to,
             OrientationPmuPhase::Crossfade,
         ));
+        let previous =
+            (self.previous_levels_valid && self.previous_revealing == revealing && !done)
+                .then_some(&self.previous_levels);
         match self.effect {
             OrientationTransitionEffect::BrightnessFade => render_brightness_wave_dirty(
                 frame,
@@ -470,13 +473,14 @@ impl OrientationTransitionRuntime {
                 &levels,
                 damage,
             ),
-            OrientationTransitionEffect::CenterPixelZoom => render_center_pixel_zoom_wave_dirty(
+            OrientationTransitionEffect::CenterPixelZoom => render_center_pixel_zoom_wave_retained(
                 frame,
                 output,
                 self.width,
                 self.height,
                 &levels,
                 damage,
+                previous,
             ),
         };
         self.previous_levels = levels;
@@ -598,6 +602,27 @@ fn render_center_pixel_zoom_wave(
     output.len().min(u64::MAX as usize) as u64
 }
 
+fn zoom_words<'a, 'b>(
+    frame: &'a [Rgb565Pixel],
+    output: &'b mut [Rgb565Pixel],
+) -> (&'a [u16], &'b mut [u16]) {
+    const {
+        assert!(std::mem::size_of::<Rgb565Pixel>() == std::mem::size_of::<u16>());
+    }
+    const {
+        assert!(std::mem::align_of::<Rgb565Pixel>() >= std::mem::align_of::<u16>());
+    }
+    // SAFETY: Slint RGB565 is a transparent packed u16 with every bit pattern
+    // valid; preserve the original disjoint slice borrows and lengths.
+    unsafe {
+        (
+            std::slice::from_raw_parts(frame.as_ptr().cast(), frame.len()),
+            std::slice::from_raw_parts_mut(output.as_mut_ptr().cast(), output.len()),
+        )
+    }
+}
+
+#[cfg(test)]
 fn render_center_pixel_zoom_wave_dirty(
     frame: &[Rgb565Pixel],
     output: &mut [Rgb565Pixel],
@@ -606,12 +631,42 @@ fn render_center_pixel_zoom_wave_dirty(
     black_levels: &[u8; ORIENTATION_TILE_COUNT],
     damage: OrientationTransitionDamage,
 ) {
-    if render_center_pixel_zoom_wave_neon(frame, output, width, height, black_levels, damage) {
-        return;
-    }
-    render_center_pixel_zoom_wave_scalar(frame, output, width, height, black_levels, damage);
+    render_center_pixel_zoom_wave_retained(
+        frame,
+        output,
+        width,
+        height,
+        black_levels,
+        damage,
+        None,
+    );
 }
 
+fn render_center_pixel_zoom_wave_retained(
+    frame: &[Rgb565Pixel],
+    output: &mut [Rgb565Pixel],
+    width: usize,
+    height: usize,
+    black_levels: &[u8; ORIENTATION_TILE_COUNT],
+    damage: OrientationTransitionDamage,
+    previous: Option<&[u8; ORIENTATION_TILE_COUNT]>,
+) {
+    let (frame, output) = zoom_words(frame, output);
+    assert!(
+        mister_magik_framebuffer_scenes::orientation::render_zoom_retained(
+            frame,
+            output,
+            width,
+            height,
+            black_levels,
+            &damage.rows,
+            previous,
+        )
+        .is_some()
+    );
+}
+
+#[cfg(test)]
 fn render_center_pixel_zoom_wave_scalar(
     frame: &[Rgb565Pixel],
     output: &mut [Rgb565Pixel],
@@ -620,25 +675,17 @@ fn render_center_pixel_zoom_wave_scalar(
     black_levels: &[u8; ORIENTATION_TILE_COUNT],
     damage: OrientationTransitionDamage,
 ) {
-    for tile_row in 0..ORIENTATION_GRID_ROWS {
-        let tile_y0 = tile_row * height / ORIENTATION_GRID_ROWS;
-        let tile_y1 = (tile_row + 1) * height / ORIENTATION_GRID_ROWS;
-        for tile_column in 0..ORIENTATION_GRID_COLUMNS {
-            if damage.rows[tile_row] & (1_u16 << tile_column) == 0 {
-                continue;
-            }
-            let tile_x0 = tile_column * width / ORIENTATION_GRID_COLUMNS;
-            let tile_x1 = (tile_column + 1) * width / ORIENTATION_GRID_COLUMNS;
-            copy_rect(frame, output, width, tile_x0, tile_x1, tile_y0, tile_y1);
-            let black_level = black_levels[tile_row * ORIENTATION_GRID_COLUMNS + tile_column];
-            if black_level == ORIENTATION_TILE_SKIP {
-                continue;
-            }
-            let (x0, x1) = centered_span(tile_x0, tile_x1, black_level);
-            let (y0, y1) = centered_span(tile_y0, tile_y1, black_level);
-            fill_black_rect(output, width, x0, x1, y0, y1);
-        }
-    }
+    let (frame, output) = zoom_words(frame, output);
+    assert!(
+        mister_magik_framebuffer_scenes::orientation::render_zoom_scalar(
+            frame,
+            output,
+            width,
+            height,
+            black_levels,
+            &damage.rows
+        )
+    );
 }
 
 fn orientation_wave_state<'a>(
@@ -758,55 +805,27 @@ fn render_brightness_wave_neon(
     false
 }
 
+#[cfg(all(test, target_os = "linux", target_arch = "arm"))]
 fn render_center_pixel_zoom_wave_neon(
     frame: &[Rgb565Pixel],
     output: &mut [Rgb565Pixel],
     width: usize,
     height: usize,
-    black_levels: &[u8; ORIENTATION_TILE_COUNT],
+    levels: &[u8; ORIENTATION_TILE_COUNT],
     damage: OrientationTransitionDamage,
 ) -> bool {
-    #[cfg(all(target_os = "linux", target_arch = "arm"))]
-    if orientation_neon_enabled()
-        && frame.len() == output.len()
-        && frame.len() == width.saturating_mul(height)
-        && width >= ORIENTATION_GRID_COLUMNS
-        && height >= ORIENTATION_GRID_ROWS
-    {
-        unsafe extern "C" {
-            fn mister_magik_orientation_zoom_neon(
-                source: *const u16,
-                output: *mut u16,
-                width: usize,
-                height: usize,
-                black_levels: *const u8,
-                dirty_rows: *const u16,
-            );
-        }
-        // SAFETY: the slices are complete, distinct RGB565 planes with the
-        // supplied geometry; the fixed level array covers every grid tile.
-        unsafe {
-            mister_magik_orientation_zoom_neon(
-                frame.as_ptr().cast(),
-                output.as_mut_ptr().cast(),
-                width,
-                height,
-                black_levels.as_ptr(),
-                damage.rows.as_ptr(),
-            );
-        }
-        return true;
+    if !orientation_neon_enabled() {
+        return false;
     }
-    let _ = (
+    let (frame, output) = zoom_words(frame, output);
+    mister_magik_framebuffer_scenes::orientation::render_zoom(
         frame,
         output,
         width,
         height,
-        black_levels,
-        damage,
-        orientation_neon_enabled(),
-    );
-    false
+        levels,
+        &damage.rows,
+    )
 }
 
 fn orientation_tile_eased_level(phase_elapsed_us: u64, row: usize, column: usize) -> Option<u8> {
@@ -831,56 +850,6 @@ fn orientation_tile_eased_level(phase_elapsed_us: u64, row: usize, column: usize
         .saturating_add(u64::from(u16::MAX) / 2)
         / u64::from(u16::MAX);
     Some(u8::try_from(level).unwrap_or(RGB565_OPACITY_LEVELS))
-}
-
-fn centered_span(start: usize, end: usize, level: u8) -> (usize, usize) {
-    let span = end.saturating_sub(start);
-    if span == 0 {
-        return (start, start);
-    }
-    let scaled = span
-        .saturating_sub(1)
-        .saturating_mul(usize::from(level))
-        .saturating_add(usize::from(RGB565_OPACITY_LEVELS / 2))
-        / usize::from(RGB565_OPACITY_LEVELS);
-    let visible_span = 1usize.saturating_add(scaled).min(span);
-    let center = start + span.saturating_sub(1) / 2;
-    let centered_start = center.saturating_sub((visible_span - 1) / 2).max(start);
-    (
-        centered_start,
-        centered_start.saturating_add(visible_span).min(end),
-    )
-}
-
-fn fill_black_rect(
-    output: &mut [Rgb565Pixel],
-    stride: usize,
-    x0: usize,
-    x1: usize,
-    y0: usize,
-    y1: usize,
-) {
-    for y in y0..y1 {
-        let start = y * stride + x0;
-        let end = y * stride + x1;
-        output[start..end].fill(Rgb565Pixel(0));
-    }
-}
-
-fn copy_rect(
-    source: &[Rgb565Pixel],
-    output: &mut [Rgb565Pixel],
-    stride: usize,
-    x0: usize,
-    x1: usize,
-    y0: usize,
-    y1: usize,
-) {
-    for y in y0..y1 {
-        let start = y * stride + x0;
-        let end = y * stride + x1;
-        output[start..end].copy_from_slice(&source[start..end]);
-    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1267,6 +1236,71 @@ mod tests {
             false,
         ));
         assert_eq!(runtime.duration, ORIENTATION_WAVE_TOTAL_DURATION);
+    }
+
+    #[test]
+    fn retained_zoom_runtime_matches_full_redraw_through_restart_and_reveal() {
+        for (width, height) in [(33, 31), (160, 90)] {
+            let source = (0..width * height)
+                .map(|i| Rgb565Pixel((i as u16).wrapping_mul(7919)))
+                .collect::<Vec<_>>();
+            let destination = source.iter().map(|p| Rgb565Pixel(!p.0)).collect::<Vec<_>>();
+            let start = Instant::now();
+            let mut runtime = OrientationTransitionRuntime::new_with_effect(
+                width,
+                height,
+                OrientationTransitionEffect::CenterPixelZoom,
+            );
+            assert!(runtime.start(
+                ScreenOrientation::Normal,
+                ScreenOrientation::MonitorClockwise,
+                &source,
+                start,
+                false
+            ));
+            assert!(runtime.capture_destination(&destination));
+            let mut retained = source.clone();
+            for elapsed in (0..1550).step_by(17).chain([1550]) {
+                let duration = Duration::from_millis(elapsed);
+                let mut expected = source.clone();
+                render_center_pixel_zoom_wave(
+                    &source,
+                    &destination,
+                    &mut expected,
+                    width,
+                    height,
+                    duration,
+                );
+                assert!(
+                    runtime
+                        .render_into(&mut retained, start + duration)
+                        .is_some()
+                );
+                assert!(retained == expected, "retained mismatch at {elapsed}ms");
+            }
+            assert!(runtime.start(
+                ScreenOrientation::MonitorClockwise,
+                ScreenOrientation::Normal,
+                &destination,
+                start,
+                false
+            ));
+            assert!(runtime.capture_destination(&source));
+            assert!(runtime.restart_animation(start));
+            runtime.render_into(&mut retained, start).unwrap();
+            let mut expected = destination.clone();
+            // Level zero already covers the first tile's centre pixel; it is
+            // distinct from the skip sentinel, even at the restart timestamp.
+            render_center_pixel_zoom_wave(
+                &destination,
+                &source,
+                &mut expected,
+                width,
+                height,
+                Duration::ZERO,
+            );
+            assert!(retained == expected, "restart differs from fresh redraw");
+        }
     }
 
     #[test]

--- a/crates/framebuffer-scenes/build.rs
+++ b/crates/framebuffer-scenes/build.rs
@@ -7,6 +7,7 @@ mod c_build_support;
 fn main() {
     println!("cargo:rerun-if-env-changed=MISTER_RGB565_NEON");
     println!("cargo:rerun-if-changed=src/rgb565_neon.c");
+    println!("cargo:rerun-if-changed=src/orientation_neon.c");
     println!("cargo:rerun-if-changed=../../mister/platform/runtime/c_build_support.rs");
     if std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() != Ok("arm") {
         return;
@@ -15,6 +16,7 @@ fn main() {
     build
         .inherit_rustflags(false)
         .file("src/rgb565_neon.c")
+        .file("src/orientation_neon.c")
         .flag("-std=c11")
         .flag("-O3")
         .flag("-mtune=cortex-a9")

--- a/crates/framebuffer-scenes/src/lib.rs
+++ b/crates/framebuffer-scenes/src/lib.rs
@@ -1109,6 +1109,136 @@ mod tests {
     use super::*;
 
     #[test]
+    fn half_blend_preserves_channel_floor_without_cross_channel_carries() {
+        for (bits, shift) in [(5_u32, 11_u32), (6, 5), (5, 0)] {
+            for from in 0_u16..(1 << bits) {
+                for to in 0_u16..(1 << bits) {
+                    let a = from << shift;
+                    let b = to << shift;
+                    assert_eq!(
+                        (a & b) + (((a ^ b) & 0xf7de) >> 1),
+                        ((from + to) / 2) << shift
+                    );
+                }
+            }
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn scalar_blend_exact(from: Rgb565Pixel, to: Rgb565Pixel, alpha: u16) -> Rgb565Pixel {
+        let from = u32::from(from.0);
+        let to = u32::from(to.0);
+        let alpha = u32::from(alpha.min(32));
+        let inverse = 32 - alpha;
+        let red_blue = (((from & 0xf81f) * inverse + (to & 0xf81f) * alpha) >> 5) & 0xf81f;
+        let green = (((from & 0x07e0) * inverse + (to & 0x07e0) * alpha) >> 5) & 0x07e0;
+        Rgb565Pixel((red_blue | green) as u16)
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    fn assert_neon_blend_case(
+        previous: &[Rgb565Pixel],
+        current: &[Rgb565Pixel],
+        start: usize,
+        end: usize,
+        alpha: u16,
+    ) {
+        const CANARY: Rgb565Pixel = Rgb565Pixel(0xdead);
+        assert!(start <= end && end <= previous.len() && end <= current.len());
+        let mut actual = vec![CANARY; end + 5];
+        let mut expected = actual.clone();
+        for index in start..end {
+            expected[index] = scalar_blend_exact(previous[index], current[index], alpha);
+        }
+        if start == end {
+            assert!(!blend_rgb565_neon_if_available(
+                &mut actual,
+                previous,
+                current,
+                start,
+                end,
+                alpha,
+            ));
+        } else {
+            assert!(blend_rgb565_neon_if_available(
+                &mut actual,
+                previous,
+                current,
+                start,
+                end,
+                alpha,
+            ));
+        }
+        assert_eq!(actual, expected, "range={start}..{end} alpha={alpha}");
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    #[test]
+    fn neon_blend_covers_empty_small_boundaries_alignment_and_canaries() {
+        let previous = (0..96)
+            .map(|index| Rgb565Pixel((index as u16).wrapping_mul(977).wrapping_add(13)))
+            .collect::<Vec<_>>();
+        let current = (0..96)
+            .map(|index| Rgb565Pixel((index as u16).wrapping_mul(613).wrapping_add(29)))
+            .collect::<Vec<_>>();
+        for offset in [0, 1] {
+            let previous = &previous[offset..];
+            let current = &current[offset..];
+            for length in [0, 1, 2, 7, 8, 9, 15, 16, 17, 31, 32, 33] {
+                assert_neon_blend_case(previous, current, 3, 3 + length, 16);
+            }
+        }
+    }
+
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    #[test]
+    fn neon_blend_exhausts_each_channel_and_mixed_patterns() {
+        fn pack(red: u16, green: u16, blue: u16) -> Rgb565Pixel {
+            Rgb565Pixel((red << 11) | (green << 5) | blue)
+        }
+
+        for alpha in [0, 1, 2, 15, 16, 31, 32, 33, 255] {
+            let channels: [(u16, fn(u16, u16) -> (Rgb565Pixel, Rgb565Pixel)); 3] = [
+                (32, |from: u16, to: u16| {
+                    (pack(from, 17, 9), pack(to, 17, 9))
+                }),
+                (64, |from: u16, to: u16| {
+                    (pack(19, from, 11), pack(19, to, 11))
+                }),
+                (32, |from: u16, to: u16| {
+                    (pack(23, 41, from), pack(23, 41, to))
+                }),
+            ];
+            for (limit, pack_pixel) in channels {
+                let mut previous = Vec::with_capacity(usize::from(limit) * usize::from(limit));
+                let mut current = Vec::with_capacity(usize::from(limit) * usize::from(limit));
+                for from in 0..limit {
+                    for to in 0..limit {
+                        let (previous_pixel, current_pixel) = pack_pixel(from, to);
+                        previous.push(previous_pixel);
+                        current.push(current_pixel);
+                    }
+                }
+                assert_neon_blend_case(&previous, &current, 0, previous.len(), alpha);
+            }
+
+            let previous = (0..40)
+                .map(|index| pack(index % 32, (index * 11) % 64, (index * 7) % 32))
+                .collect::<Vec<_>>();
+            let current = (0..40)
+                .map(|index| {
+                    pack(
+                        31 - index % 32,
+                        63 - (index * 5) % 64,
+                        31 - (index * 3) % 32,
+                    )
+                })
+                .collect::<Vec<_>>();
+            assert_neon_blend_case(&previous, &current, 3, 37, alpha);
+        }
+    }
+
+    #[test]
     fn geometry_rejects_invalid_or_overflowing_lengths() {
         assert!(SceneGeometry::new(0, 1, 1).is_err());
         assert!(SceneGeometry::new(1, 0, 1).is_err());

--- a/crates/framebuffer-scenes/src/lib.rs
+++ b/crates/framebuffer-scenes/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 pub mod navigation;
+pub mod orientation;
 
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]

--- a/crates/framebuffer-scenes/src/orientation.rs
+++ b/crates/framebuffer-scenes/src/orientation.rs
@@ -1,0 +1,273 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Portable orientation zoom compositor shared by the app and Mini.
+pub const COLUMNS: usize = 16;
+pub const ROWS: usize = 9;
+pub const TILES: usize = COLUMNS * ROWS;
+pub const SKIP: u8 = 255;
+
+pub fn centered_span(start: usize, end: usize, level: u8) -> (usize, usize) {
+    let span = end.saturating_sub(start);
+    if span == 0 {
+        return (start, start);
+    }
+    let scaled = span
+        .saturating_sub(1)
+        .saturating_mul(usize::from(level))
+        .saturating_add(16)
+        / 32;
+    let visible = 1usize.saturating_add(scaled).min(span);
+    let center = start + span.saturating_sub(1) / 2;
+    let first = center.saturating_sub((visible - 1) / 2).max(start);
+    (first, first.saturating_add(visible).min(end))
+}
+
+fn valid(
+    source: &[u16],
+    output: &[u16],
+    width: usize,
+    height: usize,
+    levels: &[u8; TILES],
+) -> bool {
+    width.checked_mul(height) == Some(source.len())
+        && source.len() == output.len()
+        && levels.iter().all(|&v| v <= 32 || v == SKIP)
+}
+
+/// Previous levels must describe this exact destination buffer and unchanged
+/// source contents. Pass None on source/reveal change, buffer replacement or reset.
+#[allow(clippy::too_many_arguments)]
+pub fn render_zoom_retained(
+    source: &[u16],
+    output: &mut [u16],
+    width: usize,
+    height: usize,
+    levels: &[u8; TILES],
+    dirty_rows: &[u16; ROWS],
+    previous: Option<&[u8; TILES]>,
+) -> Option<usize> {
+    if !valid(source, output, width, height, levels) {
+        return None;
+    }
+    let Some(previous) = previous else {
+        if !render_zoom(source, output, width, height, levels, dirty_rows) {
+            return None;
+        }
+        return Some(
+            (0..ROWS)
+                .map(|row| {
+                    (0..COLUMNS)
+                        .filter(|&col| dirty_rows[row] & (1 << col) != 0)
+                        .map(|col| {
+                            ((col + 1) * width / COLUMNS - col * width / COLUMNS)
+                                * ((row + 1) * height / ROWS - row * height / ROWS)
+                        })
+                        .sum::<usize>()
+                })
+                .sum(),
+        );
+    };
+    if !previous.iter().all(|&v| v <= 32 || v == SKIP) {
+        return None;
+    }
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    if width >= COLUMNS && height >= ROWS && {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        *ENABLED.get_or_init(|| {
+            std::env::var("MISTER_ORIENTATION_SIMD")
+                .ok()
+                .is_none_or(|v| !v.trim().eq_ignore_ascii_case("scalar"))
+        })
+    } {
+        unsafe extern "C" {
+            fn mister_magik_orientation_zoom_delta_neon(
+                source: *const u16,
+                output: *mut u16,
+                width: usize,
+                height: usize,
+                levels: *const u8,
+                previous: *const u8,
+                dirty_rows: *const u16,
+            ) -> usize;
+        }
+        // SAFETY: complete disjoint planes, valid nonempty tile geometry and arrays.
+        return Some(unsafe {
+            mister_magik_orientation_zoom_delta_neon(
+                source.as_ptr(),
+                output.as_mut_ptr(),
+                width,
+                height,
+                levels.as_ptr(),
+                previous.as_ptr(),
+                dirty_rows.as_ptr(),
+            )
+        });
+    }
+    let mut writes = 0;
+    for row in 0..ROWS {
+        for col in 0..COLUMNS {
+            if dirty_rows[row] & (1 << col) == 0 {
+                continue;
+            }
+            let tile = row * COLUMNS + col;
+            let rect = |level| {
+                if level == SKIP {
+                    return (0, 0, 0, 0);
+                }
+                let (x0, x1) =
+                    centered_span(col * width / COLUMNS, (col + 1) * width / COLUMNS, level);
+                let (y0, y1) = centered_span(row * height / ROWS, (row + 1) * height / ROWS, level);
+                (x0, y0, x1, y1)
+            };
+            let old = rect(previous[tile]);
+            let now = rect(levels[tile]);
+            // Scalar reference visits the tile, changing only the symmetric difference.
+            for y in row * height / ROWS..(row + 1) * height / ROWS {
+                for x in col * width / COLUMNS..(col + 1) * width / COLUMNS {
+                    let inside = |r: (usize, usize, usize, usize)| {
+                        x >= r.0 && x < r.2 && y >= r.1 && y < r.3
+                    };
+                    if inside(old) != inside(now) {
+                        output[y * width + x] = if inside(now) {
+                            0
+                        } else {
+                            source[y * width + x]
+                        };
+                        writes += 1;
+                    }
+                }
+            }
+        }
+    }
+    Some(writes)
+}
+
+/// Apply changed tiles to a retained, tightly packed RGB565 plane.
+pub fn render_zoom(
+    source: &[u16],
+    output: &mut [u16],
+    width: usize,
+    height: usize,
+    levels: &[u8; TILES],
+    dirty_rows: &[u16; ROWS],
+) -> bool {
+    if !valid(source, output, width, height, levels) {
+        return false;
+    }
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    {
+        static ENABLED: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+        let enabled = *ENABLED.get_or_init(|| {
+            std::env::var("MISTER_ORIENTATION_SIMD")
+                .ok()
+                .is_none_or(|v| !v.trim().eq_ignore_ascii_case("scalar"))
+        });
+        if enabled && width >= COLUMNS && height >= ROWS {
+            unsafe extern "C" {
+                fn mister_magik_orientation_zoom_neon(
+                    source: *const u16,
+                    output: *mut u16,
+                    width: usize,
+                    height: usize,
+                    levels: *const u8,
+                    dirty_rows: *const u16,
+                );
+            }
+            // SAFETY: validated complete distinct planes, nonempty tiles, and fixed arrays.
+            unsafe {
+                mister_magik_orientation_zoom_neon(
+                    source.as_ptr(),
+                    output.as_mut_ptr(),
+                    width,
+                    height,
+                    levels.as_ptr(),
+                    dirty_rows.as_ptr(),
+                );
+            }
+            return true;
+        }
+    }
+    render_zoom_scalar(source, output, width, height, levels, dirty_rows)
+}
+
+/// Production scalar fallback and target diagnostic oracle.
+pub fn render_zoom_scalar(
+    source: &[u16],
+    output: &mut [u16],
+    width: usize,
+    height: usize,
+    levels: &[u8; TILES],
+    dirty_rows: &[u16; ROWS],
+) -> bool {
+    if !valid(source, output, width, height, levels) {
+        return false;
+    }
+    for tile_row in 0..ROWS {
+        let y0 = tile_row * height / ROWS;
+        let y1 = (tile_row + 1) * height / ROWS;
+        for column in 0..COLUMNS {
+            if dirty_rows[tile_row] & (1 << column) == 0 {
+                continue;
+            }
+            let x0 = column * width / COLUMNS;
+            let x1 = (column + 1) * width / COLUMNS;
+            for y in y0..y1 {
+                output[y * width + x0..y * width + x1]
+                    .copy_from_slice(&source[y * width + x0..y * width + x1]);
+            }
+            let level = levels[tile_row * COLUMNS + column];
+            if level == SKIP {
+                continue;
+            }
+            let (bx0, bx1) = centered_span(x0, x1, level);
+            let (by0, by1) = centered_span(y0, y1, level);
+            for y in by0..by1 {
+                output[y * width + bx0..y * width + bx1].fill(0);
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn zoom_endpoints_and_untouched_tiles() {
+        let source = vec![0xffff; 32 * 18];
+        let mut output = vec![0xa55a; source.len()];
+        let mut rows = [0; ROWS];
+        rows[0] = 1;
+        assert!(render_zoom(
+            &source,
+            &mut output,
+            32,
+            18,
+            &[32; TILES],
+            &rows
+        ));
+        assert_eq!(output[0], 0);
+        assert_eq!(output[32], 0);
+        assert_eq!(output[2], 0xa55a);
+        assert_eq!(output[64], 0xa55a);
+        assert!(render_zoom(
+            &source,
+            &mut output,
+            32,
+            18,
+            &[SKIP; TILES],
+            &rows
+        ));
+        assert_eq!(output[0], 0xffff);
+        assert_eq!(output[2], 0xa55a);
+        assert!(!render_zoom(
+            &source,
+            &mut output,
+            32,
+            18,
+            &[33; TILES],
+            &rows
+        ));
+    }
+}

--- a/crates/framebuffer-scenes/src/orientation.rs
+++ b/crates/framebuffer-scenes/src/orientation.rs
@@ -105,9 +105,9 @@ pub fn render_zoom_retained(
         });
     }
     let mut writes = 0;
-    for row in 0..ROWS {
+    for (row, &dirty_columns) in dirty_rows.iter().enumerate() {
         for col in 0..COLUMNS {
-            if dirty_rows[row] & (1 << col) == 0 {
+            if dirty_columns & (1 << col) == 0 {
                 continue;
             }
             let tile = row * COLUMNS + col;

--- a/crates/framebuffer-scenes/src/orientation_neon.c
+++ b/crates/framebuffer-scenes/src/orientation_neon.c
@@ -217,3 +217,57 @@ void mister_magik_orientation_zoom_neon(
         }
     }
 }
+
+typedef struct { size_t x0, y0, x1, y1; } zoom_rect;
+
+static zoom_rect black_rect(size_t width, size_t height, size_t tile, uint8_t level) {
+    zoom_rect r = {0,0,0,0};
+    if (level == ORIENTATION_SKIP) return r;
+    const size_t row = tile / ORIENTATION_COLUMNS, col = tile % ORIENTATION_COLUMNS;
+    centered_span(col * width / ORIENTATION_COLUMNS, (col+1) * width / ORIENTATION_COLUMNS,
+        level, &r.x0, &r.x1);
+    centered_span(row * height / ORIENTATION_ROWS, (row+1) * height / ORIENTATION_ROWS,
+        level, &r.y0, &r.y1);
+    return r;
+}
+
+static size_t paint_rect(const uint16_t *source, uint16_t *output,
+    size_t width, zoom_rect r, int black) {
+    for (size_t y = r.y0; y < r.y1; ++y) {
+        if (black) zero_pixels(output + y * width + r.x0, r.x1-r.x0);
+        else copy_pixels(source + y * width + r.x0, output + y * width + r.x0, r.x1-r.x0);
+    }
+    return (r.x1-r.x0) * (r.y1-r.y0);
+}
+
+static size_t paint_difference(const uint16_t *source, uint16_t *output,
+    size_t width, zoom_rect a, zoom_rect b, int black) {
+    const size_t x0 = a.x0 > b.x0 ? a.x0 : b.x0;
+    const size_t y0 = a.y0 > b.y0 ? a.y0 : b.y0;
+    const size_t x1 = a.x1 < b.x1 ? a.x1 : b.x1;
+    const size_t y1 = a.y1 < b.y1 ? a.y1 : b.y1;
+    if (x0 >= x1 || y0 >= y1) return paint_rect(source, output, width, a, black);
+    size_t writes = paint_rect(source, output, width, (zoom_rect){a.x0,a.y0,a.x1,y0},black);
+    writes += paint_rect(source, output, width, (zoom_rect){a.x0,y1,a.x1,a.y1},black);
+    writes += paint_rect(source, output, width, (zoom_rect){a.x0,y0,x0,y1},black);
+    writes += paint_rect(source, output, width, (zoom_rect){x1,y0,a.x1,y1},black);
+    return writes;
+}
+
+size_t mister_magik_orientation_zoom_delta_neon(const uint16_t *restrict source,
+    uint16_t *restrict output, size_t width, size_t height,
+    const uint8_t *restrict levels, const uint8_t *restrict previous,
+    const uint16_t *restrict dirty_rows) {
+    size_t writes = 0;
+    for (size_t row = 0; row < ORIENTATION_ROWS; ++row) {
+        for (size_t col = 0; col < ORIENTATION_COLUMNS; ++col) {
+            if ((dirty_rows[row] & (1u << col)) == 0) continue;
+            const size_t tile = row * ORIENTATION_COLUMNS + col;
+            const zoom_rect old = black_rect(width,height,tile,previous[tile]);
+            const zoom_rect now = black_rect(width,height,tile,levels[tile]);
+            writes += paint_difference(source,output,width,old,now,0);
+            writes += paint_difference(source,output,width,now,old,1);
+        }
+    }
+    return writes;
+}

--- a/crates/framebuffer-scenes/src/rgb565_neon.c
+++ b/crates/framebuffer-scenes/src/rgb565_neon.c
@@ -160,32 +160,30 @@ void mister_magik_rgb565_rotate_counter_clockwise(
 }
 
 static inline uint16x8_t blend8(uint16x8_t from, uint16x8_t to, uint16_t alpha) {
-    const uint16_t inverse = (uint16_t)(32u - alpha);
-    const uint16x4_t from_lo = vget_low_u16(from);
-    const uint16x4_t from_hi = vget_high_u16(from);
-    const uint16x4_t to_lo = vget_low_u16(to);
-    const uint16x4_t to_hi = vget_high_u16(to);
-    const uint16x4_t red_blue_mask = vdup_n_u16(0xf81f);
-    const uint16x4_t green_mask = vdup_n_u16(0x07e0);
-    const uint16x4_t lo = vorr_u16(
-        vmovn_u32(vandq_u32(vshrq_n_u32(
-            vmlal_n_u16(vmull_n_u16(vand_u16(from_lo, red_blue_mask), inverse),
-                        vand_u16(to_lo, red_blue_mask), alpha), 5),
-            vdupq_n_u32(0xf81f))),
-        vmovn_u32(vandq_u32(vshrq_n_u32(
-            vmlal_n_u16(vmull_n_u16(vand_u16(from_lo, green_mask), inverse),
-                        vand_u16(to_lo, green_mask), alpha), 5),
-            vdupq_n_u32(0x07e0))));
-    const uint16x4_t hi = vorr_u16(
-        vmovn_u32(vandq_u32(vshrq_n_u32(
-            vmlal_n_u16(vmull_n_u16(vand_u16(from_hi, red_blue_mask), inverse),
-                        vand_u16(to_hi, red_blue_mask), alpha), 5),
-            vdupq_n_u32(0xf81f))),
-        vmovn_u32(vandq_u32(vshrq_n_u32(
-            vmlal_n_u16(vmull_n_u16(vand_u16(from_hi, green_mask), inverse),
-                        vand_u16(to_hi, green_mask), alpha), 5),
-            vdupq_n_u32(0x07e0))));
-    return vcombine_u16(lo, hi);
+    if (alpha == 0) return from;
+    if (alpha == 32) return to;
+    // For 0 < alpha < 32, vqdmulh(delta, alpha << 10) is exactly
+    // floor(delta * alpha / 32), including negative deltas (not truncation
+    // toward zero). Unpacked channel deltas are bounded by 63, so the
+    // doubled product cannot saturate. Handle alpha 32 above: its coefficient
+    // is not representable in signed 16 bits. No rounding step is introduced.
+    const int16x8_t coefficient = vdupq_n_s16((int16_t)(alpha << 10));
+    const uint16x8_t red_from = vshrq_n_u16(from, 11);
+    const uint16x8_t red_to = vshrq_n_u16(to, 11);
+    const uint16x8_t green_from = vandq_u16(vshrq_n_u16(from, 5), vdupq_n_u16(63));
+    const uint16x8_t green_to = vandq_u16(vshrq_n_u16(to, 5), vdupq_n_u16(63));
+    const uint16x8_t blue_from = vandq_u16(from, vdupq_n_u16(31));
+    const uint16x8_t blue_to = vandq_u16(to, vdupq_n_u16(31));
+    const uint16x8_t red = vreinterpretq_u16_s16(vaddq_s16(
+        vreinterpretq_s16_u16(red_from), vqdmulhq_s16(vsubq_s16(
+            vreinterpretq_s16_u16(red_to), vreinterpretq_s16_u16(red_from)), coefficient)));
+    const uint16x8_t green = vreinterpretq_u16_s16(vaddq_s16(
+        vreinterpretq_s16_u16(green_from), vqdmulhq_s16(vsubq_s16(
+            vreinterpretq_s16_u16(green_to), vreinterpretq_s16_u16(green_from)), coefficient)));
+    const uint16x8_t blue = vreinterpretq_u16_s16(vaddq_s16(
+        vreinterpretq_s16_u16(blue_from), vqdmulhq_s16(vsubq_s16(
+            vreinterpretq_s16_u16(blue_to), vreinterpretq_s16_u16(blue_from)), coefficient)));
+    return vorrq_u16(vorrq_u16(vshlq_n_u16(red, 11), vshlq_n_u16(green, 5)), blue);
 }
 
 static inline uint16_t blend1(uint16_t from, uint16_t to, uint16_t alpha) {

--- a/crates/framebuffer-scenes/src/rgb565_neon.c
+++ b/crates/framebuffer-scenes/src/rgb565_neon.c
@@ -202,6 +202,23 @@ void mister_magik_rgb565_blend(
 ) {
     const uint16_t clamped_alpha = alpha > 32u ? 32u : alpha;
     size_t index = start;
+    if (clamped_alpha == 16u) {
+        // Floor-average each RGB565 channel without cross-channel carries.
+        // Mask each channel's low bit before shifting the differing bits.
+        const uint16x8_t mask = vdupq_n_u16(0xf7de);
+        for (; index + 7 < end; index += 8) {
+            const uint16x8_t from = vld1q_u16(previous + index);
+            const uint16x8_t to = vld1q_u16(current + index);
+            const uint16x8_t half_difference =
+                vshrq_n_u16(vandq_u16(veorq_u16(from, to), mask), 1);
+            vst1q_u16(destination + index, vaddq_u16(vandq_u16(from, to), half_difference));
+        }
+        for (; index < end; ++index) {
+            const uint16_t from = previous[index], to = current[index];
+            destination[index] = (from & to) + (((from ^ to) & 0xf7deu) >> 1);
+        }
+        return;
+    }
     for (; index + 7 < end; index += 8) {
         const uint16x8_t from = vld1q_u16(previous + index);
         const uint16x8_t to = vld1q_u16(current + index);

--- a/crates/screenshot-parade/src/raster.rs
+++ b/crates/screenshot-parade/src/raster.rs
@@ -233,19 +233,29 @@ impl PreparedScreenshotCard {
             kernel,
             preparation_slack,
         );
-        let shifted = std::array::from_fn(|index| {
-            if let Some(slack) = preparation_slack {
-                slack.checkpoint();
-            }
-            prepare_linear_phase(
-                &styled,
-                &coverage,
-                &source_opaque_spans,
-                &premultiplied,
-                index + 1,
-                kernel,
-                preparation_slack,
-            )
+        let shifted = prepare_shifted_phases_batched(
+            &styled,
+            &coverage,
+            &source_opaque_spans,
+            &premultiplied,
+            kernel,
+            preparation_slack,
+        )
+        .unwrap_or_else(|| {
+            std::array::from_fn(|index| {
+                if let Some(slack) = preparation_slack {
+                    slack.checkpoint();
+                }
+                prepare_linear_phase(
+                    &styled,
+                    &coverage,
+                    &source_opaque_spans,
+                    &premultiplied,
+                    index + 1,
+                    kernel,
+                    preparation_slack,
+                )
+            })
         });
         let phase_us = phase_started.elapsed().as_micros();
         (
@@ -828,6 +838,107 @@ fn premultiply_linear_source(
         }
     }
     premultiplied
+}
+
+fn prepare_shifted_phases_batched(
+    image: &LinearImage,
+    source_coverage: &[u8],
+    source_opaque_spans: &[OpaqueSpan],
+    premultiplied_source: &[[u16; 4]],
+    kernel: LinearPhaseKernel,
+    preparation_slack: Option<&PreparationSlack>,
+) -> Option<[PreparedLinearPhase; CRT_SHIFTED_PHASE_COUNT]> {
+    let batch = match kernel {
+        #[cfg(test)]
+        LinearPhaseKernel::Scalar => return None,
+        LinearPhaseKernel::Neon => 5,
+    };
+    #[cfg(all(target_os = "linux", target_arch = "arm"))]
+    {
+        unsafe extern "C" {
+            fn mister_magik_screenshot_phase_batch_neon(
+                source: *const u16,
+                source_width: usize,
+                height: usize,
+                output_width: usize,
+                weights: *const i32,
+                source_opaque_spans: *const OpaqueSpan,
+                linear_to_srgb: *const u8,
+                pixels: *const *mut u16,
+                phases: usize,
+            );
+        }
+        let width = image.width + 1;
+        let mut pixels: [Vec<Rgb565Pixel>; CRT_SHIFTED_PHASE_COUNT] =
+            std::array::from_fn(|_| vec![Rgb565Pixel(0); width * image.height]);
+        let weights: [[i32; 6]; CRT_SHIFTED_PHASE_COUNT] =
+            std::array::from_fn(|i| fractional_delay_weights(i + 1));
+        for first in (0..CRT_SHIFTED_PHASE_COUNT).step_by(batch) {
+            let phases = batch.min(CRT_SHIFTED_PHASE_COUNT - first);
+            for row in (0..image.height).step_by(4) {
+                if let Some(slack) = preparation_slack {
+                    slack.checkpoint();
+                }
+                let rows = 4.min(image.height - row);
+                let pointers: [*mut u16; 5] = std::array::from_fn(|i| {
+                    if i < phases {
+                        pixels[first + i][row * width..].as_mut_ptr().cast()
+                    } else {
+                        std::ptr::null_mut()
+                    }
+                });
+                // SAFETY: each live pointer addresses a distinct complete output plane;
+                // inputs cover the same four-row stripe, with six coefficients per phase.
+                unsafe {
+                    mister_magik_screenshot_phase_batch_neon(
+                        premultiplied_source[row * image.width..].as_ptr().cast(),
+                        image.width,
+                        rows,
+                        width,
+                        weights[first].as_ptr(),
+                        source_opaque_spans[row..].as_ptr(),
+                        linear_to_srgb_table().as_ptr(),
+                        pointers.as_ptr(),
+                        phases,
+                    );
+                }
+            }
+        }
+        Some(std::array::from_fn(|index| {
+            let phase_image = ScreenshotImage {
+                pixels: std::mem::take(&mut pixels[index]),
+                width,
+                height: image.height,
+                stride: width,
+            };
+            // As in the single-phase path, visible coverage is shape-preserving,
+            // not the temporary alpha written by the C colour reconstruction.
+            let coverage = shape_preserving_shifted_coverage(
+                source_coverage,
+                image.width,
+                image.height,
+                index + 1,
+                preparation_slack,
+            );
+            let coverage = coverage_plane(coverage, &phase_image, preparation_slack);
+            PreparedLinearPhase {
+                image: phase_image,
+                coverage,
+            }
+        }))
+    }
+    #[cfg(not(all(target_os = "linux", target_arch = "arm")))]
+    {
+        let _ = (
+            image,
+            source_coverage,
+            source_opaque_spans,
+            premultiplied_source,
+            batch,
+            preparation_slack,
+        );
+        None
+    }
 }
 
 fn prepare_linear_phase(

--- a/crates/screenshot-parade/src/screenshot_phase_neon.c
+++ b/crates/screenshot-parade/src/screenshot_phase_neon.c
@@ -7,26 +7,17 @@
 
 #include "screenshot_phase_reciprocals.h"
 
-static inline uint16x4_t reconstruct_six_tap(
+static inline uint16x4_t reconstruct_six_tap_extrema(
     uint16x4_t value0,
     uint16x4_t value1,
     uint16x4_t value2,
     uint16x4_t value3,
     uint16x4_t value4,
     uint16x4_t value5,
+    uint16x4_t minima,
+    uint16x4_t maxima,
     const int32_t *restrict weights
 ) {
-    uint16x4_t minima = vmin_u16(value0, value1);
-    uint16x4_t maxima = vmax_u16(value0, value1);
-    minima = vmin_u16(minima, value2);
-    maxima = vmax_u16(maxima, value2);
-    minima = vmin_u16(minima, value3);
-    maxima = vmax_u16(maxima, value3);
-    minima = vmin_u16(minima, value4);
-    maxima = vmax_u16(maxima, value4);
-    minima = vmin_u16(minima, value5);
-    maxima = vmax_u16(maxima, value5);
-
     int32x4_t sums = vmulq_n_s32(
         vreinterpretq_s32_u32(vmovl_u16(value0)),
         weights[0]
@@ -50,6 +41,30 @@ static inline uint16x4_t reconstruct_six_tap(
         vreinterpretq_s32_u32(vmovl_u16(maxima))
     );
     return vmovn_u32(vreinterpretq_u32_s32(reconstructed));
+}
+
+static inline uint16x4_t reconstruct_six_tap(
+    uint16x4_t value0,
+    uint16x4_t value1,
+    uint16x4_t value2,
+    uint16x4_t value3,
+    uint16x4_t value4,
+    uint16x4_t value5,
+    const int32_t *restrict weights
+) {
+    uint16x4_t minima = vmin_u16(value0, value1);
+    uint16x4_t maxima = vmax_u16(value0, value1);
+    minima = vmin_u16(minima, value2);
+    maxima = vmax_u16(maxima, value2);
+    minima = vmin_u16(minima, value3);
+    maxima = vmax_u16(maxima, value3);
+    minima = vmin_u16(minima, value4);
+    maxima = vmax_u16(maxima, value4);
+    minima = vmin_u16(minima, value5);
+    maxima = vmax_u16(maxima, value5);
+
+    return reconstruct_six_tap_extrema(value0, value1, value2, value3, value4,
+        value5, minima, maxima, weights);
 }
 
 static inline uint16_t unpremultiply_exact(
@@ -296,6 +311,59 @@ void mister_magik_screenshot_phase_neon(
                 row_pixels + output_x,
                 row_coverage + output_x
             );
+        }
+    }
+}
+
+void mister_magik_screenshot_phase_batch_neon(
+    const uint16_t *restrict source,
+    size_t source_width, size_t height, size_t output_width,
+    const int32_t *restrict weights,
+    const uint16_t *restrict source_opaque_spans,
+    const uint8_t *restrict linear_to_srgb,
+    uint16_t *const *restrict pixels,
+    size_t phases
+) {
+    const uint16x4_t zero = vdup_n_u16(0);
+    for (size_t y = 0; y < height; ++y) {
+        const uint16_t *row = source + y * source_width * 4;
+        const size_t opaque_start = (size_t)source_opaque_spans[y * 2] + 3;
+        const size_t opaque_end = source_opaque_spans[y * 2 + 1];
+        for (size_t x = 0; x < output_width; ++x) {
+            const ptrdiff_t sx = (ptrdiff_t)x - 3;
+            const uint16x4_t value0 = load_or_zero(row, source_width, sx, zero);
+            const uint16x4_t value1 = load_or_zero(row, source_width, sx + 1, zero);
+            const uint16x4_t value2 = load_or_zero(row, source_width, sx + 2, zero);
+            const uint16x4_t value3 = load_or_zero(row, source_width, sx + 3, zero);
+            const uint16x4_t value4 = load_or_zero(row, source_width, sx + 4, zero);
+            const uint16x4_t value5 = load_or_zero(row, source_width, sx + 5, zero);
+            uint16x4_t minima = vmin_u16(value0, value1);
+            uint16x4_t maxima = vmax_u16(value0, value1);
+            minima = vmin_u16(minima, value2);
+            maxima = vmax_u16(maxima, value2);
+            minima = vmin_u16(minima, value3);
+            maxima = vmax_u16(maxima, value3);
+            minima = vmin_u16(minima, value4);
+            maxima = vmax_u16(maxima, value4);
+            minima = vmin_u16(minima, value5);
+            maxima = vmax_u16(maxima, value5);
+            const int opaque = opaque_end > 2 && x >= opaque_start && x < opaque_end - 2;
+            for (size_t phase = 0; phase < phases; ++phase) {
+                const uint16x4_t value = reconstruct_six_tap_extrema(
+                    value0, value1, value2, value3, value4, value5,
+                    minima, maxima, weights + phase * 6
+                );
+                // Rust replaces this temporary with shape-preserving coverage.
+                // Retain reconstructed alpha for exact unpremultiplication.
+                uint8_t discarded_coverage;
+                if (opaque) {
+                    write_opaque_phase_pixel(value, linear_to_srgb,
+                        pixels[phase] + y * output_width + x, &discarded_coverage);
+                } else {
+                    write_phase_pixel(value, linear_to_srgb,
+                        pixels[phase] + y * output_width + x, &discarded_coverage);
+                }
+            }
         }
     }
 }

--- a/docs/neon-production-wins.md
+++ b/docs/neon-production-wins.md
@@ -1,0 +1,58 @@
+# Measured Cortex-A9 production optimisations
+
+This integration includes only the four selected numerical implementations and
+their shared ownership/parity tests. It does not restore retired tooling, add
+runtime tuning switches, or include rejected experiment implementations.
+
+| Change | Fixed-work Mini baseline / candidate | Full-app evidence |
+| --- | --- | --- |
+| E01 signed high-multiply RGB565 blend | 2186 / 1445 ms, about 34% faster | Linked production dispatch inspected; selection journey did not establish an overall app speedup |
+| E02 multiplication-free half blend | 336.5 / 224.3 ms; matched-core PMU supports about 25% | Exact output; do not use cross-core timing alone to claim 33% |
+| E13 shared neighbourhood work across five screenshot phases | 71.6 / 64.0 ms, about 11% faster | Two live screensaver windows passed 598 animation intervals each with zero drops/rejections |
+| E11 retained orientation rectangle differences | 540.5 / 220.9 ms, about 59% faster | 168.5 / 72.5-73.3 ms zoom work over 190 frames; endpoint captures byte-identical |
+
+Times are workload/stage totals, not per-frame latency or additive whole-app gains.
+RGB565 rounding, saturation, opacity endpoints, coverage and retained-buffer
+semantics are preserved. The original 128-byte scanout-copy prefetch is unchanged:
+removing it was about 38% slower and tested alternatives did not establish a win.
+
+## Evidence and remaining qualification
+
+The campaign history and ignored raw artifacts remain on the local
+`nigel/neon-production-wins` branch at `f85b3711c`, including the experiment index
+at its historical `magik2/docs/neon-campaign.md` path. Raw binaries, screenshots
+and profiles are not part of this PR. Rejected/inconclusive E03-E10, E12, E14 and
+E17-E19 remain on their original experiment branches, not in this source tree.
+E15/E16 were not implemented. Do not merge rejected candidates to retain history.
+
+Full-app baseline run `20260908T005513Z-8492dc6fbc05` uses ELF
+`4170686d9ddc40e9c73e3b46dd31929b4a1672d9f1f2821e5810f0e5ed6fe09a`.
+Candidate runs `20260908T010019Z-32528ee3bd07` and
+`20260908T183018Z-601fc5bfadc9` use ELF
+`1c223e5383fa8e6cc3817360dd9920953d1751df61daa80cd53e083121093289`.
+Their portrait PNGs are byte-identical, SHA-256
+`57646dea9659ea93e6d1d0b82856faaafeefb56ab250bb2968922272d8c5ff41`;
+restored PNGs are also byte-identical,
+`712e496fdf8136fe5cda313278ccb3fc840cb546ee544ec86340ba57e27c0e92`.
+The earlier conversational E11 text-loss attribution was incorrect.
+
+Both baseline and candidate orientation journeys retain one physical dropped
+frame, with zero latch rejections/invalid ownership intervals. Startup retains
+two drops. These are open zero-drop qualification failures, not waived by the
+performance wins. Endpoint parity is not an all-frame correctness proof.
+
+E13 candidate run `20260908T010119Z-39ad833b7987` prepares 53/52 live cards
+with 2516044/2544959 us cumulative phase work, versus baseline
+`20260908T005649Z-45b19560cd3e`: 52 cards and 2945311 us. Live geometry and
+scheduling differ, so these numbers support rather than replace fixed-fixture
+Mini evidence. Candidate windows have zero physical drops/latch rejections;
+one native screenshot was available and inspected.
+
+Exact linked-ELF disassembly verifies both affected kernels and production
+callers. Stack entry saves, invariant reloads, arrays and confirmed spills are
+classified separately. PMU cache-dependent stalls are not all data dependencies,
+L1 refills are not DRAM misses, and NEON clock-enabled cycles are not utilisation.
+
+This PR ports the production changes onto the current tooling-retirement base.
+The historical ELF hashes above describe campaign measurements, not the new
+integration binary. Current integration checks are reported separately in the PR.


### PR DESCRIPTION
## Summary

Integrate the four retained Cortex-A9 optimisation candidates into the current real-app source, without bringing back retired tooling or rejected experiment implementations:

- E01: exact signed high-multiply RGB565 blend (~34% fixed-work Mini improvement).
- E02: multiplication-free half blend (~25% supported by matched-core PMU timings).
- E11: shared retained orientation rectangle updates (~59% Mini; full-app zoom stage 168.5 → 72.5–73.3 ms over 190 frames).
- E13: share screenshot neighbourhood work across five phases (~11% Mini improvement).

Keep the existing 128-byte copy prefetch. Preserve rejected candidates on their existing local experiment branches/history; none is included in this production tree. E15/E16 were not implemented. No changes are pushed directly to main, and this PR does not deploy or merge anything.

## Correctness and evidence

- Add blend channel, endpoint, alignment, tail and canary tests, plus retained orientation parity coverage.
- Move the production orientation kernel into shared ownership rather than keeping a Mini copy.
- Record historical timing, exact ELF/capture identities, PMU interpretation and qualification limits in `docs/neon-production-wins.md`.
- Correct the earlier E11 text-loss attribution: the baseline and candidate endpoint PNGs are byte-identical.

These are workload/stage gains, not additive whole-app gains. Historical campaign binaries are not the newly integrated PR binary. Raw binaries/captures/profiles are excluded.

## Validation

- PASS: `scripts/cargo test --offline --manifest-path crates/framebuffer-scenes/Cargo.toml --lib` — 48 tests.
- PASS: `scripts/cargo test --offline --manifest-path crates/screenshot-parade/Cargo.toml --lib raster::` — 16 tests. Host checks do not execute ARM-only NEON paths.
- PASS: `git diff --check`.
- BLOCKED: focused full-app orientation host test compilation exhausted host disk space.
- BLOCKED: `scripts/magik build app` cannot resolve `slint-testing==0.3` because the configured private package registry returns HTTP 401. No authentication bypass or legacy build route was used.
- Rust semantic diagnostics were partially available; an orientation diagnostics request was cancelled, so focused Cargo validation was used as fallback.

Draft pending full-app integration/ARM verification and CI. Historical orientation journeys have one physical dropped frame in both baseline and candidate; startup has two. These remain open zero-drop qualification failures, not waived by the speedups. E13 historical live screensaver windows each passed 598 animation intervals with zero drops/rejections.
