### PR TITLE
Fix platform component reuse across tooling refactors

### DIFF
--- a/.github/workflows/platform-bundle.yml
+++ b/.github/workflows/platform-bundle.yml
@@ -44,9 +44,9 @@ jobs:
       fpga-changed: ${{ steps.plan.outputs.fpga_changed }}
       kernel-changed: ${{ steps.plan.outputs.kernel_changed }}
       main-id: ${{ steps.identity.outputs.main_id }}
-      fpga-id: ${{ steps.reuse.outputs.fpga_id || steps.identity.outputs.fpga_id }}
+      fpga-id: ${{ steps.reuse.outputs.fpga_id || steps.baseline.outputs.fpga_id }}
       fpga-synthesis-id: ${{ steps.identity.outputs.fpga_synthesis_id }}
-      kernel-id: ${{ steps.reuse.outputs.kernel_id || steps.identity.outputs.kernel_id }}
+      kernel-id: ${{ steps.reuse.outputs.kernel_id || steps.baseline.outputs.kernel_id }}
       main-revision: ${{ steps.identity.outputs.main_revision }}
       bundle-id: ${{ steps.plan.outputs.bundle_id }}
       candidate-hit: ${{ steps.reuse.outputs.candidate_hit }}
@@ -111,6 +111,15 @@ jobs:
           printf 'version=%s\ntag=%s\nmanifest=%s\n' "$version" "$tag" "$manifest" >> "$GITHUB_OUTPUT"
           printf 'latest manifest inspection: %ss, %s bytes\n' "$((SECONDS-started))" "$(stat -c %s "$manifest")" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Validate current host contracts and compare released inputs
+        id: baseline
+        run: |
+          set -euo pipefail
+          python3 scripts/checks/check-latch-protocol.py
+          scripts/checks/check-scanout-slots-contract.sh
+          python3 scripts/release/platform/platform-component-id.py release-identities \
+            --manifest '${{ steps.current.outputs.manifest }}' --github-output "$GITHUB_OUTPUT"
+
       - name: Plan platform update
         id: plan
         run: |
@@ -118,8 +127,8 @@ jobs:
             --manifest '${{ steps.current.outputs.manifest }}' \
             --current-version '${{ steps.current.outputs.version }}' \
             --main-id '${{ steps.identity.outputs.main_id }}' \
-            --fpga-id '${{ steps.identity.outputs.fpga_id }}' \
-            --kernel-id '${{ steps.identity.outputs.kernel_id }}' \
+            --fpga-id '${{ steps.baseline.outputs.fpga_id }}' \
+            --kernel-id '${{ steps.baseline.outputs.kernel_id }}' \
             --github-output "$GITHUB_OUTPUT"
 
       - name: Resolve exact reusable candidate and components
@@ -133,8 +142,8 @@ jobs:
           FPGA_CHANGED: ${{ steps.plan.outputs.fpga_changed }}
           KERNEL_CHANGED: ${{ steps.plan.outputs.kernel_changed }}
           MAIN_ID: ${{ steps.identity.outputs.main_id }}
-          FPGA_ID: ${{ steps.identity.outputs.fpga_id }}
-          KERNEL_ID: ${{ steps.identity.outputs.kernel_id }}
+          FPGA_ID: ${{ steps.baseline.outputs.fpga_id }}
+          KERNEL_ID: ${{ steps.baseline.outputs.kernel_id }}
           MAIN_REVISION: ${{ steps.identity.outputs.main_revision }}
         run: |
           set -euo pipefail
@@ -195,8 +204,7 @@ jobs:
             return 1
           }
           resolve_equivalent() {
-            local kind="$1" prefix="$2" inputs_manifest="$3" artifact_id run_id head_sha name identity attempt details verification canonical
-            local -a component_inputs
+            local kind="$1" prefix="$2" artifact_id run_id head_sha name identity attempt details verification canonical
             while IFS=$'\t' read -r artifact_id run_id head_sha name; do
               [[ "$artifact_id" =~ ^[0-9]+$ ]] || continue
               [[ "$run_id" =~ ^[0-9]+$ ]] || continue
@@ -220,10 +228,8 @@ jobs:
               if ! head_sha="$(jq -er '.origin.head_sha | strings | select(test("^[0-9a-f]{40}$"))' "$verification")"; then
                 continue
               fi
-              git merge-base --is-ancestor "$head_sha" "$GITHUB_SHA" || continue
-              mapfile -t component_inputs < <(sed -e '/^[[:space:]]*#/d' -e '/^[[:space:]]*$/d' -e '\#^\.github/workflows/platform-bundle.yml$#d' "$inputs_manifest")
-              component_inputs+=("$inputs_manifest")
-              git diff --quiet "$head_sha" "$GITHUB_SHA" -- "${component_inputs[@]}" || continue
+              python3 scripts/release/platform/platform-component-id.py equivalent \
+                "$kind" --revision "$head_sha" || continue
               canonical="build/platform-reuse/$kind"
               if [ "$kind" = fpga ]; then
                 scripts/magik-ci ci platform-bundle compact-component \
@@ -254,10 +260,10 @@ jobs:
           else
             [ "$MAIN_CHANGED" = true ] && resolve main "platform-main-v0.1-$MAIN_ID" "$MAIN_ID" || [ "$MAIN_CHANGED" != true ] || true
             if [ "$FPGA_CHANGED" = true ] && ! resolve fpga "platform-fpga-v0.1-$FPGA_ID" "$FPGA_ID"; then
-              resolve_equivalent fpga platform-fpga-v0.1- scripts/platform-component-inputs/fpga-v0.1.txt || true
+              resolve_equivalent fpga platform-fpga-v0.1- || true
             fi
             if [ "$KERNEL_CHANGED" = true ] && ! resolve kernel "platform-kernel-v0.1-$KERNEL_ID" "$KERNEL_ID"; then
-              resolve_equivalent kernel platform-kernel-v0.1- scripts/platform-component-inputs/kernel-v0.1.txt || true
+              resolve_equivalent kernel platform-kernel-v0.1- || true
             fi
             [ "$MAIN_CHANGED" = true ] || echo 'main_hit=false' >> "$GITHUB_OUTPUT"
             [ "$FPGA_CHANGED" = true ] || echo 'fpga_hit=false' >> "$GITHUB_OUTPUT"
@@ -322,8 +328,8 @@ jobs:
             echo "| Component | Decision | Identity |"
             echo "|---|---|---|"
             echo "| Main | $(status '${{ steps.plan.outputs.main_changed }}' '${{ steps.reuse.outputs.main_hit }}') | \`${{ steps.identity.outputs.main_id }}\` |"
-            echo "| FPGA | $(status '${{ steps.plan.outputs.fpga_changed }}' '${{ steps.reuse.outputs.fpga_hit }}') | \`${{ steps.reuse.outputs.fpga_id || steps.identity.outputs.fpga_id }}\` |"
-            echo "| Kernel | $(status '${{ steps.plan.outputs.kernel_changed }}' '${{ steps.reuse.outputs.kernel_hit }}') | \`${{ steps.reuse.outputs.kernel_id || steps.identity.outputs.kernel_id }}\` |"
+            echo "| FPGA | $(status '${{ steps.plan.outputs.fpga_changed }}' '${{ steps.reuse.outputs.fpga_hit }}') | \`${{ steps.reuse.outputs.fpga_id || steps.baseline.outputs.fpga_id }}\` |"
+            echo "| Kernel | $(status '${{ steps.plan.outputs.kernel_changed }}' '${{ steps.reuse.outputs.kernel_hit }}') | \`${{ steps.reuse.outputs.kernel_id || steps.baseline.outputs.kernel_id }}\` |"
             if [ '${{ steps.reuse.outputs.candidate_hit }}' = true ]; then
               echo
               echo "Exact verified candidate recovered; component builds and assembly will be skipped."

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -81,6 +81,26 @@ rebooting or running the installer; incomplete packages fail verification.
 
 ## Device and platform delivery
 
+Platform component IDs hash selected input contents; the last-changing Git
+revision remains provenance, not part of the cache key. The platform workflow
+contributes each component's build job and shared build settings, rather than
+unrelated planning and publication steps. The explicit FPGA build date is a
+synthesis input. Host protocol/scanout integration checks run before reuse, so
+retiring an agent adapter does not by itself rebuild the RBF or module.
+
+Before planning a release, compare the latest published component's recorded
+source tree with the current selected inputs. Identical inputs may reuse the
+original component ID and receipts even across reconstructed Git history or an
+identity-algorithm update. Missing source objects or changed inputs require a
+new build; published receipts are never relabelled. The complete baseline
+archive is still downloaded and verified before assembly. FPGA report-validation
+changes remain component inputs, while the separate synthesis key allows the
+existing RBFs to be checked again without rerunning Quartus.
+
+Kernel cache attestation is intentionally usable with the Ubuntu 20.04 build
+container's Python 3.8. The CLI loads FFmpeg and database dependencies only for
+operations that use them; the general host-tooling Python requirement is unchanged.
+
 Use `scripts/magik deploy` for development applications and
 `scripts/magik-platform` for explicit platform/Main transactions. Normal platform
 delivery checks artifact integrity, activation and bounded startup health.

--- a/scripts/magik_ci/build.py
+++ b/scripts/magik_ci/build.py
@@ -8,8 +8,6 @@ import os
 import subprocess
 from pathlib import Path
 
-from scripts.magik_ci import ffmpeg
-
 TARGET = "armv7-unknown-linux-gnueabihf"
 COMMANDS = {
     "runtime-ci": ("apps/mister/Cargo.toml", "ci-fast", "ui"),
@@ -48,6 +46,8 @@ def _environment(
         # Cross mounts configured host volumes at their canonical host paths.
         # The FFmpeg preparation container uses /project, but Cross cannot see
         # that mount point when MISTER_REPO_ROOT enables volume mounting.
+        from scripts.magik_ci import ffmpeg
+
         dist = repository / ffmpeg.RELATIVE_WORK / "dist"
         include = dist / "include"
         environment.update(
@@ -180,6 +180,8 @@ def execute(repository: Path, intent: str) -> None:
         command.append("--timings")
     environment = _environment(repository, intent, profile, features, runner)
     if runner == "cross" and intent in {"runtime-ci", "runtime-device"}:
+        from scripts.magik_ci import ffmpeg
+
         ffmpeg.prepare(repository)
     subprocess.run(command, cwd=repository, env=environment, check=True)
     _write_build_identity(repository, intent, profile, features, runner)

--- a/scripts/magik_ci/cli.py
+++ b/scripts/magik_ci/cli.py
@@ -8,7 +8,7 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
-from . import architecture, build, bundle, databases, host, metadata, quality
+from . import architecture, build, bundle, host, metadata, quality
 from .common import github_output, repository_root
 
 
@@ -415,6 +415,8 @@ def main() -> int:
             else:
                 manifest.verify(args.manifest, args.root, layout=args.layout)
         elif args.command == "game-databases":
+            from . import databases
+
             if args.action == "verify":
                 databases.verify(
                     args.archive, args.manifest, release_version=args.release_version

--- a/scripts/platform-component-inputs/fpga-synthesis-v0.1.txt
+++ b/scripts/platform-component-inputs/fpga-synthesis-v0.1.txt
@@ -9,3 +9,4 @@ mister/platform/kernel/scanout-slots/mister_magik_scanout_platform.h
 scripts/build-fpga-vblank-latch-core.sh
 scripts/prepare-fpga-menu-signoff.py
 scripts/install-quartus-lite-docker.sh
+scripts/quartus/fpga-build-epoch-v1.txt

--- a/scripts/platform-component-inputs/fpga-v0.1.txt
+++ b/scripts/platform-component-inputs/fpga-v0.1.txt
@@ -9,7 +9,8 @@ mister/platform/kernel/scanout-slots/mister_magik_scanout_platform.h
 scripts/build-fpga-vblank-latch-core.sh
 scripts/prepare-fpga-menu-signoff.py
 scripts/install-quartus-lite-docker.sh
-scripts/checks/check-latch-protocol.py
+scripts/quartus/fpga-build-epoch-v1.txt
+# Host protocol consistency checks run before reuse; they do not change the RBF.
 scripts/checks/generate-latch-protocol.py
 scripts/checks/generate-video-diagnostics-protocol.py
 scripts/checks/generate-hdmi-evidence-protocol.py
@@ -18,10 +19,4 @@ scripts/checks/check-fpga-latch-coverage.py
 scripts/checks/check-fpga-quartus-delta.py
 scripts/checks/verify-fpga-rbf-manifest.py
 scripts/checks/verify-crt-qualification-evidence.py
-scripts/tests/test-fpga-vblank-latch.sh
-scripts/tests/test-fpga-rbf-manifest.py
-scripts/tests/test-fpga-quartus-delta.py
-scripts/tests/test-crt-qualification-evidence.py
-scripts/tests/test-platform-component-id.py
-.github/workflows/fpga-latch-fast.yml
 .github/workflows/platform-bundle.yml

--- a/scripts/platform-component-inputs/kernel-v0.1.txt
+++ b/scripts/platform-component-inputs/kernel-v0.1.txt
@@ -4,7 +4,5 @@
 # MiSTer MagiK kernel component identity inputs, format v0.1.
 mister/platform/kernel/scanout-slots
 scripts/build-scanout-slots-module.sh
-scripts/checks/check-scanout-slots-contract.sh
-scripts/tests/test-scanout-platform-contract.py
-.github/workflows/kernel-scanout.yml
+# Host integration checks run before reuse; they do not change the module.
 .github/workflows/platform-bundle.yml

--- a/scripts/release/platform/platform-component-id.py
+++ b/scripts/release/platform/platform-component-id.py
@@ -8,7 +8,9 @@ from __future__ import annotations
 
 import argparse
 import hashlib
+import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -127,14 +129,110 @@ def component_id(root: Path, component: str) -> tuple[str, str]:
     require_clean_repository(root)
     revision = component_revision(root, component)
     digest = hashlib.sha256()
-    digest.update(
-        f"format={FORMAT}\ncomponent={component}\nrevision={revision}\n".encode()
-    )
+    digest.update(f"format={FORMAT}\ncomponent={component}\n".encode())
     for path in selected_files(root, component):
         relative = path.relative_to(root).as_posix()
-        file_hash = hashlib.sha256(path.read_bytes()).hexdigest()
+        file_hash = hashlib.sha256(
+            identity_bytes(component, relative, path.read_bytes())
+        ).hexdigest()
         digest.update(f"path={relative}\nsha256={file_hash}\n".encode())
     return digest.hexdigest(), revision
+
+
+def identity_bytes(component: str, relative: str, data: bytes) -> bytes:
+    """Build jobs are inputs; unrelated planning/publication jobs are not."""
+    if relative != ".github/workflows/platform-bundle.yml":
+        return data
+    job = {"fpga": "build-fpga", "kernel": "build-kernel"}[component]
+    matches = re.findall(
+        rf"^  {job}:\n.*?(?=^  [\w-]+:|\Z)",
+        data.decode(),
+        re.MULTILINE | re.DOTALL,
+    )
+    if len(matches) != 1:
+        raise IdentityError(f"expected one {job} job in {relative}")
+    # Global defaults or non-Main environment settings can affect either build.
+    # The three existing Main-only settings must not invalidate FPGA/kernel.
+    globals_ = []
+    for key in ("env", "defaults"):
+        for block in re.findall(
+            rf"^{key}:\n.*?(?=^[\w-]+:|\Z)", data.decode(), re.MULTILINE | re.DOTALL
+        ):
+            lines = [
+                line
+                for line in block.splitlines()
+                if not re.match(r"^  MAIN_(REPOSITORY|BRANCH|TOOLCHAIN_VERSION):", line)
+            ]
+            globals_.append("\n".join(lines).rstrip())
+    return "\n".join([*globals_, matches[0].rstrip()]).encode()
+
+
+def equivalent_inputs(root: Path, component: str, revision: str) -> bool:
+    """Compare actual input blobs, even across reconstructed Git history.
+
+    Use the current input selection on both trees. Identity implementation and
+    selection-file bytes describe the hashing scheme, not the built artifact.
+    A release keeps its original identity and provenance when inputs match.
+    """
+    if not re.fullmatch(r"[0-9a-f]{40}", revision):
+        return False
+    inputs = component_inputs(root, component)[:-2]
+    try:
+        previous = run_git(
+            root, "ls-tree", "-r", "--full-tree", revision, "--", *inputs
+        )
+        current = run_git(root, "ls-tree", "-r", "--full-tree", "HEAD", "--", *inputs)
+
+        def entries(tree: str) -> dict[str, tuple[str, str]]:
+            result = {}
+            for line in tree.splitlines():
+                metadata, name = line.split("\t", 1)
+                mode, kind, oid = metadata.split()
+                if kind != "blob" or mode not in {"100644", "100755"}:
+                    raise IdentityError("component inputs must be regular files")
+                result[name] = (mode, oid)
+            return result
+
+        old, new = entries(previous), entries(current)
+        if not old or old.keys() != new.keys():
+            return False
+        for name, (mode, oid) in new.items():
+            old_mode, old_oid = old[name]
+            if mode != old_mode:
+                return False
+            if oid != old_oid:
+                if name != ".github/workflows/platform-bundle.yml":
+                    return False
+                before = run_git(root, "cat-file", "blob", old_oid).encode()
+                after = run_git(root, "cat-file", "blob", oid).encode()
+                # Only the workflow has a deliberately selected input region.
+                if identity_bytes(component, name, before) != identity_bytes(
+                    component, name, after
+                ):
+                    return False
+        return True
+    except IdentityError:
+        return False
+
+
+def release_identities(root: Path, manifest: dict) -> dict[str, str]:
+    require_clean_repository(root)
+    if manifest.get("format") != "mister-magik-platform-bundle-v0.2":
+        raise IdentityError("unsupported release manifest")
+    result = {}
+    for component in ("fpga", "kernel"):
+        desired, _ = component_id(root, component)
+        origin = manifest.get("components", {}).get(component, {})
+        previous = manifest.get(f"{component}_input_sha256", "")
+        reuse = (
+            origin.get("component") == component
+            and origin.get("head_branch") == "main"
+            and re.fullmatch(r"[0-9a-f]{64}", previous)
+            and equivalent_inputs(root, component, origin.get("head_sha", ""))
+        )
+        result[f"{component}_id"] = previous if reuse else desired
+        result[f"{component}_release_equivalent"] = "true" if reuse else "false"
+    return result
 
 
 def bundle_id(fpga_id: str, kernel_id: str) -> str:
@@ -152,6 +250,12 @@ def main() -> int:
         "--root", type=Path, default=Path(__file__).resolve().parents[3]
     )
     commands = parser.add_subparsers(dest="command", required=True)
+    release = commands.add_parser("release-identities")
+    release.add_argument("--manifest", type=Path, required=True)
+    release.add_argument("--github-output", type=Path, required=True)
+    equivalent = commands.add_parser("equivalent")
+    equivalent.add_argument("name", choices=sorted(COMPONENT_INPUT_MANIFESTS))
+    equivalent.add_argument("--revision", required=True)
     component = commands.add_parser("component")
     component.add_argument("name", choices=sorted(COMPONENT_INPUT_MANIFESTS))
     component_output = component.add_mutually_exclusive_group()
@@ -166,7 +270,22 @@ def main() -> int:
     bundle.add_argument("--kernel-id", required=True)
     try:
         args = parser.parse_args()
-        if args.command == "component":
+        if args.command == "release-identities":
+            values = release_identities(
+                args.root.resolve(), json.loads(args.manifest.read_text())
+            )
+            with args.github_output.open("a") as output:
+                for key, value in values.items():
+                    output.write(f"{key}={value}\n")
+            print(json.dumps(values, sort_keys=True))
+        elif args.command == "equivalent":
+            require_clean_repository(args.root.resolve())
+            return (
+                0
+                if equivalent_inputs(args.root.resolve(), args.name, args.revision)
+                else 1
+            )
+        elif args.command == "component":
             identity, revision = component_id(args.root.resolve(), args.name)
             if args.revision_only:
                 print(revision)

--- a/scripts/tests/test-platform-component-id.py
+++ b/scripts/tests/test-platform-component-id.py
@@ -71,6 +71,12 @@ class ComponentIdentityTests(unittest.TestCase):
                     if not fixture.exists():
                         fixture.write_text(f"{component}:{relative}\n")
         subprocess.run(["git", "init", "-q", str(self.root)], check=True, env=git_env())
+        (self.root / ".github/workflows/platform-bundle.yml").write_text(
+            "jobs:\n  plan:\n    name: Plan\n"
+            "  build-kernel:\n    container: ubuntu:20.04\n"
+            "  build-fpga:\n    env:\n      QUARTUS_VERSION: '17.0'\n"
+            "  publish:\n    name: Publish\n"
+        )
         run_git(self.root, "config", "user.email", "test@example.invalid")
         run_git(self.root, "config", "user.name", "Test")
         run_git(self.root, "add", ".")
@@ -200,6 +206,116 @@ class ComponentIdentityTests(unittest.TestCase):
         kernel_after, _ = component_id.component_id(self.root, "kernel")
         self.assertEqual(fpga_before, fpga_after)
         self.assertEqual(kernel_before, kernel_after)
+
+    def head(self) -> str:
+        return component_id.run_git(self.root, "rev-parse", "HEAD")
+
+    def test_reverted_input_restores_identity_despite_changed_history(self) -> None:
+        before, revision = component_id.component_id(self.root, "fpga-synthesis")
+        path = self.root / "scripts/build-fpga-vblank-latch-core.sh"
+        original = path.read_text()
+        path.write_text("temporary change\n")
+        self.commit("change")
+        path.write_text(original)
+        self.commit("restore")
+        after, new_revision = component_id.component_id(self.root, "fpga-synthesis")
+        self.assertNotEqual(revision, new_revision)
+        self.assertEqual(before, after)
+
+    def test_planning_changes_do_not_invalidate_build_jobs(self) -> None:
+        before = {
+            name: component_id.component_id(self.root, name)[0]
+            for name in ("kernel", "fpga")
+        }
+        base = self.head()
+        path = self.root / ".github/workflows/platform-bundle.yml"
+        path.write_text(path.read_text().replace("name: Plan", "name: Better planning"))
+        self.commit("change orchestration")
+        for name, identity in before.items():
+            self.assertEqual(identity, component_id.component_id(self.root, name)[0])
+            self.assertTrue(component_id.equivalent_inputs(self.root, name, base))
+        path.write_text(path.read_text().replace("ubuntu:20.04", "ubuntu:24.04"))
+        self.commit("change compiler environment")
+        self.assertNotEqual(
+            before["kernel"], component_id.component_id(self.root, "kernel")[0]
+        )
+        self.assertFalse(component_id.equivalent_inputs(self.root, "kernel", base))
+
+    def test_host_contract_checks_do_not_invalidate_components(self) -> None:
+        before = {
+            name: component_id.component_id(self.root, name)[0]
+            for name in ("kernel", "fpga")
+        }
+        for check in ("check-latch-protocol.py", "check-scanout-slots-contract.sh"):
+            path = self.root / "scripts/checks" / check
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text("current host integration checks\n")
+        self.commit("retire old host adapters")
+        for name, identity in before.items():
+            self.assertEqual(identity, component_id.component_id(self.root, name)[0])
+
+    def test_release_reuse_keeps_original_identity_across_reconstructed_history(
+        self,
+    ) -> None:
+        base = self.head()
+        manifest = {"format": "mister-magik-platform-bundle-v0.2", "components": {}}
+        for component in ("fpga", "kernel"):
+            manifest[f"{component}_input_sha256"] = (
+                "a" if component == "fpga" else "b"
+            ) * 64
+            manifest["components"][component] = {
+                "component": component,
+                "head_branch": "main",
+                "head_sha": base,
+            }
+        run_git(self.root, "checkout", "--orphan", "reconstructed")
+        self.commit("same files, unrelated history")
+        result = component_id.release_identities(self.root, manifest)
+        self.assertEqual(result["fpga_id"], "a" * 64)
+        self.assertEqual(result["kernel_id"], "b" * 64)
+        self.assertEqual(result["kernel_release_equivalent"], "true")
+        path = self.root / "mister/platform/kernel/scanout-slots/input.txt"
+        path.write_text("real module change\n")
+        self.commit("change module")
+        result = component_id.release_identities(self.root, manifest)
+        self.assertEqual(result["fpga_id"], "a" * 64)
+        self.assertNotEqual(result["kernel_id"], "b" * 64)
+        self.assertEqual(result["kernel_release_equivalent"], "false")
+        self.assertEqual(manifest["components"]["kernel"]["head_sha"], base)
+
+    def test_reuse_rejects_missing_revision_and_changed_file_set(self) -> None:
+        base = self.head()
+        self.assertFalse(component_id.equivalent_inputs(self.root, "kernel", "0" * 40))
+        path = self.root / "mister/platform/kernel/scanout-slots/new.c"
+        path.write_text("new module source\n")
+        self.commit("add source")
+        self.assertFalse(component_id.equivalent_inputs(self.root, "kernel", base))
+
+    def test_build_epoch_invalidates_synthesis(self) -> None:
+        before, _ = component_id.component_id(self.root, "fpga-synthesis")
+        (self.root / "scripts/quartus/fpga-build-epoch-v1.txt").write_text("260909\n")
+        self.commit("change embedded build date")
+        self.assertNotEqual(
+            before, component_id.component_id(self.root, "fpga-synthesis")[0]
+        )
+
+    def test_shared_build_environment_is_an_input(self) -> None:
+        path = self.root / ".github/workflows/platform-bundle.yml"
+        path.write_text("env:\n  CROSS_COMPILE: old-compiler-\n" + path.read_text())
+        self.commit("shared build setting")
+        before, _ = component_id.component_id(self.root, "kernel")
+        base = self.head()
+        path.write_text(path.read_text().replace("old-compiler-", "new-compiler-"))
+        self.commit("change shared compiler")
+        self.assertNotEqual(before, component_id.component_id(self.root, "kernel")[0])
+        self.assertFalse(component_id.equivalent_inputs(self.root, "kernel", base))
+
+    def test_missing_build_job_is_rejected(self) -> None:
+        path = self.root / ".github/workflows/platform-bundle.yml"
+        path.write_text("jobs:\n  plan:\n    name: Only planning\n")
+        self.commit("remove build jobs")
+        with self.assertRaisesRegex(ValueError, "expected one build-kernel job"):
+            component_id.component_id(self.root, "kernel")
 
     def test_dirty_checkout_is_rejected(self) -> None:
         (self.root / "scripts/build-fpga-vblank-latch-core.sh").write_text("dirty\n")

--- a/scripts/tests/test_magik_ci.py
+++ b/scripts/tests/test_magik_ci.py
@@ -253,6 +253,31 @@ import scripts.magik_ci.cli
 """
         subprocess.run([sys.executable, "-c", command], check=True)
 
+    def test_kernel_attestation_does_not_import_new_python_dependencies(self) -> None:
+        # The kernel builder runs Python 3.8. These unrelated imports must stay
+        # lazy even when the complete CLI parser is constructed.
+        command = """
+import builtins, json, pathlib, sys, tempfile
+real_import = builtins.__import__
+def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+    if name == 'tomllib' or (name == 'itertools' and 'pairwise' in (fromlist or ())):
+        raise ModuleNotFoundError(name)
+    return real_import(name, globals, locals, fromlist, level)
+builtins.__import__ = guarded_import
+from scripts.magik_ci.cli import main
+with tempfile.TemporaryDirectory() as directory:
+    root = pathlib.Path(directory)
+    (root / 'module.ko').write_bytes(b'fixture')
+    sys.argv = ['magik-ci', 'ci', 'platform-bundle', 'write-component-cache',
+        '--component', 'kernel', '--artifact', directory,
+        '--component-id', 'a' * 64, '--run-id', '123', '--head-sha', 'b' * 40]
+    assert main() == 0
+    origin = json.loads((root / 'platform-component-origin-v1.json').read_text())
+    assert origin['component_id'] == 'a' * 64
+    assert (root / 'platform-component-SHA256SUMS').is_file()
+"""
+        subprocess.run([sys.executable, "-c", command], check=True)
+
     def test_failed_platform_run_is_eligible_only_for_verified_components(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             run = Path(directory) / "run.json"

--- a/scripts/tests/test_magik_ci_ffmpeg.py
+++ b/scripts/tests/test_magik_ci_ffmpeg.py
@@ -79,7 +79,7 @@ def test_runtime_prepares_ffmpeg_before_cross(repository: Path, intent: str) -> 
     with (
         patch.dict("os.environ", {"MISTER_ARM_BUILD_BACKEND": "cross"}),
         patch.object(
-            build.ffmpeg, "prepare", side_effect=lambda root: events.append("ffmpeg")
+            ffmpeg, "prepare", side_effect=lambda root: events.append("ffmpeg")
         ),
         patch.object(
             build.subprocess, "run", side_effect=lambda *a, **kw: events.append("cross")
@@ -94,7 +94,7 @@ def test_failed_preparation_stops_cargo(repository: Path) -> None:
     with (
         patch.dict("os.environ", {"MISTER_ARM_BUILD_BACKEND": "cross"}),
         patch.object(
-            build.ffmpeg,
+            ffmpeg,
             "prepare",
             side_effect=subprocess.CalledProcessError(1, "ffmpeg"),
         ),
@@ -117,7 +117,7 @@ def test_cross_environment_uses_host_mounted_paths(repository: Path) -> None:
 def test_library_check_does_not_prepare_ffmpeg(repository: Path) -> None:
     with (
         patch.dict("os.environ", {"MISTER_ARM_BUILD_BACKEND": "cross"}),
-        patch.object(build.ffmpeg, "prepare") as prepare,
+        patch.object(ffmpeg, "prepare") as prepare,
         patch.object(build.subprocess, "run"),
     ):
         build.execute(repository, "runtime-library-ci")


### PR DESCRIPTION
The Main 20260907 platform update marked unchanged FPGA and kernel components for rebuild because tooling refactors changed validation inputs and reconstructed Git history. The kernel build then completed but cache attestation failed when the CLI eagerly imported Python features unavailable in its Ubuntu 20.04 Python 3.8 environment.

Hash selected input contents independently of the provenance revision, scope workflow inputs to each component's build job and shared build settings, and keep host integration checks and test scaffolding out of artifact identities. Run the current host contract checks before reuse. Include the explicit FPGA build epoch in both FPGA and synthesis inputs.

Compare recorded release/component source blobs with the current selection, including build settings, instead of requiring ancestry. Equivalent components retain their original IDs and receipts; missing source objects, changed file sets, source changes, or changed compiler settings prevent reuse. Baseline archive verification and existing artifact eligibility checks remain in place. Load FFmpeg and database modules only for CLI operations that use them.

Validation:

- Replayed planning against the actual platform v0.40 manifest and merged Main revision `9d20fa020cf05953920e813957e5107b2daaeb7a`: `main_changed=true`, `fpga_changed=false`, `kernel_changed=false`; the original FPGA/kernel identities are retained.
- 67 focused tests passed, including regressions for restored contents with different history, unrelated source history, workflow-only edits, changed compiler settings, changed/missing inputs, and build-date changes. Re-ran all 19 identity tests after the final input-list adjustment.
- Kernel cache receipt creation and verification passed under an isolated CPython 3.8.20 interpreter.
- Current latch/scanout host contract checks, Ruff, and type checks passed.
- The required pre-push gate passed all 268 selected tests and 30 subtests.

No platform workflow, FPGA synthesis, release publication, or device operation was started for this PR.
