### PR TITLE
Install ripgrep for platform planning checks

### DIFF
--- a/.github/workflows/platform-bundle.yml
+++ b/.github/workflows/platform-bundle.yml
@@ -111,6 +111,9 @@ jobs:
           printf 'version=%s\ntag=%s\nmanifest=%s\n' "$version" "$tag" "$manifest" >> "$GITHUB_OUTPUT"
           printf 'latest manifest inspection: %ss, %s bytes\n' "$((SECONDS-started))" "$(stat -c %s "$manifest")" >> "$GITHUB_STEP_SUMMARY"
 
+      - name: Install host contract check tools
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ripgrep
+
       - name: Validate current host contracts and compare released inputs
         id: baseline
         run: |


### PR DESCRIPTION
Platform run 34269542428 failed before planning because `check-scanout-slots-contract.sh` requires `rg`, which is absent on the hosted runner. Install `ripgrep` in the planning job before running the host contract checks.

Both host contract checks pass locally. Comparing the exact candidate with platform v0.40 still reuses its original FPGA and kernel identities: the dependency setup is outside their build jobs. No component build, publication, or device operation was started.
