### PR TITLE
Queue published platform and database updates for deploy

### DIFF
--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -8,6 +8,7 @@
 //! design with nearest-neighbour letterboxing.
 
 use crate::Rgb565Pixel;
+use crate::launcher_navigation::{BrowseDirection, BrowseFrame};
 
 pub const LOGICAL_WIDTH: usize = 960;
 pub const LOGICAL_HEIGHT: usize = 540;
@@ -43,8 +44,17 @@ impl LauncherScene {
 
     #[must_use]
     pub fn render(self, data: LauncherData<'_>) -> Vec<Rgb565Pixel> {
+        self.render_browse(data, None)
+    }
+
+    #[must_use]
+    pub fn render_browse(
+        self,
+        data: LauncherData<'_>,
+        motion: Option<BrowseFrame>,
+    ) -> Vec<Rgb565Pixel> {
         let mut logical = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
-        render_logical(&mut logical, data);
+        render_logical(&mut logical, data, motion);
         scale_letterboxed(&logical, self.width, self.height)
     }
 }
@@ -64,7 +74,7 @@ const fn rgb(red: u16, green: u16, blue: u16) -> u16 {
     ((red >> 3) << 11) | ((green >> 2) << 5) | (blue >> 3)
 }
 
-fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
+fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>, motion: Option<BrowseFrame>) {
     draw_rect(pixels, 0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT, BACKGROUND);
     draw_text(pixels, 26, 20, "MISTER MAGIK", CREAM, 3);
     draw_text(pixels, 875, 22, data.clock, CREAM, 2);
@@ -106,11 +116,71 @@ fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
         MUTED,
         1,
     );
-    draw_carousel(pixels, data);
+    if let Some(motion) = motion {
+        draw_carousel_motion(pixels, data, motion);
+    } else {
+        draw_carousel(pixels, data);
+    }
     draw_line(pixels, 26, 500, 934, 500, RULE);
     draw_text(pixels, 30, 516, "A  OPEN", CREAM, 1);
     draw_text(pixels, 130, 516, "B  BACK", CREAM, 1);
     draw_text(pixels, 586, 516, "←  →   BROWSE CARDS", CREAM, 1);
+}
+
+fn draw_carousel_motion(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>, motion: BrowseFrame) {
+    if data.cards.is_empty() || motion.direction.is_none() {
+        draw_carousel(pixels, data);
+        return;
+    }
+    draw_rect(
+        pixels,
+        296,
+        CARD_TOP,
+        638,
+        REFLECTION_TOP + REFLECTION_HEIGHT - CARD_TOP,
+        BACKGROUND,
+    );
+    let selected = motion.selected % data.cards.len();
+    let progress = motion.progress_millis.min(motion.duration_millis.max(1)) as u32;
+    let duration = motion.duration_millis.max(1);
+    let right = motion.direction == Some(BrowseDirection::Right);
+    let t = |value: i32| value * progress as i32 / duration as i32;
+    let slot_x = |relative: isize| match relative {
+        -3 => 187,
+        -2 => 296,
+        -1 => 405,
+        0 => 514,
+        1 => 702,
+        2 => 813,
+        _ => 934,
+    };
+    let slot_width = |relative: isize| match relative {
+        0 => 188,
+        1 => 111,
+        2 => 121,
+        _ => 109,
+    };
+    for relative in [-3_isize, -2, -1, 1, 2, 3, 0] {
+        let index = (selected as isize + relative).rem_euclid(data.cards.len() as isize) as usize;
+        let destination_relative = if right { relative - 1 } else { relative + 1 };
+        let source_x = slot_x(relative);
+        let destination_x = slot_x(destination_relative);
+        let source_width = slot_width(relative);
+        let destination_width = slot_width(destination_relative);
+        let x = source_x + t(destination_x - source_x);
+        let width = source_width + t(destination_width - source_width);
+        if x >= 0 && width > 0 {
+            draw_card(
+                pixels,
+                x as usize,
+                width as usize,
+                data.cards[index],
+                relative == 0,
+                index,
+                data.cards.len(),
+            );
+        }
+    }
 }
 
 fn draw_carousel(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -371,8 +371,8 @@ fn draw_cached_motion(
     motion: BrowseFrame,
 ) {
     let selected = motion.selected % cards.len();
-    let progress = motion.progress_millis.min(motion.duration_millis.max(1)) as i32;
     let duration = motion.duration_millis.max(1) as i32;
+    let progress = eased_progress(motion.progress_millis.min(duration as u32), duration as u32);
     let right = motion.direction == Some(BrowseDirection::Right);
     let t = |value: i32| value * progress / duration;
     let slot_x = |relative: isize| match relative {
@@ -421,6 +421,17 @@ fn draw_cached_motion(
                 prominence as usize,
             );
         }
+    }
+}
+
+fn eased_progress(progress: u32, duration: u32) -> i32 {
+    if duration == crate::launcher_navigation::TAP_SLIDE_MS as u32 {
+        let t = progress.min(duration) as i64;
+        let d = duration as i64;
+        // Integer smoothstep: 3t^2 - 2t^3, with exact 0 and duration ends.
+        ((3 * t * t * d - 2 * t * t * t) / (d * d)) as i32
+    } else {
+        progress.min(duration) as i32
     }
 }
 
@@ -1026,6 +1037,23 @@ mod tests {
         prepared.render_into(frame(90), &mut middle);
         assert_ne!(start, middle);
         assert_eq!(frame(90).duration_millis, 180);
+    }
+
+    #[test]
+    fn tap_motion_uses_smoothstep_with_exact_endpoints() {
+        assert_eq!(eased_progress(0, 180), 0);
+        assert!(eased_progress(45, 180) < 45);
+        assert_eq!(eased_progress(90, 180), 90);
+        assert!(eased_progress(135, 180) > 135);
+        assert_eq!(eased_progress(180, 180), 180);
+    }
+
+    #[test]
+    fn held_motion_stays_linear_and_release_does_not_change_duration() {
+        assert_eq!(eased_progress(0, 150), 0);
+        assert_eq!(eased_progress(37, 150), 37);
+        assert_eq!(eased_progress(75, 150), 75);
+        assert_eq!(eased_progress(150, 150), 150);
     }
 
     #[test]

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -53,8 +53,14 @@ impl LauncherScene {
         data: LauncherData<'_>,
         motion: Option<BrowseFrame>,
     ) -> Vec<Rgb565Pixel> {
+        if let Some(frame) = motion {
+            let mut output = vec![Rgb565Pixel(BACKGROUND); self.width.saturating_mul(self.height)];
+            let mut prepared = self.prepare(data);
+            prepared.render_into(frame, &mut output);
+            return output;
+        }
         let mut logical = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
-        render_logical(&mut logical, data, motion);
+        render_logical(&mut logical, data);
         scale_letterboxed(&logical, self.width, self.height)
     }
 
@@ -119,7 +125,7 @@ impl PreparedLauncher {
             clock: data.clock,
         };
         let mut chrome = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
-        render_logical(&mut chrome, source, None);
+        render_logical(&mut chrome, source);
         draw_rect(
             &mut chrome,
             296,
@@ -185,7 +191,7 @@ const fn rgb(red: u16, green: u16, blue: u16) -> u16 {
     ((red >> 3) << 11) | ((green >> 2) << 5) | (blue >> 3)
 }
 
-fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>, motion: Option<BrowseFrame>) {
+fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
     draw_rect(pixels, 0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT, BACKGROUND);
     draw_text(pixels, 26, 20, "MISTER MAGIK", CREAM, 3);
     draw_text(pixels, 875, 22, data.clock, CREAM, 2);
@@ -227,73 +233,11 @@ fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>, motion: Op
         MUTED,
         1,
     );
-    if let Some(motion) = motion {
-        draw_carousel_motion(pixels, data, motion);
-    } else {
-        draw_carousel(pixels, data);
-    }
+    draw_carousel(pixels, data);
     draw_line(pixels, 26, 500, 934, 500, RULE);
     draw_text(pixels, 30, 516, "A  OPEN", CREAM, 1);
     draw_text(pixels, 130, 516, "B  BACK", CREAM, 1);
     draw_text(pixels, 586, 516, "←  →   BROWSE CARDS", CREAM, 1);
-}
-
-fn draw_carousel_motion(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>, motion: BrowseFrame) {
-    if data.cards.is_empty() || motion.direction.is_none() {
-        draw_carousel(pixels, data);
-        return;
-    }
-    draw_rect(
-        pixels,
-        296,
-        CARD_TOP,
-        638,
-        REFLECTION_TOP + REFLECTION_HEIGHT - CARD_TOP,
-        BACKGROUND,
-    );
-    let selected = motion.selected % data.cards.len();
-    let progress = motion.progress_millis.min(motion.duration_millis.max(1)) as u32;
-    let duration = motion.duration_millis.max(1);
-    let right = motion.direction == Some(BrowseDirection::Right);
-    let t = |value: i32| value * progress as i32 / duration as i32;
-    let slot_x = |relative: isize| match relative {
-        -4 => 78,
-        -3 => 187,
-        -2 => 296,
-        -1 => 405,
-        0 => 514,
-        1 => 702,
-        2 => 813,
-        3 => 934,
-        _ => 1055,
-    };
-    let slot_width = |relative: isize| match relative {
-        0 => 188,
-        1 => 111,
-        2 => 121,
-        _ => 109,
-    };
-    for relative in [-3_isize, -2, -1, 1, 2, 3, 0] {
-        let index = (selected as isize + relative).rem_euclid(data.cards.len() as isize) as usize;
-        let destination_relative = if right { relative - 1 } else { relative + 1 };
-        let source_x = slot_x(relative);
-        let destination_x = slot_x(destination_relative);
-        let source_width = slot_width(relative);
-        let destination_width = slot_width(destination_relative);
-        let x = source_x + t(destination_x - source_x);
-        let width = source_width + t(destination_width - source_width);
-        if x >= 0 && width > 0 {
-            draw_card(
-                pixels,
-                x as usize,
-                width as usize,
-                data.cards[index],
-                false,
-                index,
-                data.cards.len(),
-            );
-        }
-    }
 }
 
 fn draw_carousel(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
@@ -1037,6 +981,24 @@ mod tests {
         prepared.render_into(frame(90), &mut middle);
         assert_ne!(start, middle);
         assert_eq!(frame(90).duration_millis, 180);
+    }
+
+    #[test]
+    fn cold_motion_render_uses_the_prepared_renderer() {
+        let scene = LauncherScene::new(960, 540);
+        let frame = BrowseFrame {
+            selected: 0,
+            target: 1,
+            phase: crate::launcher_navigation::BrowsePhase::Sliding,
+            direction: Some(BrowseDirection::Right),
+            progress_millis: 90,
+            duration_millis: 180,
+        };
+        let cold = scene.render_browse(data(), Some(frame));
+        let mut prepared = scene.prepare(data());
+        let mut hot = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        prepared.render_into(frame, &mut hot);
+        assert_eq!(cold, hot);
     }
 
     #[test]

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -54,6 +54,7 @@ const CREAM: u16 = rgb(238, 232, 213);
 const MUTED: u16 = rgb(143, 151, 150);
 const RULE: u16 = rgb(48, 61, 63);
 const WHITE: u16 = rgb(250, 247, 232);
+const DARK_TEXT: u16 = rgb(10, 20, 24);
 const CARD_TOP: usize = 135;
 const CARD_BOTTOM: usize = 428;
 const REFLECTION_TOP: usize = 433;
@@ -97,11 +98,16 @@ fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
     draw_text(pixels, 29, 459, "ACROSS ALL COLLECTIONS", MUTED, 1);
 
     draw_text(pixels, 296, 101, "COLLECTIONS", MUTED, 1);
+    let selected = if data.cards.is_empty() {
+        0
+    } else {
+        data.selected % data.cards.len()
+    };
     draw_text(
         pixels,
         888,
         101,
-        &format!("{:02} / {:02}", data.selected + 1, data.cards.len()),
+        &format!("{:02} / {:02}", selected + 1, data.cards.len()),
         MUTED,
         1,
     );
@@ -162,11 +168,29 @@ fn draw_card(
     if selected {
         draw_rect_outline(pixels, x, top, width, bottom - top, CREAM);
         draw_rect_outline(pixels, x + 4, top + 4, width - 8, bottom - top - 8, CREAM);
-        draw_text_centered(pixels, x, 220, width, card.name, WHITE, 3);
-        draw_text_centered(pixels, x, 385, width, &format_games(card.games), CREAM, 1);
+        let foreground = if card.colour == rgb(199, 190, 167) {
+            DARK_TEXT
+        } else {
+            WHITE
+        };
+        draw_text_centered(pixels, x, 220, width, card.name, foreground, 3);
+        draw_text_centered(
+            pixels,
+            x,
+            385,
+            width,
+            &format_games(card.games),
+            foreground,
+            1,
+        );
     } else {
         draw_text(pixels, x + 15, 151, &ordinal(index, card_count), CREAM, 1);
-        draw_text_centered(pixels, x, 353, width, card.name, CREAM, 1);
+        let foreground = if card.colour == rgb(199, 190, 167) {
+            DARK_TEXT
+        } else {
+            CREAM
+        };
+        draw_text_centered(pixels, x, 353, width, card.name, foreground, 1);
     }
     draw_reflection(pixels, x, width, bottom);
 }
@@ -389,6 +413,7 @@ fn glyph(character: char) -> [u8; 7] {
         '7' => [31, 1, 2, 4, 8, 8, 8],
         '8' => [14, 17, 17, 14, 17, 17, 14],
         '9' => [14, 17, 17, 15, 1, 1, 14],
+        ':' => [0, 6, 6, 0, 6, 6, 0],
         '/' => [1, 2, 2, 4, 8, 8, 16],
         '←' => [4, 2, 31, 2, 4, 0, 0],
         '→' => [4, 8, 31, 8, 4, 0, 0],

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -49,7 +49,7 @@ impl LauncherScene {
     }
 }
 
-const BACKGROUND: u16 = rgb(7, 12, 15);
+const BACKGROUND: u16 = rgb(0, 0, 0);
 const CREAM: u16 = rgb(238, 232, 213);
 const MUTED: u16 = rgb(143, 151, 150);
 const RULE: u16 = rgb(48, 61, 63);
@@ -58,7 +58,7 @@ const DARK_TEXT: u16 = rgb(10, 20, 24);
 const CARD_TOP: usize = 135;
 const CARD_BOTTOM: usize = 428;
 const REFLECTION_TOP: usize = 433;
-const REFLECTION_HEIGHT: usize = 44;
+const REFLECTION_HEIGHT: usize = 32;
 
 const fn rgb(red: u16, green: u16, blue: u16) -> u16 {
     ((red >> 3) << 11) | ((green >> 2) << 5) | (blue >> 3)
@@ -67,9 +67,7 @@ const fn rgb(red: u16, green: u16, blue: u16) -> u16 {
 fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
     draw_rect(pixels, 0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT, BACKGROUND);
     draw_text(pixels, 26, 20, "MISTER MAGIK", CREAM, 3);
-    draw_text(pixels, 26, 53, "PLAY / COLLECT / REMEMBER", MUTED, 1);
     draw_text(pixels, 875, 22, data.clock, CREAM, 2);
-    draw_text(pixels, 842, 53, "SETTINGS", MUTED, 1);
     draw_line(pixels, 26, 76, 934, 76, RULE);
 
     draw_line(pixels, 265, 95, 265, 478, RULE);
@@ -82,8 +80,6 @@ fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
     draw_text(pixels, 30, 310, "COLLECTIONS", MUTED, 1);
     draw_text(pixels, 150, 310, "FAVOURITES", MUTED, 1);
     draw_line(pixels, 28, 340, 240, 340, RULE);
-    draw_text(pixels, 29, 366, "ONE LIBRARY.", CREAM, 2);
-    draw_text(pixels, 29, 393, "EVERY GENERATION.", CREAM, 1);
     for (index, colour) in [
         rgb(226, 52, 67),
         rgb(237, 193, 54),
@@ -95,7 +91,6 @@ fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
     {
         draw_rect(pixels, 29 + index * 54, 436, 48, 7, *colour);
     }
-    draw_text(pixels, 29, 459, "ACROSS ALL COLLECTIONS", MUTED, 1);
 
     draw_text(pixels, 296, 101, "COLLECTIONS", MUTED, 1);
     let selected = if data.cards.is_empty() {
@@ -116,7 +111,6 @@ fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
     draw_text(pixels, 30, 516, "A  OPEN", CREAM, 1);
     draw_text(pixels, 130, 516, "B  BACK", CREAM, 1);
     draw_text(pixels, 586, 516, "←  →   BROWSE CARDS", CREAM, 1);
-    draw_text(pixels, 846, 516, "MISTER / OFFLINE", MUTED, 1);
 }
 
 fn draw_carousel(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
@@ -220,25 +214,30 @@ fn ordinal(index: usize, count: usize) -> String {
 fn draw_reflection(pixels: &mut [Rgb565Pixel], x: usize, width: usize, bottom: usize) {
     for row in 0..REFLECTION_HEIGHT {
         let source_y = bottom.saturating_sub(1 + row);
-        let alpha = 3_u16.saturating_sub((row / 11) as u16);
         for column in x..x + width {
             let target_y = REFLECTION_TOP + row;
             if target_y < LOGICAL_HEIGHT {
                 let source = pixels[source_y * LOGICAL_WIDTH + column].0;
                 pixels[target_y * LOGICAL_WIDTH + column] =
-                    Rgb565Pixel(blend(source, BACKGROUND, alpha, 4));
+                    Rgb565Pixel(reflection_pixel(source, column, row));
             }
         }
     }
 }
 
-fn blend(source: u16, background: u16, level: u16, levels: u16) -> u16 {
-    let mix = |s: u16, b: u16, bits: u16| {
-        ((s * level + b * (levels - level)) / levels) & ((1 << bits) - 1)
+fn reflection_pixel(source: u16, x: usize, row: usize) -> u16 {
+    // A quiet quadratic fade, quantized with a stationary 4x4 Bayer pattern.
+    // Dither only the fractional channel level: never add noise to black.
+    const BAYER: [[u32; 4]; 4] = [[0, 8, 2, 10], [12, 4, 14, 6], [3, 11, 1, 9], [15, 7, 13, 5]];
+    let remaining = (REFLECTION_HEIGHT - 1 - row) as u32;
+    let span = (REFLECTION_HEIGHT - 1) as u32;
+    let alpha = 56 * remaining * remaining / (span * span);
+    let threshold = BAYER[row % 4][x % 4] * 16 + 8;
+    let fade = |channel: u16| -> u16 {
+        let value = u32::from(channel) * alpha;
+        (value / 256 + u32::from(value % 256 > threshold)) as u16
     };
-    (mix((source >> 11) & 31, (background >> 11) & 31, 5) << 11)
-        | (mix((source >> 5) & 63, (background >> 5) & 63, 6) << 5)
-        | mix(source & 31, background & 31, 5)
+    (fade((source >> 11) & 31) << 11) | (fade((source >> 5) & 63) << 5) | fade(source & 31)
 }
 
 fn scale_letterboxed(logical: &[Rgb565Pixel], width: usize, height: usize) -> Vec<Rgb565Pixel> {
@@ -487,6 +486,26 @@ mod tests {
     }
 
     #[test]
+    fn simplified_chrome_leaves_removed_copy_regions_pure_black() {
+        let frame = LauncherScene::new(960, 540).render(data());
+        assert_eq!(BACKGROUND, 0);
+        for (left, top, right, bottom) in [
+            (26, 53, 934, 60),
+            (29, 366, 240, 407),
+            (29, 459, 240, 466),
+            (846, 516, 934, 523),
+        ] {
+            for y in top..bottom {
+                assert!(
+                    frame[y * 960 + left..y * 960 + right]
+                        .iter()
+                        .all(|pixel| pixel.0 == 0)
+                );
+            }
+        }
+    }
+
+    #[test]
     fn output_is_deterministic_and_packed() {
         let scene = LauncherScene::new(960, 540);
         assert_eq!(scene.render(data()), scene.render(data()));
@@ -521,7 +540,7 @@ mod tests {
         draw_reflection(&mut pixels, 520, 1, CARD_BOTTOM);
         assert_eq!(
             pixels[REFLECTION_TOP * LOGICAL_WIDTH + 520].0,
-            blend(rgb(240, 40, 80), BACKGROUND, 3, 4)
+            reflection_pixel(rgb(240, 40, 80), 520, 0)
         );
         assert_ne!(
             pixels[(REFLECTION_TOP + 1) * LOGICAL_WIDTH + 520].0,
@@ -532,8 +551,25 @@ mod tests {
             pixels[(REFLECTION_TOP + 1) * LOGICAL_WIDTH + 520].0
         );
         assert_eq!(
-            pixels[(REFLECTION_TOP + 33) * LOGICAL_WIDTH + 520].0,
+            pixels[(REFLECTION_TOP + REFLECTION_HEIGHT - 1) * LOGICAL_WIDTH + 520].0,
             BACKGROUND
+        );
+    }
+
+    #[test]
+    fn reflection_is_dim_dithered_and_preserves_black() {
+        for row in 0..REFLECTION_HEIGHT {
+            for x in 0..4 {
+                assert_eq!(reflection_pixel(0, x, row), 0);
+                let pixel = reflection_pixel(0xffff, x, row);
+                assert!((pixel >> 11) <= 7);
+                assert!(((pixel >> 5) & 63) <= 14);
+                assert!((pixel & 31) <= 7);
+            }
+        }
+        assert_ne!(
+            reflection_pixel(0xffff, 0, 1),
+            reflection_pixel(0xffff, 1, 1)
         );
     }
 

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -276,7 +276,7 @@ fn draw_carousel_motion(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>, moti
                 x as usize,
                 width as usize,
                 data.cards[index],
-                relative == 0,
+                false,
                 index,
                 data.cards.len(),
             );
@@ -396,7 +396,7 @@ fn draw_cached_motion(
                 x as usize,
                 width as usize,
                 &cards[index],
-                relative == 0,
+                false,
                 &ordinals[index],
                 (353 - 133 * prominence / 256) as usize,
                 (256 + 512 * prominence / 256) as usize,

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -79,6 +79,45 @@ pub struct PreparedLauncher {
     cards: Vec<PreparedCard>,
     ordinals: Vec<Vec<[u8; 7]>>,
     collection_labels: Vec<String>,
+    faces: Vec<CardFaces>,
+    flip_columns: Vec<crate::launcher_flip::Column>,
+    reverse_flip: bool,
+}
+
+struct CardFaces {
+    compact: [crate::launcher_flip::Face; 3],
+    detail: crate::launcher_flip::Face,
+}
+
+fn bake_face(
+    card: &PreparedCard,
+    ordinal: &[[u8; 7]],
+    width: usize,
+    selected: bool,
+) -> crate::launcher_flip::Face {
+    let mut scratch = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+    draw_cached_card(
+        &mut scratch,
+        296,
+        width,
+        card,
+        if selected { &[] } else { ordinal },
+        if selected { 220 } else { 353 },
+        if selected { 768 } else { 256 },
+        if selected { 256 } else { 0 },
+    );
+    let top = if selected { CARD_TOP } else { CARD_TOP + 8 };
+    let height = CARD_BOTTOM - top;
+    let mut pixels = Vec::with_capacity(width * height);
+    for y in top..CARD_BOTTOM {
+        pixels
+            .extend_from_slice(&scratch[y * LOGICAL_WIDTH + 296..y * LOGICAL_WIDTH + 296 + width]);
+    }
+    crate::launcher_flip::Face {
+        pixels,
+        width,
+        height,
+    }
 }
 
 struct PreparedCard {
@@ -102,7 +141,7 @@ impl PreparedLauncher {
                 games_mask: text_mask(&format_games(card.games)),
             })
             .collect();
-        let ordinals = (0..cards.len())
+        let ordinals: Vec<_> = (0..cards.len())
             .map(|index| text_mask(&ordinal(index, cards.len())))
             .collect();
         let collection_labels = (0..cards.len())
@@ -126,15 +165,16 @@ impl PreparedLauncher {
         };
         let mut chrome = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
         render_logical(&mut chrome, source);
-        draw_rect(
-            &mut chrome,
-            296,
-            CARD_TOP,
-            638,
-            REFLECTION_TOP + REFLECTION_HEIGHT - CARD_TOP,
-            BACKGROUND,
-        );
+        draw_rect(&mut chrome, 296, 120, 638, 477 - 120, BACKGROUND);
         draw_rect(&mut chrome, 880, 95, 54, 16, BACKGROUND);
+        let faces = cards
+            .iter()
+            .zip(&ordinals)
+            .map(|(card, ordinal)| CardFaces {
+                compact: [109, 111, 121].map(|width| bake_face(card, ordinal, width, false)),
+                detail: bake_face(card, ordinal, 188, true),
+            })
+            .collect();
         Self {
             scene,
             chrome,
@@ -142,7 +182,14 @@ impl PreparedLauncher {
             cards,
             ordinals,
             collection_labels,
+            faces,
+            flip_columns: vec![crate::launcher_flip::Column::default(); LOGICAL_WIDTH],
+            reverse_flip: true,
         }
+    }
+
+    pub fn set_reverse_flip(&mut self, reverse: bool) {
+        self.reverse_flip = reverse;
     }
 
     pub fn render_into(&mut self, frame: BrowseFrame, output: &mut [Rgb565Pixel]) {
@@ -162,11 +209,17 @@ impl PreparedLauncher {
                 frame.selected,
             );
         } else {
-            draw_cached_motion(&mut self.logical, &self.cards, &self.ordinals, frame);
+            let flip = (frame.phase == crate::launcher_navigation::BrowsePhase::Flipping)
+                .then_some((
+                    &self.faces[..],
+                    &mut self.flip_columns[..],
+                    self.reverse_flip,
+                ));
+            draw_cached_motion(&mut self.logical, &self.cards, &self.ordinals, frame, flip);
         }
         // Moving neighbours may be partially outside the carousel; restore
         // the clip margins after rasterizing signed slot geometry.
-        for y in CARD_TOP..REFLECTION_TOP + REFLECTION_HEIGHT {
+        for y in 120..477 {
             let row = y * LOGICAL_WIDTH;
             self.logical[row..row + 296].copy_from_slice(&self.chrome[row..row + 296]);
             self.logical[row + 934..row + LOGICAL_WIDTH]
@@ -313,6 +366,7 @@ fn draw_cached_motion(
     cards: &[PreparedCard],
     ordinals: &[Vec<[u8; 7]>],
     motion: BrowseFrame,
+    mut flip: Option<(&[CardFaces], &mut [crate::launcher_flip::Column], bool)>,
 ) {
     let selected = motion.selected % cards.len();
     let duration = motion.duration_millis.max(1) as i32;
@@ -336,7 +390,13 @@ fn draw_cached_motion(
         2 => 121,
         _ => 109,
     };
-    let relatives: &[isize] = if right {
+    let relatives: &[isize] = if flip.is_some() && progress * 2 > duration {
+        if right {
+            &[-2, -1, 2, 3, 0, 1]
+        } else {
+            &[-3, -2, 1, 2, 0, -1]
+        }
+    } else if right {
         &[-2, -1, 1, 2, 3, 0]
     } else {
         &[-3, -2, -1, 1, 2, 0]
@@ -354,6 +414,43 @@ fn draw_cached_motion(
             } else {
                 0
             };
+            if (*relative == 0 || destination == 0) && progress > 0 && progress < duration {
+                if let Some((faces, columns, reverse)) = flip.as_mut() {
+                    let spin = (if right { 1_i64 } else { -1 }) * if *reverse { -1 } else { 1 };
+                    let angle = if *relative == 0 { 65536 } else { 0 }
+                        + spin * i64::from(progress) * 65536 / i64::from(duration);
+                    let (_, cos) = crate::launcher_flip::sin_cos(angle);
+                    let face = if cos < 0 {
+                        &faces[index].detail
+                    } else {
+                        let compact_width = if *relative == 0 {
+                            slot_width(destination)
+                        } else {
+                            slot_width(*relative)
+                        };
+                        &faces[index].compact[match compact_width {
+                            111 => 1,
+                            121 => 2,
+                            _ => 0,
+                        }]
+                    };
+                    let top = CARD_TOP as i32 + 8 - 8 * prominence / 256;
+                    crate::launcher_flip::draw(
+                        pixels,
+                        face,
+                        crate::launcher_flip::Pose {
+                            x,
+                            top,
+                            width,
+                            height: CARD_BOTTOM as i32 - top,
+                            angle,
+                        },
+                        columns,
+                        reflection_pixel,
+                    );
+                    continue;
+                }
+            }
             draw_cached_card(
                 pixels,
                 x as usize,
@@ -369,7 +466,9 @@ fn draw_cached_motion(
 }
 
 fn eased_progress(progress: u32, duration: u32) -> i32 {
-    if duration == crate::launcher_navigation::TAP_SLIDE_MS as u32 {
+    if duration == crate::launcher_navigation::TAP_SLIDE_MS as u32
+        || duration == crate::launcher_navigation::TAP_FLIP_MS as u32
+    {
         let t = progress.min(duration) as i64;
         let d = duration as i64;
         // Integer smoothstep: 3t^2 - 2t^3, with exact 0 and duration ends.

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -336,6 +336,8 @@ fn draw_cached_carousel(
             &cards[index],
             false,
             &ordinals[index],
+            353,
+            256,
         );
     }
     draw_cached_card(
@@ -345,6 +347,8 @@ fn draw_cached_carousel(
         &cards[selected % cards.len()],
         true,
         "",
+        220,
+        768,
     );
 }
 
@@ -380,6 +384,13 @@ fn draw_cached_motion(
         let x = slot_x(relative) + t(slot_x(destination) - slot_x(relative));
         let width = slot_width(relative) + t(slot_width(destination) - slot_width(relative));
         if x >= 0 && width > 0 {
+            let prominence = if relative == 0 {
+                256 - (256 * progress / duration)
+            } else if destination == 0 {
+                256 * progress / duration
+            } else {
+                0
+            };
             draw_cached_card(
                 pixels,
                 x as usize,
@@ -387,6 +398,8 @@ fn draw_cached_motion(
                 &cards[index],
                 relative == 0,
                 &ordinals[index],
+                (353 - 133 * prominence / 256) as usize,
+                (256 + 512 * prominence / 256) as usize,
             );
         }
     }
@@ -399,6 +412,8 @@ fn draw_cached_card(
     card: &PreparedCard,
     selected: bool,
     ordinal_label: &str,
+    title_y: usize,
+    title_scale_q8: usize,
 ) {
     let top = if selected { CARD_TOP } else { CARD_TOP + 8 };
     let bottom = CARD_BOTTOM;
@@ -415,11 +430,27 @@ fn draw_cached_card(
         if width > 8 && bottom - top > 8 {
             draw_rect_outline(pixels, x + 4, top + 4, width - 8, bottom - top - 8, CREAM);
         }
-        draw_text_centered(pixels, x, 220, width, &card.name, foreground, 3);
+        draw_text_scaled_centered(
+            pixels,
+            x,
+            title_y,
+            width,
+            &card.name,
+            foreground,
+            title_scale_q8,
+        );
         draw_text_centered(pixels, x, 385, width, &card.games_label, foreground, 1);
     } else {
         draw_text(pixels, x + 15, 151, ordinal_label, foreground, 1);
-        draw_text_centered(pixels, x, 353, width, &card.name, foreground, 1);
+        draw_text_scaled_centered(
+            pixels,
+            x,
+            title_y,
+            width,
+            &card.name,
+            foreground,
+            title_scale_q8,
+        );
     }
     draw_reflection(pixels, x, width, bottom);
 }
@@ -620,6 +651,35 @@ fn draw_text_centered(
         colour,
         scale,
     );
+}
+
+fn draw_text_scaled_centered(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    width: usize,
+    text: &str,
+    colour: u16,
+    scale_q8: usize,
+) {
+    let text_width = text.chars().count() * 6 * scale_q8 / 256;
+    let origin = x + width.saturating_sub(text_width) / 2;
+    let mut cursor = origin;
+    for character in text.chars() {
+        let glyph = glyph(character);
+        for (row, bits) in glyph.iter().enumerate() {
+            let y0 = y + row * scale_q8 / 256;
+            let y1 = y + (row + 1) * scale_q8 / 256;
+            for column in 0..5 {
+                if bits & (1 << (4 - column)) != 0 {
+                    let x0 = cursor + column * scale_q8 / 256;
+                    let x1 = cursor + (column + 1) * scale_q8 / 256;
+                    draw_rect(pixels, x0, y0, (x1 - x0).max(1), (y1 - y0).max(1), colour);
+                }
+            }
+        }
+        cursor += 6 * scale_q8 / 256;
+    }
 }
 
 fn draw_number(

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -1,0 +1,510 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Static text-and-colour launcher scene used by the Mini-MagiK visual probe.
+//!
+//! The scene deliberately has no Slint or runtime dependency. It renders a
+//! packed RGB565 frame at the requested output size, using a 960x540 logical
+//! design with nearest-neighbour letterboxing.
+
+use crate::Rgb565Pixel;
+
+pub const LOGICAL_WIDTH: usize = 960;
+pub const LOGICAL_HEIGHT: usize = 540;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LauncherCard<'a> {
+    pub name: &'a str,
+    pub games: u32,
+    pub colour: u16,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LauncherData<'a> {
+    pub cards: &'a [LauncherCard<'a>],
+    pub selected: usize,
+    pub library_games: u32,
+    pub collections: u32,
+    pub favourites: u32,
+    pub clock: &'a str,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LauncherScene {
+    pub width: usize,
+    pub height: usize,
+}
+
+impl LauncherScene {
+    #[must_use]
+    pub const fn new(width: usize, height: usize) -> Self {
+        Self { width, height }
+    }
+
+    #[must_use]
+    pub fn render(self, data: LauncherData<'_>) -> Vec<Rgb565Pixel> {
+        let mut logical = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        render_logical(&mut logical, data);
+        scale_letterboxed(&logical, self.width, self.height)
+    }
+}
+
+const BACKGROUND: u16 = rgb(7, 12, 15);
+const CREAM: u16 = rgb(238, 232, 213);
+const MUTED: u16 = rgb(143, 151, 150);
+const RULE: u16 = rgb(48, 61, 63);
+const WHITE: u16 = rgb(250, 247, 232);
+const CARD_TOP: usize = 135;
+const CARD_BOTTOM: usize = 428;
+const REFLECTION_TOP: usize = 433;
+const REFLECTION_HEIGHT: usize = 44;
+
+const fn rgb(red: u16, green: u16, blue: u16) -> u16 {
+    ((red >> 3) << 11) | ((green >> 2) << 5) | (blue >> 3)
+}
+
+fn render_logical(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
+    draw_rect(pixels, 0, 0, LOGICAL_WIDTH, LOGICAL_HEIGHT, BACKGROUND);
+    draw_text(pixels, 26, 20, "MISTER MAGIK", CREAM, 3);
+    draw_text(pixels, 26, 53, "PLAY / COLLECT / REMEMBER", MUTED, 1);
+    draw_text(pixels, 875, 22, data.clock, CREAM, 2);
+    draw_text(pixels, 842, 53, "SETTINGS", MUTED, 1);
+    draw_line(pixels, 26, 76, 934, 76, RULE);
+
+    draw_line(pixels, 265, 95, 265, 478, RULE);
+    draw_text(pixels, 29, 101, "YOUR LIBRARY", MUTED, 1);
+    draw_number(pixels, 28, 142, data.library_games, CREAM, 5);
+    draw_text(pixels, 29, 205, "GAMES READY TO PLAY", MUTED, 1);
+    draw_line(pixels, 28, 239, 240, 239, RULE);
+    draw_number(pixels, 30, 265, data.collections, CREAM, 3);
+    draw_number(pixels, 150, 265, data.favourites, CREAM, 3);
+    draw_text(pixels, 30, 310, "COLLECTIONS", MUTED, 1);
+    draw_text(pixels, 150, 310, "FAVOURITES", MUTED, 1);
+    draw_line(pixels, 28, 340, 240, 340, RULE);
+    draw_text(pixels, 29, 366, "ONE LIBRARY.", CREAM, 2);
+    draw_text(pixels, 29, 393, "EVERY GENERATION.", CREAM, 1);
+    for (index, colour) in [
+        rgb(226, 52, 67),
+        rgb(237, 193, 54),
+        rgb(85, 170, 91),
+        rgb(41, 145, 196),
+    ]
+    .iter()
+    .enumerate()
+    {
+        draw_rect(pixels, 29 + index * 54, 436, 48, 7, *colour);
+    }
+    draw_text(pixels, 29, 459, "ACROSS ALL COLLECTIONS", MUTED, 1);
+
+    draw_text(pixels, 296, 101, "COLLECTIONS", MUTED, 1);
+    draw_text(
+        pixels,
+        888,
+        101,
+        &format!("{:02} / {:02}", data.selected + 1, data.cards.len()),
+        MUTED,
+        1,
+    );
+    draw_carousel(pixels, data);
+    draw_line(pixels, 26, 500, 934, 500, RULE);
+    draw_text(pixels, 30, 516, "A  OPEN", CREAM, 1);
+    draw_text(pixels, 130, 516, "B  BACK", CREAM, 1);
+    draw_text(pixels, 586, 516, "←  →   BROWSE CARDS", CREAM, 1);
+    draw_text(pixels, 846, 516, "MISTER / OFFLINE", MUTED, 1);
+}
+
+fn draw_carousel(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
+    if data.cards.is_empty() {
+        return;
+    }
+    let selected = data.selected % data.cards.len();
+    let positions = [296_usize, 405, 514, 702, 813];
+    let widths = [109_usize, 109, 188, 111, 121];
+    for slot in [4_usize, 3, 1, 0] {
+        let relative = slot as isize - 2;
+        let index = (selected as isize + relative).rem_euclid(data.cards.len() as isize) as usize;
+        let card = data.cards[index];
+        let selected_card = slot == 2;
+        draw_card(
+            pixels,
+            positions[slot],
+            widths[slot],
+            card,
+            selected_card,
+            index,
+            data.cards.len(),
+        );
+    }
+    let card = data.cards[selected];
+    draw_card(
+        pixels,
+        positions[2],
+        widths[2],
+        card,
+        true,
+        selected,
+        data.cards.len(),
+    );
+}
+
+fn draw_card(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    width: usize,
+    card: LauncherCard<'_>,
+    selected: bool,
+    index: usize,
+    card_count: usize,
+) {
+    let top = if selected { CARD_TOP } else { CARD_TOP + 8 };
+    let bottom = CARD_BOTTOM;
+    draw_rect(pixels, x, top, width, bottom - top, card.colour);
+    if selected {
+        draw_rect_outline(pixels, x, top, width, bottom - top, CREAM);
+        draw_rect_outline(pixels, x + 4, top + 4, width - 8, bottom - top - 8, CREAM);
+        draw_text_centered(pixels, x, 220, width, card.name, WHITE, 3);
+        draw_text_centered(pixels, x, 385, width, &format_games(card.games), CREAM, 1);
+    } else {
+        draw_text(pixels, x + 15, 151, &ordinal(index, card_count), CREAM, 1);
+        draw_text_centered(pixels, x, 353, width, card.name, CREAM, 1);
+    }
+    draw_reflection(pixels, x, width, bottom);
+}
+
+fn format_games(games: u32) -> String {
+    format!("{} GAMES", games)
+}
+
+fn ordinal(index: usize, count: usize) -> String {
+    format!("{:02}", (index + 1).min(count))
+}
+
+fn draw_reflection(pixels: &mut [Rgb565Pixel], x: usize, width: usize, bottom: usize) {
+    for row in 0..REFLECTION_HEIGHT {
+        let source_y = bottom.saturating_sub(1 + row);
+        let alpha = 3_u16.saturating_sub((row / 11) as u16);
+        for column in x..x + width {
+            let target_y = REFLECTION_TOP + row;
+            if target_y < LOGICAL_HEIGHT {
+                let source = pixels[source_y * LOGICAL_WIDTH + column].0;
+                pixels[target_y * LOGICAL_WIDTH + column] =
+                    Rgb565Pixel(blend(source, BACKGROUND, alpha, 4));
+            }
+        }
+    }
+}
+
+fn blend(source: u16, background: u16, level: u16, levels: u16) -> u16 {
+    let mix = |s: u16, b: u16, bits: u16| {
+        ((s * level + b * (levels - level)) / levels) & ((1 << bits) - 1)
+    };
+    (mix((source >> 11) & 31, (background >> 11) & 31, 5) << 11)
+        | (mix((source >> 5) & 63, (background >> 5) & 63, 6) << 5)
+        | mix(source & 31, background & 31, 5)
+}
+
+fn scale_letterboxed(logical: &[Rgb565Pixel], width: usize, height: usize) -> Vec<Rgb565Pixel> {
+    if width == 0 || height == 0 {
+        return Vec::new();
+    }
+    let (scaled_width, scaled_height) =
+        if width.saturating_mul(LOGICAL_HEIGHT) <= height.saturating_mul(LOGICAL_WIDTH) {
+            (width, width * LOGICAL_HEIGHT / LOGICAL_WIDTH)
+        } else {
+            (height * LOGICAL_WIDTH / LOGICAL_HEIGHT, height)
+        };
+    if scaled_width == 0 || scaled_height == 0 {
+        return vec![Rgb565Pixel(BACKGROUND); width * height];
+    }
+    let x_offset = (width - scaled_width) / 2;
+    let y_offset = (height - scaled_height) / 2;
+    let mut output = vec![Rgb565Pixel(BACKGROUND); width * height];
+    for y in 0..scaled_height {
+        let source_y = y * LOGICAL_HEIGHT / scaled_height;
+        for x in 0..scaled_width {
+            let source_x = x * LOGICAL_WIDTH / scaled_width;
+            output[(y + y_offset) * width + x + x_offset] =
+                logical[source_y * LOGICAL_WIDTH + source_x];
+        }
+    }
+    output
+}
+
+fn draw_line(pixels: &mut [Rgb565Pixel], x0: usize, y0: usize, x1: usize, y1: usize, colour: u16) {
+    if x0 == x1 {
+        for y in y0..=y1 {
+            set_pixel(pixels, x0, y, colour);
+        }
+    } else {
+        for x in x0..=x1 {
+            set_pixel(pixels, x, y0, colour);
+        }
+    }
+}
+
+fn draw_rect(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+    colour: u16,
+) {
+    for row in y..y.saturating_add(height).min(LOGICAL_HEIGHT) {
+        for column in x..x.saturating_add(width).min(LOGICAL_WIDTH) {
+            set_pixel(pixels, column, row, colour);
+        }
+    }
+}
+
+fn draw_rect_outline(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    width: usize,
+    height: usize,
+    colour: u16,
+) {
+    draw_line(pixels, x, y, x + width - 1, y, colour);
+    draw_line(
+        pixels,
+        x,
+        y + height - 1,
+        x + width - 1,
+        y + height - 1,
+        colour,
+    );
+    for row in y..y + height {
+        set_pixel(pixels, x, row, colour);
+        set_pixel(pixels, x + width - 1, row, colour);
+    }
+}
+
+fn draw_text_centered(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    width: usize,
+    text: &str,
+    colour: u16,
+    scale: usize,
+) {
+    let text_width = text.chars().count() * 6 * scale;
+    draw_text(
+        pixels,
+        x + width.saturating_sub(text_width) / 2,
+        y,
+        text,
+        colour,
+        scale,
+    );
+}
+
+fn draw_number(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    value: u32,
+    colour: u16,
+    scale: usize,
+) {
+    draw_text(pixels, x, y, &value.to_string(), colour, scale);
+}
+
+fn draw_text(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    text: &str,
+    colour: u16,
+    scale: usize,
+) {
+    let mut cursor = x;
+    for character in text.chars() {
+        draw_glyph(pixels, cursor, y, character, colour, scale);
+        cursor += 6 * scale;
+    }
+}
+
+fn draw_glyph(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    character: char,
+    colour: u16,
+    scale: usize,
+) {
+    let glyph = glyph(character);
+    for (row, bits) in glyph.iter().enumerate() {
+        for column in 0..5 {
+            if bits & (1 << (4 - column)) != 0 {
+                draw_rect(
+                    pixels,
+                    x + column * scale,
+                    y + row * scale,
+                    scale,
+                    scale,
+                    colour,
+                );
+            }
+        }
+    }
+}
+
+fn glyph(character: char) -> [u8; 7] {
+    match character.to_ascii_uppercase() {
+        'A' => [14, 17, 17, 31, 17, 17, 17],
+        'B' => [30, 17, 17, 30, 17, 17, 30],
+        'C' => [15, 16, 16, 16, 16, 16, 15],
+        'D' => [30, 17, 17, 17, 17, 17, 30],
+        'E' => [31, 16, 16, 30, 16, 16, 31],
+        'F' => [31, 16, 16, 30, 16, 16, 16],
+        'G' => [15, 16, 16, 23, 17, 17, 15],
+        'H' => [17, 17, 17, 31, 17, 17, 17],
+        'I' => [31, 4, 4, 4, 4, 4, 31],
+        'J' => [7, 2, 2, 2, 2, 18, 12],
+        'K' => [17, 18, 20, 24, 20, 18, 17],
+        'L' => [16, 16, 16, 16, 16, 16, 31],
+        'M' => [17, 27, 21, 17, 17, 17, 17],
+        'N' => [17, 25, 21, 19, 17, 17, 17],
+        'O' => [14, 17, 17, 17, 17, 17, 14],
+        'P' => [30, 17, 17, 30, 16, 16, 16],
+        'Q' => [14, 17, 17, 17, 21, 18, 13],
+        'R' => [30, 17, 17, 30, 20, 18, 17],
+        'S' => [15, 16, 16, 14, 1, 1, 30],
+        'T' => [31, 4, 4, 4, 4, 4, 4],
+        'U' => [17, 17, 17, 17, 17, 17, 14],
+        'V' => [17, 17, 17, 17, 17, 10, 4],
+        'W' => [17, 17, 17, 21, 21, 27, 17],
+        'X' => [17, 17, 10, 4, 10, 17, 17],
+        'Y' => [17, 17, 10, 4, 4, 4, 4],
+        'Z' => [31, 1, 2, 4, 8, 16, 31],
+        '0' => [14, 17, 19, 21, 25, 17, 14],
+        '1' => [4, 12, 4, 4, 4, 4, 14],
+        '2' => [14, 17, 1, 2, 4, 8, 31],
+        '3' => [30, 1, 1, 14, 1, 1, 30],
+        '4' => [2, 6, 10, 18, 31, 2, 2],
+        '5' => [31, 16, 16, 30, 1, 1, 30],
+        '6' => [14, 16, 16, 30, 17, 17, 14],
+        '7' => [31, 1, 2, 4, 8, 8, 8],
+        '8' => [14, 17, 17, 14, 17, 17, 14],
+        '9' => [14, 17, 17, 15, 1, 1, 14],
+        '/' => [1, 2, 2, 4, 8, 8, 16],
+        '←' => [4, 2, 31, 2, 4, 0, 0],
+        '→' => [4, 8, 31, 8, 4, 0, 0],
+        '-' => [0, 0, 0, 31, 0, 0, 0],
+        '.' => [0, 0, 0, 0, 0, 6, 6],
+        _ => [0, 0, 0, 0, 0, 0, 0],
+    }
+}
+
+fn set_pixel(pixels: &mut [Rgb565Pixel], x: usize, y: usize, colour: u16) {
+    if x < LOGICAL_WIDTH && y < LOGICAL_HEIGHT {
+        pixels[y * LOGICAL_WIDTH + x] = Rgb565Pixel(colour);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CARDS: [LauncherCard<'static>; 5] = [
+        LauncherCard {
+            name: "ARCADE",
+            games: 1752,
+            colour: rgb(142, 27, 48),
+        },
+        LauncherCard {
+            name: "SNK",
+            games: 324,
+            colour: rgb(30, 75, 125),
+        },
+        LauncherCard {
+            name: "CONSOLES",
+            games: 842,
+            colour: rgb(199, 190, 167),
+        },
+        LauncherCard {
+            name: "HANDHELDS",
+            games: 126,
+            colour: rgb(45, 90, 150),
+        },
+        LauncherCard {
+            name: "COMPUTERS",
+            games: 86,
+            colour: rgb(190, 34, 55),
+        },
+    ];
+
+    fn data() -> LauncherData<'static> {
+        LauncherData {
+            cards: &CARDS,
+            selected: 0,
+            library_games: 6842,
+            collections: 18,
+            favourites: 126,
+            clock: "21:37",
+        }
+    }
+
+    #[test]
+    fn output_is_deterministic_and_packed() {
+        let scene = LauncherScene::new(960, 540);
+        assert_eq!(scene.render(data()), scene.render(data()));
+        assert_eq!(scene.render(data()).len(), 960 * 540);
+    }
+
+    #[test]
+    fn fits_requested_sizes_with_exact_letterbox() {
+        let frame = LauncherScene::new(640, 480).render(data());
+        assert_eq!(frame.len(), 640 * 480);
+        assert!(frame[..640 * 60].iter().all(|pixel| pixel.0 == BACKGROUND));
+        assert!(frame[420 * 640..].iter().all(|pixel| pixel.0 == BACKGROUND));
+        assert!(
+            frame[60 * 640..420 * 640]
+                .iter()
+                .any(|pixel| pixel.0 != BACKGROUND)
+        );
+        assert_eq!(LauncherScene::new(1, 1).render(data()).len(), 1);
+        assert!(LauncherScene::new(0, 0).render(data()).is_empty());
+    }
+
+    #[test]
+    fn reflection_reverses_rows_and_fades_to_background() {
+        let mut pixels = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        for row in 0..REFLECTION_HEIGHT {
+            pixels[(CARD_BOTTOM - 1 - row) * LOGICAL_WIDTH + 520] = Rgb565Pixel(if row % 2 == 0 {
+                rgb(240, 40, 80)
+            } else {
+                rgb(20, 180, 220)
+            });
+        }
+        draw_reflection(&mut pixels, 520, 1, CARD_BOTTOM);
+        assert_eq!(
+            pixels[REFLECTION_TOP * LOGICAL_WIDTH + 520].0,
+            blend(rgb(240, 40, 80), BACKGROUND, 3, 4)
+        );
+        assert_ne!(
+            pixels[(REFLECTION_TOP + 1) * LOGICAL_WIDTH + 520].0,
+            pixels[REFLECTION_TOP * LOGICAL_WIDTH + 520].0
+        );
+        assert_ne!(
+            pixels[(REFLECTION_TOP + 11) * LOGICAL_WIDTH + 520].0,
+            pixels[(REFLECTION_TOP + 1) * LOGICAL_WIDTH + 520].0
+        );
+        assert_eq!(
+            pixels[(REFLECTION_TOP + 33) * LOGICAL_WIDTH + 520].0,
+            BACKGROUND
+        );
+    }
+
+    #[test]
+    fn cards_are_clipped_to_carousel_region() {
+        let mut pixels = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        draw_carousel(&mut pixels, data());
+        for row in CARD_TOP..REFLECTION_TOP + REFLECTION_HEIGHT {
+            assert_eq!(pixels[row * LOGICAL_WIDTH + 295].0, BACKGROUND);
+            assert_eq!(pixels[row * LOGICAL_WIDTH + 934].0, BACKGROUND);
+        }
+    }
+}

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -509,9 +509,11 @@ fn text_mask(text: &str) -> Vec<[u8; 7]> {
 }
 
 fn draw_reflection(pixels: &mut [Rgb565Pixel], x: usize, width: usize, bottom: usize) {
+    let left = x.max(296);
+    let right = x.saturating_add(width).min(934);
     for row in 0..REFLECTION_HEIGHT {
         let source_y = bottom.saturating_sub(1 + row);
-        for column in x..x + width {
+        for column in left..right {
             let target_y = REFLECTION_TOP + row;
             if target_y < LOGICAL_HEIGHT {
                 let source = pixels[source_y * LOGICAL_WIDTH + column].0;

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -57,6 +57,107 @@ impl LauncherScene {
         render_logical(&mut logical, data, motion);
         scale_letterboxed(&logical, self.width, self.height)
     }
+
+    #[must_use]
+    pub fn prepare(self, data: LauncherData<'_>) -> PreparedLauncher {
+        PreparedLauncher::new(self, data)
+    }
+}
+
+/// Reusable launcher composition. All owned strings and working buffers are
+/// created during preparation; `render_into` is allocation-free.
+pub struct PreparedLauncher {
+    scene: LauncherScene,
+    chrome: Vec<Rgb565Pixel>,
+    logical: Vec<Rgb565Pixel>,
+    cards: Vec<PreparedCard>,
+    ordinals: Vec<String>,
+    collection_labels: Vec<String>,
+}
+
+struct PreparedCard {
+    name: String,
+    games: u32,
+    games_label: String,
+    colour: u16,
+}
+
+impl PreparedLauncher {
+    fn new(scene: LauncherScene, data: LauncherData<'_>) -> Self {
+        let cards: Vec<_> = data
+            .cards
+            .iter()
+            .map(|card| PreparedCard {
+                name: card.name.to_owned(),
+                games: card.games,
+                games_label: format_games(card.games),
+                colour: card.colour,
+            })
+            .collect();
+        let ordinals = (0..cards.len())
+            .map(|index| ordinal(index, cards.len()))
+            .collect();
+        let collection_labels = (0..cards.len())
+            .map(|index| format!("{:02} / {:02}", index + 1, cards.len()))
+            .collect();
+        let borrowed: Vec<_> = cards
+            .iter()
+            .map(|card| LauncherCard {
+                name: &card.name,
+                games: card.games,
+                colour: card.colour,
+            })
+            .collect();
+        let source = LauncherData {
+            cards: &borrowed,
+            selected: data.selected,
+            library_games: data.library_games,
+            collections: data.collections,
+            favourites: data.favourites,
+            clock: data.clock,
+        };
+        let mut chrome = vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        render_logical(&mut chrome, source, None);
+        draw_rect(
+            &mut chrome,
+            296,
+            CARD_TOP,
+            638,
+            REFLECTION_TOP + REFLECTION_HEIGHT - CARD_TOP,
+            BACKGROUND,
+        );
+        draw_rect(&mut chrome, 880, 95, 54, 16, BACKGROUND);
+        Self {
+            scene,
+            chrome,
+            logical: vec![Rgb565Pixel(BACKGROUND); LOGICAL_WIDTH * LOGICAL_HEIGHT],
+            cards,
+            ordinals,
+            collection_labels,
+        }
+    }
+
+    pub fn render_into(&mut self, frame: BrowseFrame, output: &mut [Rgb565Pixel]) {
+        self.logical.copy_from_slice(&self.chrome);
+        if let Some(label) = self.collection_labels.get(frame.selected) {
+            draw_text(&mut self.logical, 888, 101, label, MUTED, 1);
+        }
+        if self.cards.is_empty() {
+            scale_into(&self.logical, self.scene.width, self.scene.height, output);
+            return;
+        }
+        if frame.phase == crate::launcher_navigation::BrowsePhase::Settled {
+            draw_cached_carousel(
+                &mut self.logical,
+                &self.cards,
+                &self.ordinals,
+                frame.selected,
+            );
+        } else {
+            draw_cached_motion(&mut self.logical, &self.cards, &self.ordinals, frame);
+        }
+        scale_into(&self.logical, self.scene.width, self.scene.height, output);
+    }
 }
 
 const BACKGROUND: u16 = rgb(0, 0, 0);
@@ -217,6 +318,112 @@ fn draw_carousel(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
     );
 }
 
+fn draw_cached_carousel(
+    pixels: &mut [Rgb565Pixel],
+    cards: &[PreparedCard],
+    ordinals: &[String],
+    selected: usize,
+) {
+    let positions = [296_usize, 405, 514, 702, 813];
+    let widths = [109_usize, 109, 188, 111, 121];
+    for slot in [4_usize, 3, 1, 0] {
+        let relative = slot as isize - 2;
+        let index = (selected as isize + relative).rem_euclid(cards.len() as isize) as usize;
+        draw_cached_card(
+            pixels,
+            positions[slot],
+            widths[slot],
+            &cards[index],
+            false,
+            &ordinals[index],
+        );
+    }
+    draw_cached_card(
+        pixels,
+        positions[2],
+        widths[2],
+        &cards[selected % cards.len()],
+        true,
+        "",
+    );
+}
+
+fn draw_cached_motion(
+    pixels: &mut [Rgb565Pixel],
+    cards: &[PreparedCard],
+    ordinals: &[String],
+    motion: BrowseFrame,
+) {
+    let selected = motion.selected % cards.len();
+    let progress = motion.progress_millis.min(motion.duration_millis.max(1)) as i32;
+    let duration = motion.duration_millis.max(1) as i32;
+    let right = motion.direction == Some(BrowseDirection::Right);
+    let t = |value: i32| value * progress / duration;
+    let slot_x = |relative: isize| match relative {
+        -3 => 187,
+        -2 => 296,
+        -1 => 405,
+        0 => 514,
+        1 => 702,
+        2 => 813,
+        _ => 934,
+    };
+    let slot_width = |relative: isize| match relative {
+        0 => 188,
+        1 => 111,
+        2 => 121,
+        _ => 109,
+    };
+    for relative in [-3_isize, -2, -1, 1, 2, 3, 0] {
+        let index = (selected as isize + relative).rem_euclid(cards.len() as isize) as usize;
+        let destination = if right { relative - 1 } else { relative + 1 };
+        let x = slot_x(relative) + t(slot_x(destination) - slot_x(relative));
+        let width = slot_width(relative) + t(slot_width(destination) - slot_width(relative));
+        if x >= 0 && width > 0 {
+            draw_cached_card(
+                pixels,
+                x as usize,
+                width as usize,
+                &cards[index],
+                relative == 0,
+                &ordinals[index],
+            );
+        }
+    }
+}
+
+fn draw_cached_card(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    width: usize,
+    card: &PreparedCard,
+    selected: bool,
+    ordinal_label: &str,
+) {
+    let top = if selected { CARD_TOP } else { CARD_TOP + 8 };
+    let bottom = CARD_BOTTOM;
+    draw_rect(pixels, x, top, width, bottom - top, card.colour);
+    let foreground = if is_light_card(card.colour) {
+        DARK_TEXT
+    } else if selected {
+        WHITE
+    } else {
+        CREAM
+    };
+    if selected {
+        draw_rect_outline(pixels, x, top, width, bottom - top, CREAM);
+        if width > 8 && bottom - top > 8 {
+            draw_rect_outline(pixels, x + 4, top + 4, width - 8, bottom - top - 8, CREAM);
+        }
+        draw_text_centered(pixels, x, 220, width, &card.name, foreground, 3);
+        draw_text_centered(pixels, x, 385, width, &card.games_label, foreground, 1);
+    } else {
+        draw_text(pixels, x + 15, 151, ordinal_label, foreground, 1);
+        draw_text_centered(pixels, x, 353, width, &card.name, foreground, 1);
+    }
+    draw_reflection(pixels, x, width, bottom);
+}
+
 fn draw_card(
     pixels: &mut [Rgb565Pixel],
     x: usize,
@@ -314,6 +521,16 @@ fn scale_letterboxed(logical: &[Rgb565Pixel], width: usize, height: usize) -> Ve
     if width == 0 || height == 0 {
         return Vec::new();
     }
+    let mut output = vec![Rgb565Pixel(BACKGROUND); width * height];
+    scale_into(logical, width, height, &mut output);
+    output
+}
+
+fn scale_into(logical: &[Rgb565Pixel], width: usize, height: usize, output: &mut [Rgb565Pixel]) {
+    if width == 0 || height == 0 || output.len() < width.saturating_mul(height) {
+        return;
+    }
+    output.fill(Rgb565Pixel(BACKGROUND));
     let (scaled_width, scaled_height) =
         if width.saturating_mul(LOGICAL_HEIGHT) <= height.saturating_mul(LOGICAL_WIDTH) {
             (width, width * LOGICAL_HEIGHT / LOGICAL_WIDTH)
@@ -321,11 +538,10 @@ fn scale_letterboxed(logical: &[Rgb565Pixel], width: usize, height: usize) -> Ve
             (height * LOGICAL_WIDTH / LOGICAL_HEIGHT, height)
         };
     if scaled_width == 0 || scaled_height == 0 {
-        return vec![Rgb565Pixel(BACKGROUND); width * height];
+        return;
     }
     let x_offset = (width - scaled_width) / 2;
     let y_offset = (height - scaled_height) / 2;
-    let mut output = vec![Rgb565Pixel(BACKGROUND); width * height];
     for y in 0..scaled_height {
         let source_y = y * LOGICAL_HEIGHT / scaled_height;
         for x in 0..scaled_width {
@@ -334,7 +550,6 @@ fn scale_letterboxed(logical: &[Rgb565Pixel], width: usize, height: usize) -> Ve
                 logical[source_y * LOGICAL_WIDTH + source_x];
         }
     }
-    output
 }
 
 fn draw_line(pixels: &mut [Rgb565Pixel], x0: usize, y0: usize, x1: usize, y1: usize, colour: u16) {
@@ -651,5 +866,42 @@ mod tests {
             assert_eq!(pixels[row * LOGICAL_WIDTH + 295].0, BACKGROUND);
             assert_eq!(pixels[row * LOGICAL_WIDTH + 934].0, BACKGROUND);
         }
+    }
+
+    #[test]
+    fn prepared_resting_frame_matches_cold_render() {
+        let scene = LauncherScene::new(960, 540);
+        let mut prepared = scene.prepare(data());
+        let mut output = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        let frame = BrowseFrame {
+            selected: 0,
+            target: 0,
+            phase: crate::launcher_navigation::BrowsePhase::Settled,
+            direction: None,
+            progress_millis: 0,
+            duration_millis: 180,
+        };
+        prepared.render_into(frame, &mut output);
+        assert_eq!(output, scene.render(data()));
+    }
+
+    #[test]
+    fn prepared_motion_changes_continuously_and_keeps_fixed_duration() {
+        let scene = LauncherScene::new(960, 540);
+        let mut prepared = scene.prepare(data());
+        let mut start = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        let mut middle = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        let frame = |progress_millis| BrowseFrame {
+            selected: 0,
+            target: 1,
+            phase: crate::launcher_navigation::BrowsePhase::Sliding,
+            direction: Some(BrowseDirection::Right),
+            progress_millis,
+            duration_millis: 180,
+        };
+        prepared.render_into(frame(0), &mut start);
+        prepared.render_into(frame(90), &mut middle);
+        assert_ne!(start, middle);
+        assert_eq!(frame(90).duration_millis, 180);
     }
 }

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -71,15 +71,16 @@ pub struct PreparedLauncher {
     chrome: Vec<Rgb565Pixel>,
     logical: Vec<Rgb565Pixel>,
     cards: Vec<PreparedCard>,
-    ordinals: Vec<String>,
+    ordinals: Vec<Vec<[u8; 7]>>,
     collection_labels: Vec<String>,
 }
 
 struct PreparedCard {
     name: String,
     games: u32,
-    games_label: String,
     colour: u16,
+    name_mask: Vec<[u8; 7]>,
+    games_mask: Vec<[u8; 7]>,
 }
 
 impl PreparedLauncher {
@@ -90,12 +91,13 @@ impl PreparedLauncher {
             .map(|card| PreparedCard {
                 name: card.name.to_owned(),
                 games: card.games,
-                games_label: format_games(card.games),
                 colour: card.colour,
+                name_mask: text_mask(card.name),
+                games_mask: text_mask(&format_games(card.games)),
             })
             .collect();
         let ordinals = (0..cards.len())
-            .map(|index| ordinal(index, cards.len()))
+            .map(|index| text_mask(&ordinal(index, cards.len())))
             .collect();
         let collection_labels = (0..cards.len())
             .map(|index| format!("{:02} / {:02}", index + 1, cards.len()))
@@ -155,6 +157,14 @@ impl PreparedLauncher {
             );
         } else {
             draw_cached_motion(&mut self.logical, &self.cards, &self.ordinals, frame);
+        }
+        // Moving neighbours may be partially outside the carousel; restore
+        // the clip margins after rasterizing signed slot geometry.
+        for y in CARD_TOP..REFLECTION_TOP + REFLECTION_HEIGHT {
+            let row = y * LOGICAL_WIDTH;
+            self.logical[row..row + 296].copy_from_slice(&self.chrome[row..row + 296]);
+            self.logical[row + 934..row + LOGICAL_WIDTH]
+                .copy_from_slice(&self.chrome[row + 934..row + LOGICAL_WIDTH]);
         }
         scale_into(&self.logical, self.scene.width, self.scene.height, output);
     }
@@ -247,13 +257,15 @@ fn draw_carousel_motion(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>, moti
     let right = motion.direction == Some(BrowseDirection::Right);
     let t = |value: i32| value * progress as i32 / duration as i32;
     let slot_x = |relative: isize| match relative {
+        -4 => 78,
         -3 => 187,
         -2 => 296,
         -1 => 405,
         0 => 514,
         1 => 702,
         2 => 813,
-        _ => 934,
+        3 => 934,
+        _ => 1055,
     };
     let slot_width = |relative: isize| match relative {
         0 => 188,
@@ -321,7 +333,7 @@ fn draw_carousel(pixels: &mut [Rgb565Pixel], data: LauncherData<'_>) {
 fn draw_cached_carousel(
     pixels: &mut [Rgb565Pixel],
     cards: &[PreparedCard],
-    ordinals: &[String],
+    ordinals: &[Vec<[u8; 7]>],
     selected: usize,
 ) {
     let positions = [296_usize, 405, 514, 702, 813];
@@ -334,10 +346,10 @@ fn draw_cached_carousel(
             positions[slot],
             widths[slot],
             &cards[index],
-            false,
             &ordinals[index],
             353,
             256,
+            0,
         );
     }
     draw_cached_card(
@@ -345,17 +357,17 @@ fn draw_cached_carousel(
         positions[2],
         widths[2],
         &cards[selected % cards.len()],
-        true,
-        "",
+        &[],
         220,
         768,
+        256,
     );
 }
 
 fn draw_cached_motion(
     pixels: &mut [Rgb565Pixel],
     cards: &[PreparedCard],
-    ordinals: &[String],
+    ordinals: &[Vec<[u8; 7]>],
     motion: BrowseFrame,
 ) {
     let selected = motion.selected % cards.len();
@@ -364,13 +376,15 @@ fn draw_cached_motion(
     let right = motion.direction == Some(BrowseDirection::Right);
     let t = |value: i32| value * progress / duration;
     let slot_x = |relative: isize| match relative {
+        -4 => 78,
         -3 => 187,
         -2 => 296,
         -1 => 405,
         0 => 514,
         1 => 702,
         2 => 813,
-        _ => 934,
+        3 => 934,
+        _ => 1055,
     };
     let slot_width = |relative: isize| match relative {
         0 => 188,
@@ -378,13 +392,18 @@ fn draw_cached_motion(
         2 => 121,
         _ => 109,
     };
-    for relative in [-3_isize, -2, -1, 1, 2, 3, 0] {
-        let index = (selected as isize + relative).rem_euclid(cards.len() as isize) as usize;
-        let destination = if right { relative - 1 } else { relative + 1 };
-        let x = slot_x(relative) + t(slot_x(destination) - slot_x(relative));
-        let width = slot_width(relative) + t(slot_width(destination) - slot_width(relative));
+    let relatives: &[isize] = if right {
+        &[-2, -1, 1, 2, 3, 0]
+    } else {
+        &[-3, -2, -1, 1, 2, 0]
+    };
+    for relative in relatives {
+        let index = (selected as isize + *relative).rem_euclid(cards.len() as isize) as usize;
+        let destination = if right { *relative - 1 } else { *relative + 1 };
+        let x = slot_x(*relative) + t(slot_x(destination) - slot_x(*relative));
+        let width = slot_width(*relative) + t(slot_width(destination) - slot_width(*relative));
         if x >= 0 && width > 0 {
-            let prominence = if relative == 0 {
+            let prominence = if *relative == 0 {
                 256 - (256 * progress / duration)
             } else if destination == 0 {
                 256 * progress / duration
@@ -396,10 +415,10 @@ fn draw_cached_motion(
                 x as usize,
                 width as usize,
                 &cards[index],
-                false,
                 &ordinals[index],
                 (353 - 133 * prominence / 256) as usize,
                 (256 + 512 * prominence / 256) as usize,
+                prominence as usize,
             );
         }
     }
@@ -410,48 +429,48 @@ fn draw_cached_card(
     x: usize,
     width: usize,
     card: &PreparedCard,
-    selected: bool,
-    ordinal_label: &str,
+    ordinal_label: &[[u8; 7]],
     title_y: usize,
     title_scale_q8: usize,
+    prominence: usize,
 ) {
-    let top = if selected { CARD_TOP } else { CARD_TOP + 8 };
+    let top = CARD_TOP + 8 - 8 * prominence / 256;
     let bottom = CARD_BOTTOM;
     draw_rect(pixels, x, top, width, bottom - top, card.colour);
     let foreground = if is_light_card(card.colour) {
         DARK_TEXT
-    } else if selected {
-        WHITE
     } else {
-        CREAM
+        mix_colour(CREAM, WHITE, prominence)
     };
-    if selected {
-        draw_rect_outline(pixels, x, top, width, bottom - top, CREAM);
+    if prominence > 0 {
+        let outline = mix_colour(card.colour, CREAM, prominence);
+        draw_rect_outline(pixels, x, top, width, bottom - top, outline);
         if width > 8 && bottom - top > 8 {
-            draw_rect_outline(pixels, x + 4, top + 4, width - 8, bottom - top - 8, CREAM);
+            draw_rect_outline(pixels, x + 4, top + 4, width - 8, bottom - top - 8, outline);
         }
-        draw_text_scaled_centered(
+        draw_mask_scaled_centered(
             pixels,
             x,
             title_y,
             width,
-            &card.name,
+            &card.name_mask,
             foreground,
             title_scale_q8,
         );
-        draw_text_centered(pixels, x, 385, width, &card.games_label, foreground, 1);
-    } else {
-        draw_text(pixels, x + 15, 151, ordinal_label, foreground, 1);
-        draw_text_scaled_centered(
-            pixels,
-            x,
-            title_y,
-            width,
-            &card.name,
-            foreground,
-            title_scale_q8,
-        );
+        let count_colour = mix_colour(card.colour, foreground, prominence);
+        draw_mask_scaled_centered(pixels, x, 385, width, &card.games_mask, count_colour, 256);
     }
+    let ordinal_colour = mix_colour(card.colour, foreground, 256 - prominence);
+    draw_mask(pixels, x + 15, 151, ordinal_label, ordinal_colour, 256);
+    draw_mask_scaled_centered(
+        pixels,
+        x,
+        title_y,
+        width,
+        &card.name_mask,
+        foreground,
+        title_scale_q8,
+    );
     draw_reflection(pixels, x, width, bottom);
 }
 
@@ -511,12 +530,27 @@ fn is_light_card(colour: u16) -> bool {
     red + green + blue > 480
 }
 
+fn mix_colour(background: u16, foreground: u16, amount: usize) -> u16 {
+    let amount = amount.min(256) as u32;
+    let channel = |shift: u32, bits: u32| {
+        let mask = (1_u16 << bits) - 1;
+        let a = u32::from((background >> shift) & mask);
+        let b = u32::from((foreground >> shift) & mask);
+        ((a * (256 - amount) + b * amount) / 256) as u16
+    };
+    (channel(11, 5) << 11) | (channel(5, 6) << 5) | channel(0, 5)
+}
+
 fn format_games(games: u32) -> String {
     format!("{} GAMES", games)
 }
 
 fn ordinal(index: usize, count: usize) -> String {
     format!("{:02}", (index + 1).min(count))
+}
+
+fn text_mask(text: &str) -> Vec<[u8; 7]> {
+    text.chars().map(glyph).collect()
 }
 
 fn draw_reflection(pixels: &mut [Rgb565Pixel], x: usize, width: usize, bottom: usize) {
@@ -559,6 +593,10 @@ fn scale_letterboxed(logical: &[Rgb565Pixel], width: usize, height: usize) -> Ve
 
 fn scale_into(logical: &[Rgb565Pixel], width: usize, height: usize, output: &mut [Rgb565Pixel]) {
     if width == 0 || height == 0 || output.len() < width.saturating_mul(height) {
+        return;
+    }
+    if width == LOGICAL_WIDTH && height == LOGICAL_HEIGHT {
+        output[..LOGICAL_WIDTH * LOGICAL_HEIGHT].copy_from_slice(logical);
         return;
     }
     output.fill(Rgb565Pixel(BACKGROUND));
@@ -653,32 +691,57 @@ fn draw_text_centered(
     );
 }
 
-fn draw_text_scaled_centered(
+fn draw_mask(
+    pixels: &mut [Rgb565Pixel],
+    x: usize,
+    y: usize,
+    mask: &[[u8; 7]],
+    colour: u16,
+    scale_q8: usize,
+) {
+    for (index, glyph) in mask.iter().enumerate() {
+        let origin = x + index * 6 * scale_q8 / 256;
+        for (row, bits) in glyph.iter().enumerate() {
+            for column in 0..5 {
+                if bits & (1 << (4 - column)) != 0 {
+                    draw_rect(
+                        pixels,
+                        origin + column * scale_q8 / 256,
+                        y + row * scale_q8 / 256,
+                        (scale_q8 / 256).max(1),
+                        (scale_q8 / 256).max(1),
+                        colour,
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn draw_mask_scaled_centered(
     pixels: &mut [Rgb565Pixel],
     x: usize,
     y: usize,
     width: usize,
-    text: &str,
+    mask: &[[u8; 7]],
     colour: u16,
     scale_q8: usize,
 ) {
-    let text_width = text.chars().count() * 6 * scale_q8 / 256;
+    let text_width = mask.len() * 6 * scale_q8 / 256;
     let origin = x + width.saturating_sub(text_width) / 2;
-    let mut cursor = origin;
-    for character in text.chars() {
-        let glyph = glyph(character);
+    for (index, glyph) in mask.iter().enumerate() {
+        let glyph_x = origin + index * 6 * scale_q8 / 256;
         for (row, bits) in glyph.iter().enumerate() {
             let y0 = y + row * scale_q8 / 256;
             let y1 = y + (row + 1) * scale_q8 / 256;
             for column in 0..5 {
                 if bits & (1 << (4 - column)) != 0 {
-                    let x0 = cursor + column * scale_q8 / 256;
-                    let x1 = cursor + (column + 1) * scale_q8 / 256;
+                    let x0 = glyph_x + column * scale_q8 / 256;
+                    let x1 = glyph_x + (column + 1) * scale_q8 / 256;
                     draw_rect(pixels, x0, y0, (x1 - x0).max(1), (y1 - y0).max(1), colour);
                 }
             }
         }
-        cursor += 6 * scale_q8 / 256;
     }
 }
 
@@ -963,5 +1026,41 @@ mod tests {
         prepared.render_into(frame(90), &mut middle);
         assert_ne!(start, middle);
         assert_eq!(frame(90).duration_millis, 180);
+    }
+
+    #[test]
+    fn prepared_motion_has_pixel_identical_resting_endpoints() {
+        let scene = LauncherScene::new(960, 540);
+        let mut prepared = scene.prepare(data());
+        let mut old = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        let mut start = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        let mut end = vec![Rgb565Pixel(0); LOGICAL_WIDTH * LOGICAL_HEIGHT];
+        let settled = |selected| BrowseFrame {
+            selected,
+            target: selected,
+            phase: crate::launcher_navigation::BrowsePhase::Settled,
+            direction: None,
+            progress_millis: 0,
+            duration_millis: 180,
+        };
+        let moving = |progress_millis| BrowseFrame {
+            selected: 0,
+            target: 1,
+            phase: crate::launcher_navigation::BrowsePhase::Sliding,
+            direction: Some(BrowseDirection::Right),
+            progress_millis,
+            duration_millis: 180,
+        };
+        prepared.render_into(settled(0), &mut old);
+        prepared.render_into(moving(0), &mut start);
+        prepared.render_into(moving(180), &mut end);
+        assert_eq!(start, old);
+        prepared.render_into(settled(1), &mut old);
+        for y in CARD_TOP..REFLECTION_TOP + REFLECTION_HEIGHT {
+            assert_eq!(
+                &end[y * LOGICAL_WIDTH + 296..y * LOGICAL_WIDTH + 934],
+                &old[y * LOGICAL_WIDTH + 296..y * LOGICAL_WIDTH + 934]
+            );
+        }
     }
 }

--- a/crates/framebuffer-scenes/src/launcher.rs
+++ b/crates/framebuffer-scenes/src/launcher.rs
@@ -168,7 +168,7 @@ fn draw_card(
     if selected {
         draw_rect_outline(pixels, x, top, width, bottom - top, CREAM);
         draw_rect_outline(pixels, x + 4, top + 4, width - 8, bottom - top - 8, CREAM);
-        let foreground = if card.colour == rgb(199, 190, 167) {
+        let foreground = if is_light_card(card.colour) {
             DARK_TEXT
         } else {
             WHITE
@@ -184,15 +184,29 @@ fn draw_card(
             1,
         );
     } else {
-        draw_text(pixels, x + 15, 151, &ordinal(index, card_count), CREAM, 1);
-        let foreground = if card.colour == rgb(199, 190, 167) {
+        let foreground = if is_light_card(card.colour) {
             DARK_TEXT
         } else {
             CREAM
         };
+        draw_text(
+            pixels,
+            x + 15,
+            151,
+            &ordinal(index, card_count),
+            foreground,
+            1,
+        );
         draw_text_centered(pixels, x, 353, width, card.name, foreground, 1);
     }
     draw_reflection(pixels, x, width, bottom);
+}
+
+fn is_light_card(colour: u16) -> bool {
+    let red = ((colour >> 11) & 31) * 255 / 31;
+    let green = ((colour >> 5) & 63) * 255 / 63;
+    let blue = (colour & 31) * 255 / 31;
+    red + green + blue > 480
 }
 
 fn format_games(games: u32) -> String {

--- a/crates/framebuffer-scenes/src/launcher_flip.rs
+++ b/crates/framebuffer-scenes/src/launcher_flip.rs
@@ -1,0 +1,178 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Vertical door-hinge adaptation of the retained card_flip lab's Q16 sine and
+//! inverse-column rasterizer. Pose/divisions are per column, never per pixel.
+use crate::Rgb565Pixel;
+const ONE: i64 = 65536;
+
+#[derive(Clone, Copy, Default)]
+pub(super) struct Column {
+    valid: bool,
+    sx: usize,
+    source_y: i32,
+    step: i32,
+    top: usize,
+    bottom: usize,
+}
+
+pub(super) struct Face {
+    pub pixels: Vec<Rgb565Pixel>,
+    pub width: usize,
+    pub height: usize,
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct Pose {
+    pub x: i32,
+    pub top: i32,
+    pub width: i32,
+    pub height: i32,
+    // pi radians = 65536; signed angle permits the preferred reverse mapping.
+    pub angle: i64,
+}
+
+// Bhaskara approximation, as in the retained lab. Exact at 0, pi/2 and pi.
+fn sin_pi(t: i64) -> i64 {
+    let p = t * (ONE - t) / ONE;
+    16 * p * ONE / (5 * ONE - 4 * p)
+}
+
+pub(super) fn sin_cos(angle: i64) -> (i64, i64) {
+    let t = angle.rem_euclid(2 * ONE);
+    let sin = if t <= ONE {
+        sin_pi(t)
+    } else {
+        -sin_pi(t - ONE)
+    };
+    let c = (t + ONE / 2).rem_euclid(2 * ONE);
+    let cos = if c <= ONE {
+        sin_pi(c)
+    } else {
+        -sin_pi(c - ONE)
+    };
+    (sin, cos)
+}
+
+pub(super) fn draw(
+    destination: &mut [Rgb565Pixel],
+    face: &Face,
+    pose: Pose,
+    columns: &mut [Column],
+    reflection: fn(u16, usize, usize) -> u16,
+) {
+    // Original lab geometry: the vertical hinge traverses the footprint while
+    // the door swings away. Both cards share this pose, regardless of face.
+    let progress = pose.angle.rem_euclid(ONE);
+    let (sine, cosine) = sin_cos(progress);
+    let hinge_x = i64::from(pose.x) * ONE + i64::from(pose.width - 1) * progress;
+    let centre_y = i64::from(pose.top) * ONE + i64::from(pose.height - 1) * ONE / 2;
+    let camera = i64::from(pose.width) * 460 / 258;
+    columns.fill(Column::default());
+    // Bound the scan independently of angle. No card can reach the sidebar.
+    let left = pose.x.clamp(296, 934) as usize;
+    let right = (pose.x + pose.width).clamp(296, 934) as usize;
+    let spine = (pose.width * 12 / 258).max(3);
+    if cosine.abs() * i64::from(pose.width) < i64::from(spine) * ONE {
+        let start = (pose.x + pose.width / 2 - spine / 2).clamp(296, 933) as usize;
+        let end = (start + spine as usize).min(934);
+        let top = pose.top.max(120) as usize;
+        let bottom = (pose.top + pose.height).min(438) as usize;
+        for y in top..bottom {
+            for x in start..end {
+                destination[y * 960 + x] =
+                    if x == start || x + 1 == end || y == top || y + 1 == bottom {
+                        Rgb565Pixel(0xe73a)
+                    } else {
+                        face.pixels[10 * face.width + 10]
+                    };
+            }
+        }
+        for row in 0..32 {
+            let y = bottom + 5 + row;
+            if y >= 477 {
+                break;
+            }
+            for x in start..end {
+                destination[y * 960 + x] = Rgb565Pixel(reflection(
+                    destination[(bottom - 1 - row) * 960 + x].0,
+                    x,
+                    row,
+                ));
+            }
+        }
+        return;
+    }
+    for (x, column) in columns.iter_mut().enumerate().take(right).skip(left) {
+        let offset = x as i64 * ONE - hinge_x;
+        let denominator = camera * cosine - offset * sine / ONE;
+        if denominator.abs() < 4 {
+            continue;
+        }
+        let local = offset * camera * ONE / denominator;
+        if local < -ONE / 2 || local > i64::from(pose.width - 1) * ONE + ONE / 2 {
+            continue;
+        }
+        let depth = ONE + local * sine / ONE / camera;
+        if depth <= 0 {
+            continue;
+        }
+        let sx = (local * (face.width - 1) as i64 / i64::from(pose.width - 1) + ONE / 2) / ONE;
+        let sx = sx.clamp(0, (face.width - 1) as i64) as usize;
+        let sx = if cosine < 0 { face.width - 1 - sx } else { sx };
+        let step = depth * (face.height - 1) as i64 / i64::from(pose.height - 1);
+        let zero = (face.height - 1) as i64 * ONE / 2 - centre_y * step / ONE;
+        let top = ((-zero + step - 1) / step).clamp(120, 438) as usize;
+        let bottom = (((face.height - 1) as i64 * ONE - zero) / step).clamp(120, 437) as usize;
+        if top > bottom {
+            continue;
+        }
+        *column = Column {
+            valid: true,
+            sx,
+            source_y: (zero + 120 * step) as i32,
+            step: step as i32,
+            top,
+            bottom,
+        };
+    }
+    for y in 120..438 {
+        for x in left..right {
+            let c = &mut columns[x];
+            if c.valid && y >= c.top && y <= c.bottom {
+                let sy = ((c.source_y + (1 << 15)) >> 16) as usize;
+                destination[y * 960 + x] = face.pixels[sy * face.width + c.sx];
+            }
+            c.source_y += c.step;
+        }
+    }
+    for x in left..right {
+        let c = columns[x];
+        if !c.valid {
+            continue;
+        }
+        for row in 0..32 {
+            let y = c.bottom + 6 + row;
+            if y >= 477 || c.bottom < c.top + row {
+                break;
+            }
+            let source = destination[(c.bottom - row) * 960 + x].0;
+            destination[y * 960 + x] = Rgb565Pixel(reflection(source, x, row));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn exact_axes_and_same_world_rotation_have_opposite_visible_face_skew() {
+        assert_eq!(sin_cos(0), (0, ONE));
+        assert_eq!(sin_cos(ONE / 2), (ONE, 0));
+        assert_eq!(sin_cos(ONE), (0, -ONE));
+        assert_eq!(sin_cos(-ONE / 2), (-ONE, 0));
+        let (a, b) = sin_cos(-ONE / 4);
+        let (c, d) = sin_cos(ONE - ONE / 4);
+        assert_eq!((a, b), (-c, -d));
+    }
+}

--- a/crates/framebuffer-scenes/src/launcher_navigation.rs
+++ b/crates/framebuffer-scenes/src/launcher_navigation.rs
@@ -1,0 +1,280 @@
+//! Deterministic joystick browsing state for the Mini launcher.
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BrowseDirection {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BrowsePhase {
+    Settled,
+    Sliding,
+    Held,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct BrowseFrame {
+    pub selected: usize,
+    pub target: usize,
+    pub phase: BrowsePhase,
+    pub direction: Option<BrowseDirection>,
+    pub progress_millis: u32,
+}
+
+pub const TAP_SLIDE_MS: u64 = 180;
+pub const HOLD_THRESHOLD_MS: u64 = 300;
+pub const HELD_STEP_MS: u64 = 150;
+
+#[derive(Clone, Copy, Debug)]
+pub struct LauncherBrowser {
+    count: usize,
+    selected: usize,
+    target: usize,
+    direction: Option<BrowseDirection>,
+    started_ms: u64,
+    duration_ms: u64,
+    hold_started_ms: u64,
+    left: bool,
+    right: bool,
+    pending: Option<BrowseDirection>,
+    neutral_required: bool,
+}
+
+impl LauncherBrowser {
+    #[must_use]
+    pub fn new(count: usize, selected: usize) -> Self {
+        let selected = if count == 0 { 0 } else { selected % count };
+        Self {
+            count,
+            selected,
+            target: selected,
+            direction: None,
+            started_ms: 0,
+            duration_ms: TAP_SLIDE_MS,
+            hold_started_ms: 0,
+            left: false,
+            right: false,
+            pending: None,
+            neutral_required: true,
+        }
+    }
+
+    pub fn press(&mut self, direction: BrowseDirection, now_ms: u64) {
+        if self.neutral_required {
+            return;
+        }
+        let already_held = match direction {
+            BrowseDirection::Left => self.left,
+            BrowseDirection::Right => self.right,
+        };
+        if already_held {
+            return;
+        }
+        match direction {
+            BrowseDirection::Left => self.left = true,
+            BrowseDirection::Right => self.right = true,
+        }
+        self.hold_started_ms = now_ms;
+        if self.direction.is_some() {
+            self.pending = Some(direction);
+        } else {
+            if !(self.left && self.right) {
+                self.start(direction, now_ms, TAP_SLIDE_MS);
+            }
+        }
+    }
+
+    pub fn release(&mut self, direction: BrowseDirection) {
+        match direction {
+            BrowseDirection::Left => self.left = false,
+            BrowseDirection::Right => self.right = false,
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.direction = None;
+        self.pending = None;
+        self.left = false;
+        self.right = false;
+        self.neutral_required = true;
+    }
+
+    pub fn neutral(&mut self) {
+        if !self.left && !self.right {
+            self.neutral_required = false;
+        }
+    }
+
+    #[must_use]
+    pub fn frame(&mut self, now_ms: u64) -> BrowseFrame {
+        if self.direction.is_some() {
+            let elapsed = now_ms.saturating_sub(self.started_ms);
+            if elapsed < self.duration_ms {
+                let held = (self.left || self.right)
+                    && now_ms.saturating_sub(self.hold_started_ms) >= HOLD_THRESHOLD_MS;
+                return self.snapshot(held, elapsed);
+            }
+            self.selected = self.target;
+            self.direction = None;
+            if self.count == 0 || (self.left && self.right) {
+                self.pending = None;
+            } else {
+                if let Some(next) = self.pending.take() {
+                    self.start(next, now_ms, TAP_SLIDE_MS);
+                } else if (self.left || self.right)
+                    && now_ms.saturating_sub(self.hold_started_ms) >= HOLD_THRESHOLD_MS
+                {
+                    let next = if self.left {
+                        BrowseDirection::Left
+                    } else {
+                        BrowseDirection::Right
+                    };
+                    self.start(next, now_ms, HELD_STEP_MS);
+                }
+            }
+        }
+        if self.direction.is_none()
+            && self.count > 1
+            && (self.left || self.right)
+            && now_ms.saturating_sub(self.hold_started_ms) >= HOLD_THRESHOLD_MS
+        {
+            let next = if self.left {
+                BrowseDirection::Left
+            } else {
+                BrowseDirection::Right
+            };
+            self.start(next, now_ms, HELD_STEP_MS);
+        }
+        let elapsed = self
+            .direction
+            .map_or(0, |_| now_ms.saturating_sub(self.started_ms));
+        let held = self.direction.is_some()
+            && (self.left || self.right)
+            && now_ms.saturating_sub(self.hold_started_ms) >= HOLD_THRESHOLD_MS;
+        self.snapshot(held, elapsed)
+    }
+
+    #[must_use]
+    pub const fn selected(&self) -> usize {
+        self.selected
+    }
+
+    fn start(&mut self, direction: BrowseDirection, now_ms: u64, duration_ms: u64) {
+        if self.count <= 1 {
+            return;
+        }
+        self.direction = Some(direction);
+        self.started_ms = now_ms;
+        self.duration_ms = duration_ms;
+        self.target = match direction {
+            BrowseDirection::Left => (self.selected + self.count - 1) % self.count,
+            BrowseDirection::Right => (self.selected + 1) % self.count,
+        };
+    }
+
+    fn snapshot(&self, held: bool, elapsed: u64) -> BrowseFrame {
+        BrowseFrame {
+            selected: self.selected,
+            target: self.target,
+            phase: if self.direction.is_none() {
+                BrowsePhase::Settled
+            } else if held {
+                BrowsePhase::Held
+            } else {
+                BrowsePhase::Sliding
+            },
+            direction: self.direction,
+            progress_millis: elapsed.min(self.duration_ms) as u32,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ready(count: usize) -> LauncherBrowser {
+        let mut browser = LauncherBrowser::new(count, 0);
+        browser.neutral();
+        browser
+    }
+
+    #[test]
+    fn tap_moves_only_after_a_complete_slide() {
+        let mut browser = ready(5);
+        browser.press(BrowseDirection::Right, 10);
+        assert_eq!(browser.frame(100).selected, 0);
+        browser.release(BrowseDirection::Right);
+        assert_eq!(browser.frame(190).target, 1);
+        assert_eq!(browser.frame(190).phase, BrowsePhase::Settled);
+        assert_eq!(browser.selected(), 1);
+    }
+
+    #[test]
+    fn hold_repeats_at_boundaries_and_wraps() {
+        let mut browser = ready(5);
+        browser.press(BrowseDirection::Right, 0);
+        let frame = browser.frame(700);
+        assert_eq!(frame.selected, 1);
+        assert_eq!(frame.target, 2);
+        assert_eq!(frame.phase, BrowsePhase::Held);
+        assert_eq!(browser.frame(1000).selected, 2);
+    }
+
+    #[test]
+    fn hold_waits_for_threshold_after_first_tap() {
+        let mut browser = ready(5);
+        browser.press(BrowseDirection::Right, 0);
+        assert_eq!(browser.frame(180).phase, BrowsePhase::Settled);
+        assert_eq!(browser.frame(299).phase, BrowsePhase::Settled);
+        assert_eq!(browser.frame(300).target, 2);
+        assert_eq!(browser.frame(300).phase, BrowsePhase::Held);
+    }
+
+    #[test]
+    fn reversal_is_bounded_and_both_directions_cancel() {
+        let mut browser = ready(5);
+        browser.press(BrowseDirection::Right, 0);
+        browser.press(BrowseDirection::Left, 20);
+        browser.release(BrowseDirection::Right);
+        assert_eq!(browser.frame(180).selected, 1);
+        assert_eq!(browser.frame(180).target, 0);
+        assert_eq!(browser.frame(181).target, 0);
+        browser.release(BrowseDirection::Left);
+        browser.press(BrowseDirection::Right, 200);
+        assert_eq!(browser.frame(400).phase, BrowsePhase::Sliding);
+        assert_eq!(browser.frame(400).target, 1);
+    }
+
+    #[test]
+    fn rising_edge_retap_queues_one_same_direction_move() {
+        let mut browser = ready(5);
+        browser.press(BrowseDirection::Right, 0);
+        browser.release(BrowseDirection::Right);
+        browser.press(BrowseDirection::Right, 20);
+        browser.release(BrowseDirection::Right);
+        assert_eq!(browser.frame(180).selected, 1);
+        assert_eq!(browser.frame(180).target, 2);
+    }
+
+    #[test]
+    fn reset_requires_a_neutral_sample() {
+        let mut browser = ready(5);
+        browser.press(BrowseDirection::Right, 0);
+        browser.reset();
+        browser.press(BrowseDirection::Right, 1);
+        assert_eq!(browser.frame(100).phase, BrowsePhase::Settled);
+        browser.neutral();
+        browser.press(BrowseDirection::Right, 200);
+        assert_eq!(browser.frame(201).target, 1);
+    }
+
+    #[test]
+    fn one_card_never_animates() {
+        let mut browser = ready(1);
+        browser.press(BrowseDirection::Right, 0);
+        assert_eq!(browser.frame(10).phase, BrowsePhase::Settled);
+        assert_eq!(browser.selected(), 0);
+    }
+}

--- a/crates/framebuffer-scenes/src/launcher_navigation.rs
+++ b/crates/framebuffer-scenes/src/launcher_navigation.rs
@@ -1,3 +1,6 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
 //! Deterministic joystick browsing state for the Mini launcher.
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/framebuffer-scenes/src/launcher_navigation.rs
+++ b/crates/framebuffer-scenes/src/launcher_navigation.rs
@@ -12,6 +12,7 @@ pub enum BrowseDirection {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum BrowsePhase {
     Settled,
+    Flipping,
     Sliding,
     Held,
 }
@@ -27,6 +28,7 @@ pub struct BrowseFrame {
 }
 
 pub const TAP_SLIDE_MS: u64 = 180;
+pub const TAP_FLIP_MS: u64 = 460;
 pub const HOLD_THRESHOLD_MS: u64 = 300;
 pub const HELD_STEP_MS: u64 = 150;
 
@@ -43,6 +45,8 @@ pub struct LauncherBrowser {
     right: bool,
     pending: Option<BrowseDirection>,
     neutral_required: bool,
+    flip_taps: bool,
+    step_flips: bool,
 }
 
 impl LauncherBrowser {
@@ -61,7 +65,15 @@ impl LauncherBrowser {
             right: false,
             pending: None,
             neutral_required: true,
+            flip_taps: false,
+            step_flips: false,
         }
+    }
+
+    /// Configure only at a clean reset; never changes an in-flight step.
+    pub fn with_flips(mut self, enabled: bool) -> Self {
+        self.flip_taps = enabled;
+        self
     }
 
     pub fn press(&mut self, direction: BrowseDirection, now_ms: u64) {
@@ -171,7 +183,12 @@ impl LauncherBrowser {
         }
         self.direction = Some(direction);
         self.started_ms = now_ms;
-        self.duration_ms = duration_ms;
+        self.step_flips = self.flip_taps && duration_ms == TAP_SLIDE_MS;
+        self.duration_ms = if self.step_flips {
+            TAP_FLIP_MS
+        } else {
+            duration_ms
+        };
         self.target = match direction {
             BrowseDirection::Left => (self.selected + self.count - 1) % self.count,
             BrowseDirection::Right => (self.selected + 1) % self.count,
@@ -184,6 +201,8 @@ impl LauncherBrowser {
             target: self.target,
             phase: if self.direction.is_none() {
                 BrowsePhase::Settled
+            } else if self.step_flips {
+                BrowsePhase::Flipping
             } else if held {
                 BrowsePhase::Held
             } else {
@@ -199,6 +218,66 @@ impl LauncherBrowser {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn flip_finishes_before_hold_slides_and_release_never_changes_kind() {
+        let mut browser = ready(5).with_flips(true);
+        browser.press(BrowseDirection::Right, 0);
+        assert_eq!(browser.frame(300).phase, BrowsePhase::Flipping);
+        assert_eq!(browser.frame(459).duration_millis, 460);
+        let slide = browser.frame(460);
+        assert_eq!(
+            (
+                slide.selected,
+                slide.target,
+                slide.phase,
+                slide.duration_millis
+            ),
+            (1, 2, BrowsePhase::Held, 150)
+        );
+        browser.release(BrowseDirection::Right);
+        assert_eq!(browser.frame(500).phase, BrowsePhase::Sliding);
+        assert_eq!(browser.frame(610).phase, BrowsePhase::Settled);
+        browser.press(BrowseDirection::Left, 700);
+        browser.release(BrowseDirection::Left);
+        assert_eq!(browser.frame(1000).phase, BrowsePhase::Flipping);
+        assert_eq!(browser.frame(1160).selected, 1);
+    }
+
+    #[test]
+    fn flip_reversal_retap_and_long_stall_are_bounded() {
+        let mut browser = ready(5).with_flips(true);
+        browser.press(BrowseDirection::Left, 0);
+        browser.release(BrowseDirection::Left);
+        browser.press(BrowseDirection::Right, 30);
+        browser.release(BrowseDirection::Right);
+        let frame = browser.frame(5000);
+        assert_eq!(
+            (
+                frame.selected,
+                frame.target,
+                frame.phase,
+                frame.progress_millis
+            ),
+            (4, 0, BrowsePhase::Flipping, 0)
+        );
+        assert_eq!(browser.frame(5460).selected, 0);
+    }
+
+    #[test]
+    fn twelve_held_steps_never_flip_and_both_held_finish_only_once() {
+        let mut browser = ready(5).with_flips(true);
+        browser.press(BrowseDirection::Right, 0);
+        for step in 0..12 {
+            let frame = browser.frame(TAP_FLIP_MS + step * HELD_STEP_MS);
+            assert_eq!(frame.phase, BrowsePhase::Held);
+            assert_eq!(frame.duration_millis, HELD_STEP_MS as u32);
+        }
+        browser.press(BrowseDirection::Left, 2150);
+        let final_frame = browser.frame(2300);
+        assert_eq!(final_frame.phase, BrowsePhase::Settled);
+        assert_eq!(browser.frame(5000), final_frame);
+    }
 
     fn ready(count: usize) -> LauncherBrowser {
         let mut browser = LauncherBrowser::new(count, 0);

--- a/crates/framebuffer-scenes/src/launcher_navigation.rs
+++ b/crates/framebuffer-scenes/src/launcher_navigation.rs
@@ -20,6 +20,7 @@ pub struct BrowseFrame {
     pub phase: BrowsePhase,
     pub direction: Option<BrowseDirection>,
     pub progress_millis: u32,
+    pub duration_millis: u32,
 }
 
 pub const TAP_SLIDE_MS: u64 = 180;
@@ -94,6 +95,7 @@ impl LauncherBrowser {
 
     pub fn reset(&mut self) {
         self.direction = None;
+        self.target = self.selected;
         self.pending = None;
         self.left = false;
         self.right = false;
@@ -136,7 +138,7 @@ impl LauncherBrowser {
         }
         if self.direction.is_none()
             && self.count > 1
-            && (self.left || self.right)
+            && (self.left ^ self.right)
             && now_ms.saturating_sub(self.hold_started_ms) >= HOLD_THRESHOLD_MS
         {
             let next = if self.left {
@@ -186,6 +188,7 @@ impl LauncherBrowser {
             },
             direction: self.direction,
             progress_millis: elapsed.min(self.duration_ms) as u32,
+            duration_millis: self.duration_ms as u32,
         }
     }
 }
@@ -256,6 +259,18 @@ mod tests {
         browser.release(BrowseDirection::Right);
         assert_eq!(browser.frame(180).selected, 1);
         assert_eq!(browser.frame(180).target, 2);
+    }
+
+    #[test]
+    fn both_directions_held_complete_once_then_stay_idle() {
+        let mut browser = ready(5);
+        browser.press(BrowseDirection::Right, 0);
+        browser.press(BrowseDirection::Left, 20);
+        assert_eq!(browser.frame(180).selected, 1);
+        assert_eq!(browser.frame(1_200).phase, BrowsePhase::Settled);
+        assert_eq!(browser.selected(), 1);
+        assert_eq!(browser.frame(2_000).phase, BrowsePhase::Settled);
+        assert_eq!(browser.selected(), 1);
     }
 
     #[test]

--- a/crates/framebuffer-scenes/src/lib.rs
+++ b/crates/framebuffer-scenes/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 pub mod launcher;
+mod launcher_flip;
 pub mod launcher_navigation;
 pub mod navigation;
 

--- a/crates/framebuffer-scenes/src/lib.rs
+++ b/crates/framebuffer-scenes/src/lib.rs
@@ -10,6 +10,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 pub mod launcher;
+pub mod launcher_navigation;
 pub mod navigation;
 
 #[repr(transparent)]

--- a/crates/framebuffer-scenes/src/lib.rs
+++ b/crates/framebuffer-scenes/src/lib.rs
@@ -9,6 +9,7 @@ use std::mem::{MaybeUninit, align_of, size_of};
 use std::sync::OnceLock;
 use std::time::Duration;
 
+pub mod launcher;
 pub mod navigation;
 
 #[repr(transparent)]

--- a/crates/framebuffer-scenes/tests/launcher_browsing_review.rs
+++ b/crates/framebuffer-scenes/tests/launcher_browsing_review.rs
@@ -1,0 +1,115 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Independent coordinator regression checks for the milestone 2 contract.
+
+use mister_magik_framebuffer_scenes::launcher_navigation::{
+    BrowseDirection::{Left, Right},
+    BrowsePhase, LauncherBrowser,
+};
+
+fn ready() -> LauncherBrowser {
+    let mut browser = LauncherBrowser::new(5, 0);
+    browser.neutral();
+    browser
+}
+
+#[test]
+fn duplicate_pressed_events_do_not_queue_a_second_tap() {
+    let mut browser = ready();
+    browser.press(Right, 0);
+    browser.press(Right, 40);
+    browser.press(Right, 80);
+    browser.release(Right);
+    assert_eq!(browser.frame(180).selected, 1);
+    assert_eq!(browser.frame(1000).phase, BrowsePhase::Settled);
+    assert_eq!(browser.selected(), 1);
+}
+
+#[test]
+fn held_input_waits_until_threshold_and_release_keeps_slide_duration() {
+    let mut browser = ready();
+    browser.press(Right, 0);
+    assert_eq!(browser.frame(180).phase, BrowsePhase::Settled);
+    assert_eq!(browser.frame(299).phase, BrowsePhase::Settled);
+    assert_eq!(browser.frame(300).target, 2);
+    let moving = browser.frame(350);
+    browser.release(Right);
+    let released = browser.frame(350);
+    assert_eq!(released.duration_millis, moving.duration_millis);
+    assert_eq!(released.progress_millis, moving.progress_millis);
+    assert_eq!(browser.frame(450).selected, 2);
+    assert_eq!(browser.frame(1000).phase, BrowsePhase::Settled);
+    assert_eq!(browser.selected(), 2);
+}
+
+#[test]
+fn both_directions_held_never_restart_after_current_step() {
+    let mut browser = ready();
+    browser.press(Right, 0);
+    browser.press(Left, 20);
+    assert_eq!(browser.frame(180).selected, 1);
+    for now in [300, 500, 1000, 5000] {
+        assert_eq!(browser.frame(now).phase, BrowsePhase::Settled);
+        assert_eq!(browser.selected(), 1);
+    }
+}
+
+#[test]
+fn delayed_tick_cannot_skip_unseen_categories() {
+    let mut browser = ready();
+    browser.press(Right, 0);
+    let resumed = browser.frame(30_000);
+    assert_eq!(resumed.selected, 1);
+    assert_eq!(resumed.target, 2);
+    assert_eq!(resumed.progress_millis, 0);
+    assert_eq!(browser.frame(30_000).selected, 1);
+}
+
+#[test]
+fn rapid_new_taps_have_one_latest_pending_intent() {
+    let mut browser = ready();
+    browser.press(Right, 0);
+    browser.release(Right);
+    browser.press(Right, 20);
+    browser.release(Right);
+    browser.press(Left, 40);
+    browser.release(Left);
+    let queued = browser.frame(180);
+    assert_eq!(queued.selected, 1);
+    assert_eq!(queued.target, 0);
+    assert_eq!(browser.frame(360).selected, 0);
+    assert_eq!(browser.frame(1000).phase, BrowsePhase::Settled);
+}
+
+#[test]
+fn reset_removes_target_and_pending_intent_until_neutral() {
+    let mut browser = ready();
+    browser.press(Right, 0);
+    browser.reset();
+    browser.press(Left, 20);
+    let reset = browser.frame(1000);
+    assert_eq!(reset.phase, BrowsePhase::Settled);
+    assert_eq!(reset.target, reset.selected);
+    browser.neutral();
+    browser.press(Left, 1001);
+    browser.release(Left);
+    assert_eq!(browser.frame(1181).selected, 4);
+}
+
+#[test]
+fn cyclic_taps_wrap_both_directions_without_changing_order() {
+    let mut browser = ready();
+    for (step, expected) in [1, 2, 3, 4, 0].into_iter().enumerate() {
+        let now = step as u64 * 200;
+        browser.press(Right, now);
+        browser.release(Right);
+        assert_eq!(browser.frame(now + 180).selected, expected);
+    }
+    for (step, expected) in [4, 3, 2, 1, 0].into_iter().enumerate() {
+        let now = 1000 + step as u64 * 200;
+        browser.press(Left, now);
+        browser.release(Left);
+        assert_eq!(browser.frame(now + 180).selected, expected);
+    }
+}

--- a/crates/framebuffer-scenes/tests/launcher_composition_review.rs
+++ b/crates/framebuffer-scenes/tests/launcher_composition_review.rs
@@ -1,0 +1,157 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Coordinator checks against the accepted static composition, not new snapshots.
+use mister_magik_framebuffer_scenes::Rgb565Pixel;
+use mister_magik_framebuffer_scenes::launcher::{LauncherCard, LauncherData, LauncherScene};
+use mister_magik_framebuffer_scenes::launcher_navigation::{
+    BrowseDirection, BrowseFrame, BrowsePhase,
+};
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+
+thread_local! {
+    static WATCH_ALLOCATIONS: Cell<bool> = const { Cell::new(false) };
+    static ALLOCATIONS: Cell<usize> = const { Cell::new(0) };
+}
+struct ReviewAllocator;
+fn record_allocation() {
+    if WATCH_ALLOCATIONS.try_with(Cell::get).unwrap_or(false) {
+        ALLOCATIONS.with(|count| count.set(count.get() + 1));
+    }
+}
+// SAFETY: ownership and layouts are delegated unchanged to System.
+unsafe impl GlobalAlloc for ReviewAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        record_allocation();
+        // SAFETY: forward the caller's valid layout.
+        unsafe { System.alloc(layout) }
+    }
+    unsafe fn dealloc(&self, pointer: *mut u8, layout: Layout) {
+        // SAFETY: this pointer/layout came from the same System allocator.
+        unsafe { System.dealloc(pointer, layout) }
+    }
+    unsafe fn realloc(&self, pointer: *mut u8, layout: Layout, size: usize) -> *mut u8 {
+        record_allocation();
+        // SAFETY: forward the caller's valid allocation and new size.
+        unsafe { System.realloc(pointer, layout, size) }
+    }
+}
+#[global_allocator]
+static ALLOCATOR: ReviewAllocator = ReviewAllocator;
+
+#[test]
+fn prepared_animation_performs_no_heap_allocations() {
+    let mut prepared = LauncherScene::new(960, 540).prepare(data(0));
+    let mut output = vec![Rgb565Pixel(0); 960 * 540];
+    ALLOCATIONS.with(|count| count.set(0));
+    WATCH_ALLOCATIONS.with(|watch| watch.set(true));
+    for progress in (0..=180).step_by(15) {
+        prepared.render_into(moving(0, BrowseDirection::Right, progress), &mut output);
+    }
+    WATCH_ALLOCATIONS.with(|watch| watch.set(false));
+    assert_eq!(ALLOCATIONS.with(Cell::get), 0);
+}
+
+const CARDS: [LauncherCard<'static>; 5] = [
+    LauncherCard {
+        name: "ARCADE",
+        games: 1752,
+        colour: 0x88a6,
+    },
+    LauncherCard {
+        name: "SNK NEOGEO",
+        games: 324,
+        colour: 0x195f,
+    },
+    LauncherCard {
+        name: "CONSOLES",
+        games: 842,
+        colour: 0xc5b5,
+    },
+    LauncherCard {
+        name: "HANDHELDS",
+        games: 126,
+        colour: 0x2c92,
+    },
+    LauncherCard {
+        name: "COMPUTERS",
+        games: 86,
+        colour: 0xb9a6,
+    },
+];
+fn data(selected: usize) -> LauncherData<'static> {
+    LauncherData {
+        cards: &CARDS,
+        selected,
+        library_games: 6842,
+        collections: 18,
+        favourites: 126,
+        clock: "21:37",
+    }
+}
+fn moving(selected: usize, direction: BrowseDirection, progress: u32) -> BrowseFrame {
+    BrowseFrame {
+        selected,
+        target: (selected
+            + if direction == BrowseDirection::Right {
+                1
+            } else {
+                4
+            })
+            % 5,
+        phase: BrowsePhase::Sliding,
+        direction: Some(direction),
+        progress_millis: progress,
+        duration_millis: 180,
+    }
+}
+
+#[test]
+fn all_moving_frames_preserve_every_sidebar_pixel() {
+    let scene = LauncherScene::new(960, 540);
+    let baseline = scene.render(data(0));
+    let mut prepared = scene.prepare(data(0));
+    let mut output = vec![Rgb565Pixel(0); 960 * 540];
+    for direction in [BrowseDirection::Left, BrowseDirection::Right] {
+        for progress in [0, 30, 90, 150, 180] {
+            prepared.render_into(moving(0, direction, progress), &mut output);
+            for row in 0..540 {
+                assert_eq!(
+                    &output[row * 960..row * 960 + 296],
+                    &baseline[row * 960..row * 960 + 296],
+                    "sidebar row {row}, {direction:?}, {progress}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn each_start_and_end_matches_the_accepted_card_geometry() {
+    let scene = LauncherScene::new(960, 540);
+    let mut prepared = scene.prepare(data(0));
+    let mut output = vec![Rgb565Pixel(0); 960 * 540];
+    for selected in 0..5 {
+        for direction in [BrowseDirection::Left, BrowseDirection::Right] {
+            for progress in [0, 180] {
+                let frame = moving(selected, direction, progress);
+                let expected = scene.render(data(if progress == 0 {
+                    selected
+                } else {
+                    frame.target
+                }));
+                prepared.render_into(frame, &mut output);
+                // Indicator is intentionally allowed to switch only on settlement.
+                for row in 135..465 {
+                    assert_eq!(
+                        &output[row * 960 + 296..row * 960 + 934],
+                        &expected[row * 960 + 296..row * 960 + 934],
+                        "card row {row}, selection {selected}, {direction:?}, {progress}"
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/framebuffer-scenes/tests/launcher_composition_review.rs
+++ b/crates/framebuffer-scenes/tests/launcher_composition_review.rs
@@ -50,8 +50,57 @@ fn prepared_animation_performs_no_heap_allocations() {
     for progress in (0..=180).step_by(15) {
         prepared.render_into(moving(0, BrowseDirection::Right, progress), &mut output);
     }
+    for progress in (0..=460).step_by(10) {
+        let mut frame = moving(0, BrowseDirection::Right, progress);
+        frame.phase = BrowsePhase::Flipping;
+        frame.duration_millis = 460;
+        prepared.render_into(frame, &mut output);
+    }
     WATCH_ALLOCATIONS.with(|watch| watch.set(false));
     assert_eq!(ALLOCATIONS.with(Cell::get), 0);
+}
+
+#[test]
+fn perspective_endpoints_clipping_and_reverse_mapping() {
+    let scene = LauncherScene::new(960, 540);
+    let baseline = scene.render(data(0));
+    let mut prepared = scene.prepare(data(0));
+    let mut output = vec![Rgb565Pixel(0); 960 * 540];
+    let mut other = output.clone();
+    for direction in [BrowseDirection::Left, BrowseDirection::Right] {
+        for progress in [0, 1, 150, 229, 230, 231, 310, 459, 460] {
+            let mut frame = moving(0, direction, progress);
+            frame.phase = BrowsePhase::Flipping;
+            frame.duration_millis = 460;
+            prepared.set_reverse_flip(true);
+            prepared.render_into(frame, &mut output);
+            for row in 0..540 {
+                assert_eq!(
+                    &output[row * 960..row * 960 + 296],
+                    &baseline[row * 960..row * 960 + 296]
+                );
+                assert_eq!(
+                    &output[row * 960 + 934..(row + 1) * 960],
+                    &baseline[row * 960 + 934..(row + 1) * 960]
+                );
+            }
+            if progress == 0 || progress == 460 {
+                let expected = scene.render(data(if progress == 0 { 0 } else { frame.target }));
+                assert_eq!(
+                    &output[135 * 960..465 * 960],
+                    &expected[135 * 960..465 * 960]
+                );
+            }
+            if progress == 150 {
+                prepared.set_reverse_flip(false);
+                prepared.render_into(frame, &mut other);
+                assert_ne!(
+                    output, other,
+                    "mapping must change perspective, not navigation"
+                );
+            }
+        }
+    }
 }
 
 const CARDS: [LauncherCard<'static>; 5] = [

--- a/docs/host-orchestration.md
+++ b/docs/host-orchestration.md
@@ -8,6 +8,9 @@ The thin `scripts/magik-platform` entrypoint delegates native work to the same
 
 Host-only operations use existing Python tooling:
 
+- `scripts/magik2 update` downloads and queues the latest verified platform and
+  databases. The next `scripts/magik2 deploy --attended` installs outstanding Dev
+  updates before starting real MagiK; subsequent deploys skip verified releases.
 - `scripts/magik-ci dependencies sync PATH/Cargo.toml` resolves only the owning
   manifest and adjacent lockfile. `--package NAME` requests a targeted update.
 - `scripts/magik-ci clean --manifest PATH/Cargo.toml --package NAME` cleans that

--- a/magik2/agent/src/lib.rs
+++ b/magik2/agent/src/lib.rs
@@ -6,6 +6,7 @@ mod catalog_operations;
 mod device;
 mod device_identity;
 mod main_control;
+mod managed_launcher;
 mod media;
 mod mode;
 mod publication;
@@ -181,6 +182,8 @@ impl Agent {
             "transfer-check",
             "applications",
             "main-input-proxy",
+            "main-managed-magik",
+            "main-managed-mini-v1",
             "measurement",
             "diagnostics",
             "upload-v1",
@@ -652,6 +655,14 @@ impl Agent {
                 serde_json::json!({"already_running":true,"ready":true,"sha256":published_hash}),
             );
         }
+        if matches!(artifact, "magik" | "mini-magik") {
+            return self.start_managed_application(
+                request,
+                test_server.as_deref(),
+                published_hash.as_deref().unwrap_or_default(),
+                artifact,
+            );
+        }
         if let Err(error) = fs::create_dir_all(&self.state_root) {
             return response(
                 &request.id,
@@ -968,6 +979,20 @@ impl Agent {
     }
 
     fn ready_for(&self, pid: u32, hash: &str) -> bool {
+        if fs::read_link(format!("/proc/{pid}/exe"))
+            .ok()
+            .is_some_and(|path| {
+                ["magik", "mini-magik"].iter().any(|name| {
+                    path.to_string_lossy().trim_end_matches(" (deleted)")
+                        == self.install_root.join(name).to_string_lossy()
+                })
+            })
+            && !device::status()
+                .ok()
+                .is_some_and(|status| managed_launcher::owns_ready_child(&status, pid))
+        {
+            return false;
+        }
         fs::read(self.readiness_path())
             .ok()
             .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok())
@@ -1066,6 +1091,16 @@ impl Agent {
     }
 
     fn stop_owned_process(&self) -> Result<(), String> {
+        if let Some(record) = self.running_identity()
+            && device::status().ok().is_some_and(|status| {
+                status["launcher_pid"].as_u64() == Some(u64::from(record.pid))
+            })
+        {
+            main_handoff("mister_magik_suspend\n")?;
+            managed_launcher::update(Path::new(managed_launcher::ENV_PATH), None)?;
+            self.clear_owned_process();
+            return Ok(());
+        }
         let mut process = self.process.lock().expect("agent process state poisoned");
         if let Some(child) = process.as_mut() {
             if child.try_wait().map_err(|e| e.to_string())?.is_none() {

--- a/magik2/agent/src/lib.rs
+++ b/magik2/agent/src/lib.rs
@@ -179,6 +179,7 @@ impl Agent {
             "catalog-operations-v1",
             "publication-v1",
             "platform-publication-v1",
+            "publication-state-v1",
             "transfer-check",
             "applications",
             "main-input-proxy",
@@ -315,12 +316,14 @@ impl Agent {
         }
         if matches!(
             request.op.as_str(),
-            "publication-commit" | "publication-control"
+            "publication-commit" | "publication-control" | "publication-state"
         ) {
             if body_length != 0 {
                 return Err(FrameError::BodyTooLarge);
             }
-            return if request.op == "publication-control" {
+            return if request.op == "publication-state" {
+                self.publication_state(stream, &request)
+            } else if request.op == "publication-control" {
                 self.publication_control(stream, &request)
             } else {
                 self.publish(stream, &request)

--- a/magik2/agent/src/managed_launcher.rs
+++ b/magik2/agent/src/managed_launcher.rs
@@ -1,0 +1,281 @@
+//! MagiK and Mini use Main's existing launcher environment and lifecycle.
+use serde_json::Value;
+use std::fs;
+use std::io::Read;
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::Path;
+
+pub const ENV_PATH: &str = "/media/fat/mister-magik-dev/launcher.env";
+const BEGIN: &str = "# BEGIN magik2 managed launcher\n";
+const END: &str = "# END magik2 managed launcher\n";
+const LIMIT: usize = 64 * 1024;
+
+pub fn require_dev(status: &Value) -> Result<(), String> {
+    if status["executable_path"] != "/media/fat/MiSTer_MagiKDev" {
+        return Err(
+            "real MagiK deployment requires the running Dev Main; production is unchanged".into(),
+        );
+    }
+    Ok(())
+}
+
+pub fn owns_ready_child(status: &Value, pid: u32) -> bool {
+    status["launcher_state"] == "LauncherActive"
+        && status["launcher_active"] == true
+        && status["launcher_pid"].as_u64() == Some(u64::from(pid))
+        && status["launcher_ready_phase"] == "ready"
+        && status["fpga_owner"] == "magik"
+        && matches!(status["input_proxy_protocol"].as_u64(), Some(2 | 3))
+}
+
+fn without_block(text: &str) -> Result<String, String> {
+    match (text.find(BEGIN), text.find(END)) {
+        (None, None) => Ok(text.to_owned()),
+        (Some(start), Some(end))
+            if end >= start
+                && text.matches(BEGIN).count() == 1
+                && text.matches(END).count() == 1 =>
+        {
+            Ok(format!("{}{}", &text[..start], &text[end + END.len()..]))
+        }
+        _ => Err("malformed magik2 launcher environment block".into()),
+    }
+}
+
+fn quote(value: &str) -> Result<String, String> {
+    if value.chars().any(char::is_control) {
+        return Err("control character in launcher setting".into());
+    }
+    Ok(format!("'{}'", value.replace('\'', "'\\''")))
+}
+
+/// Change only our marked block. The existing file is never executed by this service.
+pub fn update(path: &Path, values: Option<&[(&str, String)]>) -> Result<(), String> {
+    let text = match fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+    {
+        Ok(file) => {
+            if !file.metadata().map_err(|e| e.to_string())?.is_file() {
+                return Err("launcher environment is not a regular file".into());
+            }
+            let mut text = String::new();
+            file.take((LIMIT + 1) as u64)
+                .read_to_string(&mut text)
+                .map_err(|e| e.to_string())?;
+            if text.len() > LIMIT {
+                return Err("launcher environment exceeds limit".into());
+            }
+            text
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => String::new(),
+        Err(error) => return Err(error.to_string()),
+    };
+    let mut next = without_block(&text)?;
+    if let Some(values) = values {
+        if !next.is_empty() && !next.ends_with('\n') {
+            next.push('\n');
+        }
+        next.push_str(BEGIN);
+        for (key, value) in values {
+            if !matches!(
+                *key,
+                "MISTER_MAGIK_PATH"
+                    | "MISTER_MAGIK2_STATE_ROOT"
+                    | "MISTER_MAGIK2_ARTIFACT_SHA256"
+                    | "MISTER_MAGIK2_PROFILE_DIR"
+                    | "SLINT_TEST_SERVER"
+            ) {
+                return Err("unsupported launcher environment key".into());
+            }
+            next.push_str(&format!("export {key}={}\n", quote(value)?));
+        }
+        next.push_str(END);
+    }
+    if next.len() > LIMIT {
+        return Err("launcher environment exceeds limit".into());
+    }
+    if next == text {
+        return Ok(());
+    }
+    let temporary = path.with_extension(format!("magik2-{}.next", std::process::id()));
+    let result = (|| {
+        use std::io::Write;
+        let mut file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&temporary)
+            .map_err(|e| e.to_string())?;
+        file.write_all(next.as_bytes()).map_err(|e| e.to_string())?;
+        file.sync_all().map_err(|e| e.to_string())?;
+        fs::rename(&temporary, path).map_err(|e| e.to_string())
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temporary);
+    }
+    result
+}
+
+impl crate::Agent {
+    pub(super) fn start_managed_application(
+        &self,
+        request: &crate::Envelope,
+        test_server: Option<&str>,
+        hash: &str,
+        artifact: &str,
+    ) -> crate::Envelope {
+        let result = (|| -> Result<(), String> {
+            require_dev(&crate::device::status()?)?;
+            let env_path = Path::new(ENV_PATH);
+            if env_path
+                .parent()
+                .unwrap()
+                .canonicalize()
+                .map_err(|e| e.to_string())?
+                != env_path.parent().unwrap()
+            {
+                return Err(
+                    "Dev launcher directory must not redirect to another installation".into(),
+                );
+            }
+            fs::create_dir_all(&self.state_root).map_err(|e| e.to_string())?;
+            self.stop_owned_process()?;
+            crate::main_handoff("mister_magik_suspend\n")?;
+            self.observation.clear_frame();
+            for file in ["probe-ready.json", "measure-request"] {
+                match fs::remove_file(self.state_root.join(file)) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error.to_string()),
+                }
+            }
+            let mut values = vec![
+                (
+                    "MISTER_MAGIK_PATH",
+                    self.install_root
+                        .join(artifact)
+                        .to_string_lossy()
+                        .into_owned(),
+                ),
+                (
+                    "MISTER_MAGIK2_STATE_ROOT",
+                    self.state_root.to_string_lossy().into_owned(),
+                ),
+                ("MISTER_MAGIK2_ARTIFACT_SHA256", hash.to_owned()),
+            ];
+            if let Some(endpoint) = test_server {
+                values.push(("SLINT_TEST_SERVER", endpoint.to_owned()));
+            }
+            if let Some(profile) = request
+                .fields
+                .get("profile_id")
+                .and_then(Value::as_str)
+                .filter(|id| crate::is_plain_name(id))
+            {
+                values.push((
+                    "MISTER_MAGIK2_PROFILE_DIR",
+                    self.state_root
+                        .join("profiles")
+                        .join(profile)
+                        .to_string_lossy()
+                        .into_owned(),
+                ));
+            }
+            update(env_path, Some(&values))?;
+            crate::main_control::request("mister_magik_resume\n")?;
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+            loop {
+                let status = crate::device::status()?;
+                if let Some(pid) = status["launcher_pid"]
+                    .as_u64()
+                    .and_then(|n| u32::try_from(n).ok())
+                    && owns_ready_child(&status, pid)
+                    && self.ready_for(pid, hash)
+                {
+                    if crate::installed_hash(Path::new(&format!("/proc/{pid}/exe"))).as_deref()
+                        != Some(hash)
+                    {
+                        return Err("Main launched a different artifact".into());
+                    }
+                    self.write_owned_process(pid, hash)?;
+                    return Ok(());
+                }
+                if std::time::Instant::now() >= deadline {
+                    return Err(format!("Main launcher readiness timed out: {status}"));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(25));
+            }
+        })();
+        match result {
+            Ok(()) => crate::response(
+                &request.id,
+                "started",
+                serde_json::json!({"already_running":false,"ready":true,"main_managed":true}),
+            ),
+            Err(error) => crate::response(
+                &request.id,
+                "error",
+                serde_json::json!({"code":"main-managed-start-failed","detail":error,"main_status":crate::device::status().ok()}),
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn readiness_requires_main_ownership_and_physical_input_routing() {
+        let good = serde_json::json!({"launcher_state":"LauncherActive", "launcher_active":true,
+            "launcher_pid":42,"launcher_ready_phase":"ready","fpga_owner":"magik","input_proxy_protocol":2});
+        assert!(owns_ready_child(&good, 42));
+        assert!(!owns_ready_child(&good, 43));
+        for (key, value) in [
+            ("launcher_state", serde_json::json!("LauncherSuspended")),
+            ("launcher_active", serde_json::json!(false)),
+            ("fpga_owner", serde_json::json!("main")),
+            ("launcher_ready_phase", serde_json::json!("waiting")),
+            ("input_proxy_protocol", serde_json::json!(0)),
+        ] {
+            let mut bad = good.clone();
+            bad[key] = value;
+            assert!(!owns_ready_child(&bad, 42));
+        }
+        assert!(
+            require_dev(&serde_json::json!({"executable_path":"/media/fat/MiSTer_MagiK"})).is_err()
+        );
+    }
+    #[test]
+    fn environment_preserves_operator_settings_and_removes_session_overrides() {
+        let root = std::env::temp_dir().join(format!("magik2-managed-env-{}", std::process::id()));
+        fs::create_dir_all(&root).unwrap();
+        let path = root.join("launcher.env");
+        let original = "export EXISTING='keep me'\n";
+        fs::write(&path, original).unwrap();
+        update(
+            &path,
+            Some(&[
+                ("MISTER_MAGIK_PATH", "/path/with ' quote".into()),
+                ("SLINT_TEST_SERVER", "127.0.0.1:1234".into()),
+            ]),
+        )
+        .unwrap();
+        let content = fs::read_to_string(&path).unwrap();
+        assert!(content.starts_with(original));
+        assert!(content.contains("'\\''"));
+        update(&path, Some(&[("MISTER_MAGIK_PATH", "/another".into())])).unwrap();
+        assert!(
+            !fs::read_to_string(&path)
+                .unwrap()
+                .contains("SLINT_TEST_SERVER")
+        );
+        update(&path, None).unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), original);
+        fs::remove_file(&path).unwrap();
+        std::os::unix::fs::symlink(root.join("missing"), &path).unwrap();
+        assert!(update(&path, None).is_err());
+        fs::remove_dir_all(root).unwrap();
+    }
+}

--- a/magik2/agent/src/publication.rs
+++ b/magik2/agent/src/publication.rs
@@ -24,6 +24,81 @@ const DATABASES: &[&str] = &[
     "game-databases-manifest.json",
 ];
 
+fn installed_state(fat: &Path, install_root: &Path) -> Result<Value, String> {
+    let paths = Layout::Development.paths();
+    let local = |path: &str| fat.join(path.strip_prefix("/media/fat/").expect("layout path"));
+    let mut platform = json!({"version":0,"verified":false});
+    let manifest_path = local(paths.manifest);
+    if manifest_path.exists() {
+        let text = fs::read_to_string(manifest_path).map_err(|e| e.to_string())?;
+        let manifest = parse(&text, Layout::Development, ValidationProfile::AgentStrict)
+            .map_err(|e| e.to_string())?;
+        let mut hashes = serde_json::Map::new();
+        let mut verified = true;
+        for (name, path) in paths.components() {
+            let hash = crate::media::hash(&local(path)).ok();
+            if !matches!(name, "gui" | "manager") {
+                verified &= hash.as_deref()
+                    == Some(
+                        manifest
+                            .required(&format!("{name}_sha256"))
+                            .map_err(|e| e.to_string())?,
+                    );
+            }
+            hashes.insert(name.to_owned(), json!(hash));
+        }
+        platform = json!({"version":manifest.required("platform_release_number").map_err(|e| e.to_string())?.parse::<u64>().map_err(|e| e.to_string())?,
+            "bundle_id":manifest.required("platform_bundle_id").map_err(|e| e.to_string())?,"verified":verified,"hashes":hashes});
+    }
+    let assets = local(paths.root).join("assets");
+    let mut databases = json!({"version":0,"verified":false});
+    let manifest_path = assets.join("game-databases-manifest.json");
+    if manifest_path.exists() {
+        let manifest: Value =
+            serde_json::from_slice(&fs::read(manifest_path).map_err(|e| e.to_string())?)
+                .map_err(|e| e.to_string())?;
+        let checks =
+            fs::read_to_string(assets.join("game-databases-SHA256SUMS")).unwrap_or_default();
+        let mut hashes = serde_json::Map::new();
+        let mut verified = manifest["format"] == "mister-magik-game-databases-manifest-v4";
+        for name in &DATABASES[..2] {
+            let hash = crate::media::hash(&assets.join(name)).ok();
+            let expected = checks
+                .lines()
+                .filter_map(|line| line.split_once("  "))
+                .find_map(|(hash, path)| (path == *name).then_some(hash));
+            verified &= expected.is_some() && hash.as_deref() == expected;
+            hashes.insert((*name).to_owned(), json!(hash));
+        }
+        hashes.insert(
+            "manifest".into(),
+            json!(crate::media::hash(
+                &assets.join("game-databases-manifest.json")
+            )?),
+        );
+        databases =
+            json!({"version":manifest["release_version"],"verified":verified,"hashes":hashes});
+    }
+    let mut stages = Vec::new();
+    let publication = install_root.join("publication");
+    if publication.exists() {
+        for entry in fs::read_dir(publication).map_err(|e| e.to_string())? {
+            let entry = entry.map_err(|e| e.to_string())?;
+            let pending = entry.path().join("pending.json");
+            if pending.exists() || entry.path().join("backup").exists() {
+                let detail = if pending.exists() {
+                    serde_json::from_slice::<Value>(&fs::read(pending).map_err(|e| e.to_string())?)
+                        .map_err(|e| e.to_string())?
+                } else {
+                    Value::Null
+                };
+                stages.push(json!({"stage":entry.file_name().to_string_lossy(),"pending":detail}));
+            }
+        }
+    }
+    Ok(json!({"platform":platform,"databases":databases,"stages":stages}))
+}
+
 fn stage(root: &Path, fields: &serde_json::Map<String, Value>) -> Result<PathBuf, String> {
     let id = fields
         .get("stage")
@@ -270,6 +345,49 @@ fn reload_healthy(previous: &Value, expected: &str) -> Result<(), String> {
 }
 
 impl crate::Agent {
+    pub(super) fn publication_state(
+        &self,
+        stream: &mut TcpStream,
+        request: &Envelope,
+    ) -> Result<(), FrameError> {
+        let _mutation = self.mutations.lock().expect("mutation state poisoned");
+        let result = (|| -> Result<Value, String> {
+            if request.fields.len() != 1 || request.fields["layout"] != "dev" {
+                return Err("publication-state requires layout=dev".into());
+            }
+            let mut state = installed_state(Path::new("/media/fat"), &self.install_root)?;
+            state["running"] = crate::device::status()?;
+            let paths = Layout::Development.paths();
+            let running_hash = state["running"]["pid"]
+                .as_u64()
+                .and_then(|pid| crate::media::hash(Path::new(&format!("/proc/{pid}/exe"))).ok());
+            state["platform"]["active"] = json!(
+                state["running"]["executable_path"] == paths.main
+                    && state["running"]["launcher_ready_phase"] == "ready"
+                    && state["running"]["scanout_slots_module_loaded"] == true
+                    && running_hash.is_some()
+                    && running_hash == crate::media::hash(Path::new(paths.main)).ok()
+                    && state["stages"]
+                        .as_array()
+                        .is_some_and(|stages| stages.is_empty())
+            );
+            state["configured_main"] = crate::mode::status()?["configured_main"].clone();
+            state["boot_id"] = json!(
+                fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e| e.to_string())?
+            );
+            Ok(state)
+        })();
+        let reply = match result {
+            Ok(fields) => response(&request.id, "publication-state", fields),
+            Err(error) => response(
+                &request.id,
+                "error",
+                json!({"code":"publication-state-failed","detail":error}),
+            ),
+        };
+        write_frame(stream, &reply, &[])
+    }
+
     pub(super) fn publication_control(
         &self,
         stream: &mut TcpStream,
@@ -289,6 +407,20 @@ impl crate::Agent {
             .map_err(|e| e.to_string())?;
             match request.fields.get("action").and_then(Value::as_str) {
                 Some("finish") => {
+                    if pending["kind"] == "databases" {
+                        let fields = json!({"stage":request.fields["stage"],"kind":"databases","layout":pending["layout"]});
+                        for (source, destination) in
+                            files(&self.install_root, fields.as_object().unwrap())?
+                        {
+                            if crate::media::hash(&source)? != crate::media::hash(&destination)? {
+                                return Err(
+                                    "database publication is incomplete; restore explicitly".into(),
+                                );
+                            }
+                        }
+                        fs::remove_dir_all(root).map_err(|e| e.to_string())?;
+                        return Ok(json!({"activated":true}));
+                    }
                     if pending["boot_id"]
                         == fs::read_to_string("/proc/sys/kernel/random/boot_id")
                             .map_err(|e| e.to_string())?
@@ -299,6 +431,18 @@ impl crate::Agent {
                     crate::mode::verify_platform(layout)?;
                     let state = crate::device::status()?;
                     let layout = Layout::parse(layout).map_err(|e| e.to_string())?;
+                    let expected = pending["manifest_sha256"].as_str().ok_or(
+                        "pending publication has no expected manifest; restore explicitly",
+                    )?;
+                    if crate::media::hash(Path::new(layout.paths().manifest))? != expected {
+                        return Err("activated manifest differs from staged publication".into());
+                    }
+                    let pid = state["pid"].as_u64().ok_or("Main PID missing")?;
+                    if crate::media::hash(Path::new(&format!("/proc/{pid}/exe")))?
+                        != crate::media::hash(Path::new(layout.paths().main))?
+                    {
+                        return Err("running Main differs from installed Main".into());
+                    }
                     if state["executable_path"] != layout.paths().main
                         || state["launcher_ready_phase"] != "ready"
                         || state["scanout_slots_module_loaded"] != true
@@ -392,8 +536,13 @@ impl crate::Agent {
             };
             let root = stage(&self.install_root, fields)?;
             let requires_reboot = fields["kind"] == "platform";
-            if requires_reboot {
-                let pending = json!({"layout":fields["layout"],"boot_id":fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e|e.to_string())?});
+            if requires_reboot || fields["kind"] == "databases" {
+                let expected_manifest = if requires_reboot {
+                    "manifest"
+                } else {
+                    "game-databases-manifest.json"
+                };
+                let pending = json!({"kind":fields["kind"],"layout":fields["layout"],"manifest_sha256":crate::media::hash(&root.join(expected_manifest))?,"boot_id":fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e|e.to_string())?});
                 fs::write(
                     root.join("pending.json"),
                     serde_json::to_vec(&pending).unwrap(),
@@ -457,6 +606,43 @@ impl crate::Agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn installed_state_hashes_databases_and_retains_interrupted_stage() {
+        let root =
+            std::env::temp_dir().join(format!("magik2-publication-state-{}", std::process::id()));
+        let fat = root.join("fat");
+        let assets = fat.join("mister-magik-dev/assets");
+        let install = root.join("agent");
+        fs::create_dir_all(&assets).unwrap();
+        let mut checks = String::new();
+        for name in &DATABASES[..2] {
+            fs::write(assets.join(name), b"content").unwrap();
+            checks.push_str(&format!(
+                "{}  {name}\n",
+                crate::media::hash(&assets.join(name)).unwrap()
+            ));
+        }
+        fs::write(assets.join("game-databases-SHA256SUMS"), checks).unwrap();
+        fs::write(
+            assets.join("game-databases-manifest.json"),
+            br#"{"format":"mister-magik-game-databases-manifest-v4","release_version":4}"#,
+        )
+        .unwrap();
+        let stage = install.join("publication").join("a".repeat(32));
+        fs::create_dir_all(stage.join("backup")).unwrap();
+        let state = installed_state(&fat, &install).unwrap();
+        assert_eq!(state["databases"]["verified"], true);
+        assert_eq!(state["databases"]["version"], 4);
+        assert_eq!(state["stages"].as_array().unwrap().len(), 1);
+        assert!(stage.join("backup").exists());
+        fs::write(assets.join(DATABASES[0]), b"corrupt").unwrap();
+        assert_eq!(
+            installed_state(&fat, &install).unwrap()["databases"]["verified"],
+            false
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn failed_activation_restores_original_artifact_set() {
         let root = std::env::temp_dir().join(format!("magik2-publish-{}", std::process::id()));

--- a/magik2/docs/milestone-1-launcher.md
+++ b/magik2/docs/milestone-1-launcher.md
@@ -1,0 +1,38 @@
+# Mini-MagiK static launcher baseline
+
+The first launcher milestone presents a static RGB565 scene through Mini-MagiK.
+It uses the 960x540 concept coordinate system, a fixed library summary rail,
+five text-only category cards, and short darkened reflections. The fixture
+values are visual test data: 6,842 games, 18 collections, and 126 favourites.
+The cards use Arcade (1,752 games), SNK NEOGEO (324), Consoles (842),
+Handhelds (126), and Computers (86).
+
+Mini renders the scene into a packed `width * height` buffer and copies rows into
+the presenter's stride-backed slot. A launcher frame is considered ready only
+after `post()` and `settle_pending()` confirm a latched presentation. Session
+preview servicing continues on idle iterations, while identical launcher frames
+are not posted again after accessibility callbacks request redraws.
+
+The consumer smoke scenario enters the retained Slint probe explicitly, checks
+its existing counter/details behavior, enters launcher mode, waits for the
+presented readiness state, checks Arcade selection, and writes a PNG derived
+from the native `fpga-latched-scanout-slots` capture. A Slint screenshot is not
+used as launcher visual evidence.
+
+Focused checks:
+
+```text
+scripts/cargo test --manifest-path crates/framebuffer-scenes/Cargo.toml --locked
+scripts/cargo check --manifest-path magik2/probe/Cargo.toml --locked
+uv run --project magik2/host pytest magik2/scenarios --collect-only
+```
+
+Device validation is deliberately deferred to the typed Mini-MagiK workflow:
+
+```text
+scripts/magik2 deploy --app mini-magik
+scripts/magik2 check --app mini-magik
+```
+
+Joystick browsing, flips, hold behavior, real catalog data, and game launching
+remain later milestones.

--- a/magik2/docs/milestone-1-launcher.md
+++ b/magik2/docs/milestone-1-launcher.md
@@ -27,12 +27,22 @@ scripts/cargo check --manifest-path magik2/probe/Cargo.toml --locked
 uv run --project magik2/host pytest magik2/scenarios --collect-only
 ```
 
-Device validation is deliberately deferred to the typed Mini-MagiK workflow:
+Device validation completed on 2026-09-07 using the typed Mini-MagiK workflow:
 
 ```text
 scripts/magik2 deploy --app mini-magik
 scripts/magik2 check --app mini-magik
 ```
+
+Deployment reused the committed Mini artifact and started it at
+`/media/fat/mister-magik2/mini-magik`. The smoke check passed on the remembered
+MiSTer with a native `fpga-latched-scanout-slots` capture at 960x540 RGB565;
+the retained PNG is `build/magik2-results/20260907T192514Z-0efe147b88c6/smoke.png`.
+The check waited for custom-scene readiness after post/settle, then sampled
+native metrics across at least 600ms. It observed unchanged presentation and
+physical post counters, the same process identity and artifact hash, and no
+evidence error. The PNG is derived from that native capture, never from a Slint
+window screenshot.
 
 Joystick browsing, flips, hold behavior, real catalog data, and game launching
 remain later milestones.

--- a/magik2/docs/milestone-1-launcher.md
+++ b/magik2/docs/milestone-1-launcher.md
@@ -47,3 +47,27 @@ Slint window screenshot.
 
 Joystick browsing, flips, hold behavior, real catalog data, and game launching
 remain later milestones.
+
+## Scaler destination correction
+
+The initial capture validated only the 960x540 source pixels. Mini used a
+source-sized destination rectangle, so the UI occupied one quarter of the
+1920x1080 display. Source captures cannot establish final HDMI screen coverage.
+
+Mini now queries Main's active `DisplayV1` state through the existing serialized
+command transport and opens `HiddenLatchPresenter::open_for_plan`. The shared
+display plan supplies both the source dimensions and the full destination scan
+rectangle, including the existing pixel-repetition and CRT route rules. It does
+not upscale the CPU-rendered buffer or change the installed video mode. Raw
+`UIO_GET_VRES` timing is not used as a substitute: this device reports core
+timing of 529x240 while Main's active mode is HDMI 1920x1080. Unresolved Main
+modes fail explicitly rather than silently choosing a source-sized rectangle.
+
+Device smoke on 2026-09-07 recorded `source=960x540`, `scan=1920x1080`, and
+`destination=1920x1080` in
+`build/magik2-results/20260907T194040Z-92b554ca28d3/events.jsonl`.
+The smoke now asserts source/capture agreement and destination/scan agreement.
+Three display-contract tests, the existing source-stride/scaled-destination
+regression, three consumer geometry tests, and Mini device smoke passed.
+These checks verify the programmed geometry and acknowledged presentation;
+the native capture remains pre-scaler evidence, not an HDMI capture.

--- a/magik2/docs/milestone-1-launcher.md
+++ b/magik2/docs/milestone-1-launcher.md
@@ -37,12 +37,13 @@ scripts/magik2 check --app mini-magik
 Deployment reused the committed Mini artifact and started it at
 `/media/fat/mister-magik2/mini-magik`. The smoke check passed on the remembered
 MiSTer with a native `fpga-latched-scanout-slots` capture at 960x540 RGB565;
-the retained PNG is `build/magik2-results/20260907T192514Z-0efe147b88c6/smoke.png`.
+the retained PNG is `build/magik2-results/20260907T192939Z-40de9bc8a191/smoke.png`.
 The check waited for custom-scene readiness after post/settle, then sampled
-native metrics across at least 600ms. It observed unchanged presentation and
-physical post counters, the same process identity and artifact hash, and no
-evidence error. The PNG is derived from that native capture, never from a Slint
-window screenshot.
+native metrics across 807ms. It observed unchanged presentation and physical
+post counters (2 and 2), the same process identity (PID 4371) and artifact hash
+(`0751282d03aa8a17d568f6277f6535814659570dd42cb770cae32ecc2e12b4d7`), and no
+evidence error. The PNG is derived from that native capture, never from a
+Slint window screenshot.
 
 Joystick browsing, flips, hold behavior, real catalog data, and game launching
 remain later milestones.

--- a/magik2/docs/milestone-2-launcher-plan.md
+++ b/magik2/docs/milestone-2-launcher-plan.md
@@ -1,0 +1,174 @@
+# Mini launcher milestone 2: joystick browsing with identity-preserving slides
+
+## Delivery and boundaries
+
+Historical plan: the initial portable implementation used Luna. The user later
+prohibited subagents; all further fixes, review and milestone 3 are performed
+directly by the coordinating agent. No push is authorized.
+
+Deliver a joystick-controlled, cyclic five-card carousel in Mini. Every move is
+a slide: the side card becomes the centre card, with its label travelling with it.
+No perspective, flips, artwork, catalog integration, game launching, settings UI,
+or broad performance optimisation. Milestone 3 adds paired same-direction flips
+on fresh presses, preferred reverse mapping, then slides while held.
+
+Read applicable AGENTS and use the Rust LSP skill. Scope: shared scene renderer,
+Mini consumer, consumer scenarios/docs, and a narrow runtime input adapter only
+if needed to consume the existing Main-mapped input protocol. Do not import the
+whole real app or alter tooling-core/native protocol/platform/Main. Report a
+concrete blocker if those interfaces cannot support delivery.
+
+## Preserve the latest baseline
+
+- [ ] Inspect status and preserve all existing work. At planning time HEAD was
+  `3db811152` and `launcher.rs` still contained our uncommitted visual cleanup.
+  Verify its diff, then commit those existing changes separately as
+  `style(mini-magik): simplify chrome and soften reflections` before new work.
+  If already committed, do not duplicate the commit.
+- [ ] Background is pure RGB565 black, including letterboxing.
+- [ ] Do not restore Settings, Play / Collect / Remember, One Library / Every
+  Generation, Across All Collections, or MiSTer / Offline text.
+- [ ] Reflections are now 32 logical pixels, beginning at about 22% brightness,
+  with a quadratic per-row fade and stationary 4x4 ordered dithering. Preserve
+  dimness, black endpoint and no temporal noise; do not restore four fade bands.
+- [ ] Preserve sidebar fixture totals, clock `21:37`, category order and colours,
+  selected cream double outline, header/footer and remaining copy.
+- [ ] Preserve Main-authoritative display planning: 960x540 source at current
+  1080p mode, `open_for_plan` destination 1920x1080. No CPU upscale to 1080p,
+  source-sized destination, raw FPGA timing inference, or display mode change.
+- [ ] Inspect the latest native baseline capture before editing:
+  `build/magik2-results/20260907T194744Z-cc0eaa4fb3cd/smoke.png`.
+
+## Commit 1: `feat(framebuffer-scenes): add launcher slide state and composition`
+
+### Navigation contract
+
+- [ ] Add a portable deterministic navigation state machine driven by explicit
+  timestamps and logical left/right press/release state; no Slint/device types.
+- [ ] Right selects the next category and moves the strip left; Left does the
+  opposite. Wrap Arcade, SNK NeoGeo, Consoles, Handhelds, Computers cyclically.
+- [ ] Fresh press starts immediately. Initial defaults: 180ms tap slide, 300ms
+  hold threshold from press, 150ms per subsequent held step. Named constants,
+  not scattered magic numbers; record any device-driven tuning.
+- [ ] Release finishes only the in-flight step; no extra release animation or
+  repeat backlog. Hold repeats start only at step boundaries after threshold.
+- [ ] Direction reversal finishes the in-flight step, then honours the latest
+  opposite intent. At most one pending discrete press; repeated OS key-repeat
+  events must not enqueue moves. Multiple new taps replace that bounded intent.
+- [ ] Both directions held cancel further movement; finish the current step.
+  Disconnect, mode exit and input reset clear held/pending intent. Require neutral
+  after startup/reconnect/mode entry so inherited held input cannot run away.
+- [ ] Distinguish settled selection from the in-flight target. Advance settled
+  selection once per completed slide; no clock-jump catch-up across unseen cards.
+- [ ] Tests: taps, short release, multi-second hold, five-card wrap both ways,
+  reversal, simultaneous directions, bounded rapid taps, reconnect/reset, empty
+  and single-card data, irregular/large time advances and settled idle.
+
+### Rendering contract
+
+- [ ] Prepare/cache static chrome and reusable card content. Render moving frames
+  into reusable buffers; no per-frame texture rebuild, text formatting or heap
+  allocation. Keep fixtures in Mini, not in the portable renderer.
+- [ ] Replace hard-coded slot switching with interpolated card rectangles and
+  continuous content transforms. Retain the current rest layout where possible.
+  Incoming title moves/scales from its side placement to centre placement;
+  outgoing title does the reverse. Never swap labels at the halfway point.
+- [ ] Fade game count/ordinal/outline as needed, but category identity remains
+  visible throughout. Do not substitute a whole face abruptly during a slide.
+- [ ] Use integer-snapped raster positions and nearest-neighbour sampling. Avoid
+  bounce/overshoot. Smooth tap easing; held steps must not add a dwell at every
+  centre. Endpoint geometry must exactly match the next resting composition.
+- [ ] Include offscreen neighbours for seamless wrap, clipping strictly to the
+  carousel. No edge teleport visible inside the clip; deterministic overlap and
+  draw order, especially while two cards trade centre prominence.
+- [ ] Reflect the current transformed card bottoms, with matching movement,
+  clipping and depth order. Read card pixels only, never reflection pixels.
+  Keep dithering deterministic in screen coordinates and black outside the fade.
+- [ ] Sidebar, header and footer stay fixed; only selection indicator changes
+  with settled selection. Clear/restore the whole dirty carousel area so old
+  cards/reflections cannot leave trails. Full scanout copies remain acceptable;
+  do not claim partial hardware updates just because chrome is cached.
+- [ ] Retain proportional logical fitting tests for 960x540 and 640x480.
+- [ ] Add start/mid/end and wrap rendering tests for continuity, clipping,
+  unchanged chrome, reflections and deterministic output; preserve existing tests.
+
+## Commit 2: `feat(mini-magik): drive launcher slides from mapped input`
+
+- [ ] First resolve the existing mapped physical input contract. Main already
+  supplies a virtual input device and the native service sets
+  `MISTER_MAGIK_INPUT_PROXY` / `MISTER_MAGIK_INPUT_PROXY_PROTOCOL` when available.
+  Inspect `apps/mister/src/input_hub.rs`, portable input event/reducer code, and
+  the service handoff read-only; reuse protocol semantics, not the entire app.
+- [ ] Do not silently call `FramebufferLabInput::open()` and label it mapped:
+  that adapter uses `InputProfile::guess` on raw joystick nodes. Do not hardcode
+  a controller layout or consume both raw and mapped streams (duplicate moves).
+- [ ] If needed, put a small nonblocking Main input adapter in runtime, reuse
+  shared wire/reducer types, and add focused parsing/reset tests. Honour packet
+  boundaries, release/reset/disconnect and supported protocol versions. Missing
+  capability is an explicit diagnostic, never fallback to guessed controls.
+  Stop/report if this requires tooling-core or Main changes.
+- [ ] Poll input and service tooling while moving AND idle. Schedule rendering
+  only for changed animation state; no continuous identical posts when settled.
+- [ ] Feed physical input and invisible test actions through the same navigation
+  state machine. Expose left-down/up, right-down/up and reset actions for testing;
+  no visible buttons, touch dependencies or synthetic navigation shortcuts.
+- [ ] Preserve show-probe/show-launcher and existing demo tests. Leaving launcher
+  cancels its animation/input state; entering it clears stale held state. Probe
+  callbacks must not mutate the launcher or leave its demo timer running.
+- [ ] Expose test-readable selected category/index, target, idle/sliding/held
+  state, input readiness/source, and fixture status. Settled-ready must reflect
+  a successfully latched final frame, not just a CPU state update.
+- [ ] Keep HiddenLatchPresenter, safe RGB565 boundary conversions, stride-aware
+  copies, Main display geometry and preview of the same composed pixels.
+- [ ] Use existing latch/metrics semantics. Pace against actual presentation;
+  separate rejected posts from physical drops/repeats. On failed final post keep
+  the scene dirty/recoverable and report error rather than falsely declaring idle.
+- [ ] Keep rendering and preview preparation separate; no preview reconstruction
+  added to the hot path. No premature NEON/threading/presenter redesign.
+- [ ] Run focused Mini and renderer checks through scripts/cargo and bounded
+  LSP diagnostics. Dependency edits only via dependency-sync workflow, staging
+  owning manifest and adjacent lockfile only.
+
+## Commit 3: `test(mini-magik): validate joystick carousel on device`
+
+- [ ] Add bounded consumer smoke coverage for initial Arcade, right/left taps,
+  cyclic wrap and return to idle; use accessibility for state only. Keep smoke
+  short. Capture the native latched frame after a settled noninitial selection.
+- [ ] Add a separate explicitly invoked launcher motion journey: several seconds
+  held each way, release, reversal and repeated taps using the test input actions.
+  Preserve the existing probe workload as separately named evidence; never claim
+  its timings as launcher performance. Do not modify tooling-core to add selectors.
+- [ ] Test idle after browsing: same artifact/PID, fresh elapsed interval, no
+  additional posts/presentations, no error, correct source/destination geometry.
+- [ ] Run focused affected Python and Rust checks only, not workspace matrices.
+- [ ] Deploy `scripts/magik2 deploy --app mini-magik`, then
+  `scripts/magik2 check --app mini-magik`. Run the bounded launcher motion
+  scenario through existing typed 2.0 selection after inspecting its CLI support.
+  Use first-attempt escalation for all device/container operations.
+- [ ] Verify real joystick left/right input separately from automation. If no
+  supported typed physical-input route is available, ask the user for a brief
+  controller test; do not equate accessibility injection with physical proof.
+- [ ] Record launcher-specific frame/latch evidence for a bounded hold window;
+  zero dropped frames required for authoritative smooth-animation acceptance.
+  No captures/tree polling inside the timing window. If evidence is insufficient
+  or nonzero, report it and fix only narrow milestone issues; do not relabel failure
+  as success or begin a broad optimisation project.
+- [ ] Inspect actual native captures for text continuity where capture supports
+  it, selected placement, reflection fade/trails, clipping and wrap. Static
+  captures alone are not proof of smooth motion. Retain evidence untracked.
+- [ ] Document commands/results, actual framebuffer geometry, input authority,
+  timings, physical-test status, limitations and deferred milestone 3. Update
+  this checklist to distinguish completed items from any blocked acceptance.
+
+## Handoff and review
+
+- [ ] Stage exact paths and escalate staging/committing on the first attempt.
+  Commit in the order above; no push and no unrelated changes/history rewriting.
+- [ ] Send the coordinator commit IDs, changed paths, focused check results,
+  device result directories, native capture path, measured drops/rejections and
+  any remaining manual acceptance. Do not claim completion without evidence.
+- [ ] Coordinator independently reviews state transitions, mapped input handling,
+  renderer hot path, wrap/draw order, final-latch readiness and smoke assertions;
+  returns concrete fixes to Luna and checks the corrected result.
+- [ ] Final response embeds the device capture and explicitly reports physical
+  joystick/motion acceptance or its remaining blocker. Stop before flips.

--- a/magik2/docs/milestone-2-launcher.md
+++ b/magik2/docs/milestone-2-launcher.md
@@ -1,0 +1,95 @@
+# Mini launcher milestone 2: browsing delivery
+
+## Scope and preserved baseline
+
+This is still Mini, with fixture catalog data, not the real launcher integration.
+Categories remain Arcade, SNK NeoGeo, Consoles, Handhelds and Computers, initially
+Arcade. Library totals 6842 / 18 / 126 and clock 21:37 are fixed fixtures; only
+Arcade's requested 1752 count has user-supplied provenance. Other counts remain
+test fixtures. No controller button launches a game in this milestone.
+
+The baseline cleanup was committed as `3e0834aad`: pure-black background, removed
+Settings/tagline/sidebar slogans/offline copy, and short 32-pixel reflections with
+approximately 22% initial brightness, quadratic fading and fixed ordered dither.
+Do not restore the former four-band reflection or removed copy.
+
+The source/destination fix remains intact: Main display state resolves the plan;
+the existing HiddenLatchPresenter programs the FPGA destination. At the accepted
+1080p mode the UI source is 960x540 and the destination is 1920x1080. Native PNGs
+capture the source, not the HDMI output after scaling.
+
+## Interaction contract
+
+- Right selects the next category while cards move left; Left reverses that.
+- An immediate tap starts a 180ms slide. A hold starts subsequent 150ms slides
+  after 300ms from the genuine press. Release completes the current slide only.
+- One latest discrete pending tap is retained; repeat events cannot build queues.
+  Opposite input finishes the current slide then follows the latest intent.
+  Both directions held prevent new movement. Large time gaps cannot skip through
+  multiple unseen cards.
+- Mode changes and input loss clear held/pending intent. The mapped reader takes
+  a kernel held-key snapshot on open and waits for neutral after inherited holds.
+- Every transition in this milestone is a slide, including fresh presses.
+  Same-direction paired perspective flips and their preferred reverse mapping
+  remain milestone 3; catalog/game launching remains milestone 4.
+
+## Implementation and review
+
+Luna at medium reasoning implemented the portable browser and renderer. The
+coordinator returned issues found in timing, endpoints, clipping and caching, and
+corrected the consumer/runtime input and final-presentation integration directly.
+Independent integration tests compare all category endpoints against the accepted
+static renderer, require an unchanged sidebar during movement, and count heap
+allocations inside the prepared renderer.
+
+Main's existing v2/v3 virtual EV_KEY stream is the only physical input authority.
+There is no guessed raw-joystick fallback or Main change. The later approved
+tooling correction reuses real MagiK's existing supervised launch path for Mini;
+see `mini-main-supervision.md` for source provenance and evidence.
+The runtime adapter drains bounded reusable batches, preserves partial input
+records, ignores repeats/invalid values, and discards a batch on SYN_DROPPED or
+transport loss. Mini reconnects without exiting or spinning a recovery loop.
+
+Slint is only the retained test shell. Invisible down/up/reset actions feed the
+same portable browser as physical input; source-specific held state is merged so
+a test release cannot release a physical hold. Probe demo callbacks are mode
+gated. Settled readiness and selection are published only after a successful
+physical latch, with pending settlement retried before writing another slot.
+
+## Focused validation
+
+Commands (run from repository root):
+
+```sh
+scripts/cargo test --manifest-path magik2/probe/Cargo.toml --locked -p mister-magik-framebuffer-scenes
+scripts/cargo test --manifest-path magik2/probe/Cargo.toml --locked -p mister-magik-mister-runtime --lib main_input::tests
+scripts/cargo test --manifest-path magik2/probe/Cargo.toml --locked -p mini-magik --bin mini-magik
+scripts/cargo clippy --manifest-path magik2/probe/Cargo.toml --locked -p mini-magik --bin mini-magik -- -D warnings
+magik2/host/.venv/bin/python -m pytest magik2/scenarios/test_mini_display.py magik2/scenarios/test_mini_motion.py --magik2-app mini-magik -q
+scripts/magik2 deploy --app mini-magik
+scripts/magik2 check --app mini-magik
+scripts/magik2 check motion --app mini-magik
+```
+
+The last command intentionally retains the two separately named probe samples
+and adds two launcher samples, one per direction. Launcher measurements use a
+2s warmup and 5s device-clock window. No accessibility polling or capture occurs
+inside that window. Launcher events use `phase=launcher-motion` so the retained
+probe summary cannot pool these workloads. Physical repeats are reported
+separately from dropped/rejected posts, with FPGA ownership/invariant checks.
+
+## Device acceptance record
+
+Deployment and smoke passed: `20260907T205835Z-0226faca5b1f` and
+`20260907T210355Z-f21739e0bc86`. Main is active and supervises Mini with the same
+960x540 source / 1920x1080 destination. The user confirmed all physical joystick
+movement works correctly on 2026-09-08.
+
+Motion qualification remains open: `20260907T210844Z-d170188add21` fails the
+retained probe workload's presentation accounting gate, before launcher samples.
+This is not evidence that the launcher's animation has passed cadence validation.
+Milestone 3 is explicitly approved as the next visual implementation, not a
+retroactive performance qualification of milestone 2.
+
+Screenshots, timing logs and runtime artifacts remain untracked. No push is part
+of this delivery.

--- a/magik2/docs/mini-main-supervision.md
+++ b/magik2/docs/mini-main-supervision.md
@@ -1,0 +1,41 @@
+# Mini mapped-input correction
+
+Main remains unchanged. No raw joystick fallback and no input lease.
+
+## Implementation checklist
+
+- [x] Reuse the real app's existing Main-managed lifecycle from `f511dad29`.
+- [x] Parameterize the owned artifact; preserve the marked Dev launcher environment block.
+- [x] Require `main-managed-mini-v1`, so an older compatible service cannot silently use suspended launch.
+- [x] Require Main's active child PID, input capability and FPGA ownership for readiness.
+- [x] Inherit Main's display contracts instead of querying its busy startup command lane.
+- [x] Complete ready-v3 using two actually confirmed alternating nonblank RGB565 frames.
+- [x] Record physical input edges independently of synthetic test actions.
+- [x] Deploy and confirm Main reports LauncherActive with Mini as its child.
+- [x] Pass consumer smoke and capture; user confirms all joystick movement works correctly.
+
+The installed service advertised `main-managed-magik`, but this consumer checkout
+predated that implementation. The old Mini path suspended Main and directly
+spawned Mini; an open proxy descriptor was therefore not proof of active routing.
+The existing real-app fix is reused here instead of changing Main's input policy.
+
+Startup presentations are outside motion measurement windows. Runtime controller
+events still use Main's mappings and the existing neutral/release handling.
+No flips, catalog integration, Main binary changes or platform delivery belong here.
+
+## Verification
+
+- Native lifecycle tests: 2 passed; process/artifact readiness and superseded-upload tests: 2 passed.
+- Runtime ready-v3 receipt test: 1 passed. Mini control tests: 2 passed.
+- Agent and Mini Clippy passed; Rust LSP reported no diagnostics for the new runtime helper and Mini.
+- Deployment capability Python tests: 4 passed. Consumer display/motion validation unit tests: 9 passed.
+- Deploy: `build/magik2-results/20260907T205835Z-0226faca5b1f`.
+- Main remained PID 581, generation 9359; reports LauncherActive, ready, FPGA owner magik.
+- Smoke/native capture: `build/magik2-results/20260907T210355Z-f21739e0bc86`, 1 passed in 27.60s.
+- First smoke exposed a test-only lifecycle-lane contention from calling device-status
+  inside the active session; replaced with the read-only native readiness gate.
+- Physical observation: `build/magik2-results/20260907T210436Z-f358924aa7d5`;
+  initial Mini PID 7095, zero physical edges, Arcade, no runtime error. User subsequently confirmed all movement correct.
+
+Captures/logs remain untracked. The Main input desync counter was 1 at the first
+post-deployment status and unchanged at the next observation; this is not a zero-desync qualification.

--- a/magik2/docs/native-operations.md
+++ b/magik2/docs/native-operations.md
@@ -32,6 +32,35 @@ Raw reports and failures are retained in the command's result directory.
 
 ## Independent platform entrypoint
 
+### Queue published releases for the next deploy
+
+Run `scripts/magik2 update` to download and verify the latest numbered platform
+and game-database releases from `NigelBreslaw/MiSTer-MagiK`. Published prereleases
+are included; drafts are excluded. The command does not contact the device.
+Both releases must verify before the shared desired pair changes. Downloads live
+under `$MISTER_MAGIK2_STATE/updates` (the normal shared state directory when unset).
+The output includes the database release directory usable with `catalog publish`.
+
+Run `scripts/magik2 deploy --attended` to install that pair on the selected MiSTer
+before starting real MagiK. A platform change requires running and selected Dev
+mode and one bounded reboot. Plain `deploy` stops before publication when attendance
+is needed. Database-only updates require no reboot or attendance. Installed hashes
+and versions determine what is outstanding; newer installed releases are never
+downgraded. Normal GUI edits do not reinstall the platform. Mini, `check`, and
+`watch` do not consume the queue.
+
+The desired pair remains available for other devices; each device has separate
+completion evidence. Platform and database publication journals are retained in
+separate subdirectories of the deploy result. If the platform succeeds and the
+database step fails, the next deploy retries only outstanding work. An interrupted
+platform transaction is finished automatically only when its saved host journal
+matches and a new boot is confirmed. Otherwise deployment stops with the stage ID
+for explicit inspection/restoration; it never repeats an ambiguous reboot.
+
+`update` errors preserve the previous desired pair. Corrupt cached releases fail
+verification rather than silently falling back. A deployment uses the desired
+pair captured when it starts, even if another update completes concurrently.
+
 The companion host-utilities branch supplies `scripts/magik-platform`:
 
 - `platform --root DIR --layout dev|public --attended --activate-fpga`

--- a/magik2/host/magik2/apps.py
+++ b/magik2/host/magik2/apps.py
@@ -15,14 +15,14 @@ class Application:
 
 
 APPLICATIONS = {
-    "mini-magik": Application("mini-magik", "magik2/probe", "mini-magik"),
+    "mini-magik": Application("mini-magik", "magik2/probe", "mini-magik", agent_capabilities=frozenset({"main-managed-mini-v1"})),
     "magik": Application(
         "magik",
         "apps/mister",
         "mister-magik-fb",
         "release-device-ui-tests",
         ("magik2",),
-        frozenset({"main-input-proxy"}),
+        frozenset({"main-managed-magik"}),
     ),
 }
 

--- a/magik2/host/magik2/build.py
+++ b/magik2/host/magik2/build.py
@@ -152,6 +152,10 @@ def write_build_cache(cache_file: Path, fingerprint: str, artifact: Path) -> Non
         temporary.unlink(missing_ok=True)
 
 
+def build_repository(package: Path) -> Path:
+    return package.resolve().parents[2 if package.name == "manager" else 1]
+
+
 def ensure_arm_package(
     package: Path,
     cache_file: Path,
@@ -165,7 +169,7 @@ def ensure_arm_package(
     from .storage import Storage
 
     storage = Storage(runner=runner)
-    with storage.build_session(package.resolve().parents[1]):
+    with storage.build_session(build_repository(package)):
         return _ensure_arm_package(
             package,
             cache_file,
@@ -192,9 +196,15 @@ def _ensure_arm_package(
         None,
     )
     profile = app.profile if app else "release"
-    binary = app.binary if app else "mister-magik2-agent"
+    binary = (
+        app.binary
+        if app
+        else "mister-magik-manager"
+        if package.name == "manager"
+        else "mister-magik2-agent"
+    )
     artifact = package / "target" / TARGET / profile / binary
-    repository = package.resolve().parents[1]
+    repository = build_repository(package)
     if (
         app
         and app.name == "magik"
@@ -222,7 +232,7 @@ def _ensure_arm_package(
             int((time.monotonic() - started) * 1000),
             fingerprint=fingerprint,
         )
-    repository = package.resolve().parents[1]
+    repository = build_repository(package)
     name = prepare(repository, runner)
     environment = []
     if app and app.name == "magik":

--- a/magik2/host/magik2/cli.py
+++ b/magik2/host/magik2/cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import ExitStack
 import hashlib
 import os
+import subprocess
 import time
 import webbrowser
 from pathlib import Path
@@ -59,7 +61,10 @@ def main() -> int:
     subcommands.add_parser(
         "mcp", help="serve framebuffer screenshots to Codex over stdio"
     )
-    subcommands.add_parser("deploy")
+    subcommands.add_parser("deploy").add_argument("--attended", action="store_true")
+    subcommands.add_parser(
+        "update", help="download and queue latest platform and databases"
+    )
     device_command = subcommands.add_parser("device")
     device_subcommands = device_command.add_subparsers(
         dest="device_command", required=True
@@ -120,6 +125,14 @@ def main() -> int:
     clean.add_argument("--apply", action="store_true")
     clean.add_argument("--all-idle", action="store_true")
     arguments = parser.parse_args()
+    if arguments.command == "update":
+        from .updates import update
+
+        try:
+            return update()
+        except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as error:
+            print(f"magik2 update: {error}", file=os.sys.stderr)
+            return 2
     if arguments.command == "storage":
         from .storage import run_storage
 
@@ -264,12 +277,34 @@ def dispatch(arguments, run) -> int:
 
 def deploy(_arguments: argparse.Namespace, run: Path) -> int:
     started = time.monotonic()
+    deployment_locks = ExitStack()
     try:
+        from .updates import desired
+
+        queued = desired() if _arguments.app == "magik" else None
         agent, status = connect_agent(
             run,
             REQUIRED_AGENT_CAPABILITIES
-            | application(_arguments.app).agent_capabilities,
+            | application(_arguments.app).agent_capabilities
+            | (
+                {"publication-state-v1", "publication-v1", "platform-publication-v1"}
+                if queued
+                else set()
+            ),
         )
+        if queued:
+            from .update_deploy import apply_updates, device_lock
+
+            deployment_locks.enter_context(device_lock(status.identity))
+            apply_updates(
+                agent,
+                status.identity,
+                queued,
+                run,
+                getattr(_arguments, "attended", False),
+                already_locked=True,
+            )
+            status = agent.status()
         append_event(
             run,
             {
@@ -301,6 +336,7 @@ def deploy(_arguments: argparse.Namespace, run: Path) -> int:
         print(f"magik2 deploy: {error} (result: {run})", file=os.sys.stderr)
         return 2
     finally:
+        deployment_locks.close()
         if "agent" in locals():
             retain_diagnostics(run, agent)
     print(f"magik2 deploy: application started (result: {run})")

--- a/magik2/host/magik2/publication.py
+++ b/magik2/host/magik2/publication.py
@@ -20,7 +20,9 @@ def publish(agent, run: Path, files: dict[str, Path], **fields):
     evidence = run / "publication.json"
 
     def save():
-        evidence.write_text(json.dumps(journal, indent=2) + "\n")
+        from .updates import atomic_json
+
+        atomic_json(evidence, journal)
 
     save()
     try:

--- a/magik2/host/magik2/testing.py
+++ b/magik2/host/magik2/testing.py
@@ -62,7 +62,14 @@ def one_element(application: Any, label: str) -> Any:
         raise AssertionError("probe exposed no Slint window")
     type_name = (
         "Text"
-        if label in {"build-label", "counter", "details-panel", "motion-state"}
+        if label in {
+            "build-label",
+            "counter",
+            "details-panel",
+            "motion-state",
+            "launcher-ready",
+            "launcher-selection",
+        }
         else "Rectangle"
     )
     matches = [

--- a/magik2/host/magik2/testing.py
+++ b/magik2/host/magik2/testing.py
@@ -62,14 +62,7 @@ def one_element(application: Any, label: str) -> Any:
         raise AssertionError("probe exposed no Slint window")
     type_name = (
         "Text"
-        if label in {
-            "build-label",
-            "counter",
-            "details-panel",
-            "motion-state",
-            "launcher-ready",
-            "launcher-selection",
-        }
+        if label in {"build-label", "counter", "details-panel", "motion-state"}
         else "Rectangle"
     )
     matches = [

--- a/magik2/host/magik2/update_deploy.py
+++ b/magik2/host/magik2/update_deploy.py
@@ -1,0 +1,282 @@
+"""Apply a pinned support-release pair before ordinary application deployment."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import zipfile
+
+from .apps import repository
+from .build import ensure_arm_application, ensure_arm_package
+from .client import AgentError
+from .publication import publish
+from .updates import atomic_json, contracts, lock, names, root, verify
+
+PLATFORM_MEMBERS = {
+    "main": "main/MiSTer_MagiK",
+    "scanout_module": "scanout/mister_magik_scanout_slots.ko",
+    "scanout_metadata": "scanout/provenance.txt",
+    "latch_rbf": "fpga/patched/menu-magik-vblank-latch.rbf",
+    "latch_metadata": "fpga/patched/menu-magik-vblank-latch.metadata.txt",
+}
+
+
+def state(agent):
+    reply, _ = agent._request(
+        "publication-state", {"layout": "dev"}, attempts=2, timeout=60
+    )
+    if reply.operation != "publication-state":
+        raise AgentError.from_fields(reply.fields)
+    return dict(reply.fields)
+
+
+def extract(archive, destination):
+    with zipfile.ZipFile(archive) as stream:
+        for member in stream.infolist():
+            path = destination / member.filename
+            if not path.resolve().is_relative_to(destination.resolve()):
+                raise ValueError("unsafe release archive path")
+        stream.extractall(destination)
+
+
+def unique(directory, pattern):
+    paths = list(directory.rglob(pattern))
+    if len(paths) != 1:
+        raise ValueError(f"expected one {pattern} in {directory}")
+    return paths[0]
+
+
+def prepare(pair, directory):
+    contracts()
+    from scripts.magik_ci import manifest
+
+    platform = pair["platform"]
+    payload = verify("platform", platform)
+    extracted = directory / "platform"
+    extract(
+        Path(platform["directory"]) / names("platform", platform["version"])[0],
+        extracted,
+    )
+    package = repository() / "apps/mister"
+    gui = ensure_arm_application(package, package / "target/magik2-build.json").artifact
+    package = repository() / "mister/tools/manager"
+    manager = ensure_arm_package(package, package / "target/magik2-build.json").artifact
+    files = {
+        "main": unique(extracted / "main", "MiSTer_MagiK"),
+        "gui": gui,
+        "manager": manager,
+        "scanout_module": unique(extracted / "scanout", "*.ko"),
+        "scanout_metadata": unique(extracted / "scanout", "provenance.txt"),
+        "latch_rbf": extracted / "fpga/patched/menu-magik-vblank-latch.rbf",
+        "latch_metadata": extracted
+        / "fpga/patched/menu-magik-vblank-latch.metadata.txt",
+    }
+    subprocess.run(
+        [
+            str(repository() / "scripts/cargo"),
+            "build",
+            "--locked",
+            "--manifest-path",
+            str(repository() / "mister/platform/contracts/manifest/Cargo.toml"),
+            "--bin",
+            "platform-manifest-check",
+        ],
+        check=True,
+    )
+    manifest_path = directory / "platform-v3.manifest"
+    receipt = json.loads(
+        unique(extracted / "main", "main-component-v0.1.json").read_text()
+    )
+    revision = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repository(), text=True
+    ).strip()
+    primary = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=repository(),
+            text=True,
+        ).strip()
+    ).parent
+    previous = os.environ.get("MISTER_MAGIK_MANIFEST_CHECK")
+    os.environ["MISTER_MAGIK_MANIFEST_CHECK"] = str(
+        primary
+        / "mister/platform/contracts/manifest/target/debug/platform-manifest-check"
+    )
+    try:
+        manifest.generate(
+            manifest_path,
+            files,
+            release_number=platform["version"],
+            bundle_id=payload["bundle_id"],
+            main_revision=receipt["source_revision"],
+            magik_revision=revision,
+            layout="dev",
+        )
+    finally:
+        if previous is None:
+            os.environ.pop("MISTER_MAGIK_MANIFEST_CHECK", None)
+        else:
+            os.environ["MISTER_MAGIK_MANIFEST_CHECK"] = previous
+    files["manifest"] = manifest_path
+    return files
+
+
+def database_files(pair, directory):
+    _, databases = contracts()
+    databases.extract_release(Path(pair["databases"]["directory"]), directory)
+    files = {
+        name: directory / name
+        for name in (
+            "magik-metadata-v1.bin",
+            "arcade-updater-index-v1.lz4b",
+            "game-databases-manifest.json",
+        )
+    }
+    files["game-databases-SHA256SUMS"] = directory / "SHA256SUMS"
+    return files
+
+
+def needed(installed, release, kind, payload):
+    version = int(installed.get("version") or 0)
+    if version > release["version"]:
+        if not installed.get("verified"):
+            raise AgentError(f"newer installed {kind} is invalid; refusing downgrade")
+        return False
+    matches = version == release["version"] and installed.get("verified")
+    if kind == "platform":
+        matches = matches and installed.get("bundle_id") == payload["bundle_id"]
+        expected = {entry["path"]: entry["sha256"] for entry in payload["files"]}
+        matches = matches and all(
+            installed.get("hashes", {}).get(name) == expected[path]
+            for name, path in PLATFORM_MEMBERS.items()
+        )
+    else:
+        manifest = Path(release["directory"]) / names(kind, release["version"])[1]
+        matches = (
+            matches
+            and installed.get("hashes", {}).get("manifest")
+            == hashlib.sha256(manifest.read_bytes()).hexdigest()
+        )
+    return not matches
+
+
+def device_lock(identity):
+    key = hashlib.sha256(identity.encode()).hexdigest()
+    return lock(root() / "devices" / f"{key}.lock")
+
+
+def apply_updates(agent, identity, pair, run, attended, *, already_locked=False):
+    device_key = hashlib.sha256(identity.encode()).hexdigest()
+    with nullcontext() if already_locked else device_lock(identity):
+        pending_path = root() / "devices" / f"{device_key}-pending.json"
+        previous = json.loads(pending_path.read_text()) if pending_path.exists() else {}
+        payloads = {
+            kind: verify(kind, pair[kind]) for kind in ("platform", "databases")
+        }
+        current = state(agent)
+        # A confirmed reboot may have completed while the previous host lost its reply.
+        for stage in current["stages"]:
+            pending = stage["pending"]
+            kind = (
+                "databases"
+                if pending and pending.get("kind") == "databases"
+                else "platform"
+            )
+            journal_path = Path(previous.get("run", "")) / kind / "publication.json"
+            journal = (
+                json.loads(journal_path.read_text())
+                if previous and journal_path.is_file()
+                else {}
+            )
+            if (
+                (attended or kind == "databases")
+                and journal.get("stage") == stage["stage"]
+                and pending
+                and pending.get("layout") == "dev"
+                and (
+                    kind == "databases" or pending.get("boot_id") != current["boot_id"]
+                )
+            ):
+                reply, _ = agent._request(
+                    "publication-control",
+                    {"stage": stage["stage"], "action": "finish", "attended": True},
+                    attempts=1,
+                    timeout=60,
+                )
+                if reply.operation != "publication-complete":
+                    raise AgentError.from_fields(reply.fields)
+            else:
+                raise AgentError(
+                    f"unfinished publication {stage['stage']}; inspect/restore the saved stage before retrying; no reboot repeated"
+                )
+        current = state(agent) if current["stages"] else current
+        platform_needed = needed(
+            current["platform"], pair["platform"], "platform", payloads["platform"]
+        )
+        databases_needed = needed(
+            current["databases"], pair["databases"], "databases", payloads["databases"]
+        )
+        if not platform_needed and current["platform"].get("active") is not True:
+            raise AgentError(
+                "installed platform is not active and healthy; inspect device state before deploying; no reboot attempted"
+            )
+        if platform_needed and not attended:
+            raise AgentError(
+                "queued platform update requires attendance; run: scripts/magik2 deploy --attended"
+            )
+        if platform_needed:
+            if (
+                current["configured_main"] != "MiSTer_MagiKDev"
+                or current["running"].get("executable_path")
+                != "/media/fat/MiSTer_MagiKDev"
+            ):
+                raise AgentError(
+                    "queued platform requires running and selected Dev mode; select the intended mode explicitly"
+                )
+        with tempfile.TemporaryDirectory(prefix="magik-update-") as temporary:
+            directory = Path(temporary)
+            db_files = (
+                database_files(pair, directory / "databases")
+                if databases_needed
+                else None
+            )
+            platform_files = prepare(pair, directory) if platform_needed else None
+            if databases_needed and not platform_needed:
+                package = repository() / "apps/mister"
+                ensure_arm_application(package, package / "target/magik2-build.json")
+            if platform_files or db_files:
+                atomic_json(pending_path, {"desired": pair, "run": str(run.resolve())})
+            for kind, files in (("platform", platform_files), ("databases", db_files)):
+                if files is None:
+                    continue
+                evidence = run / kind
+                evidence.mkdir(exist_ok=True)
+                atomic_json(
+                    evidence / "run.json",
+                    {"operation": kind, "source": {"device_identity": identity}},
+                )
+                fields = {"kind": kind, "layout": "dev"}
+                if kind == "platform":
+                    fields.update(attended=True, activate_fpga=True)
+                print(f"Installing {pair[kind]['tag']}")
+                publish(agent, evidence, files, **fields)
+                current = state(agent)
+                if needed(current[kind], pair[kind], kind, payloads[kind]):
+                    raise AgentError(
+                        f"{kind} installation did not verify; evidence: {evidence}"
+                    )
+        atomic_json(
+            root() / "devices" / f"{device_key}.json",
+            {
+                "identity": identity,
+                "desired": pair,
+                "verified": current,
+                "run": str(run.resolve()),
+            },
+        )
+        pending_path.unlink(missing_ok=True)

--- a/magik2/host/magik2/updates.py
+++ b/magik2/host/magik2/updates.py
@@ -1,0 +1,192 @@
+"""Verified immutable support releases shared by this host's devices."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+from .apps import repository
+from .token_store import state_root
+
+REPOSITORY = "NigelBreslaw/MiSTer-MagiK"
+
+
+@contextmanager
+def lock(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as stream:
+        fcntl.flock(stream, fcntl.LOCK_EX)
+        yield
+
+
+def atomic_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, delete=False) as stream:
+        temporary = Path(stream.name)
+        try:
+            json.dump(value, stream, indent=2)
+            stream.flush()
+            os.fsync(stream.fileno())
+            os.replace(temporary, path)
+            descriptor = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+def root():
+    return state_root() / "updates"
+
+
+def contracts():
+    sys.path.insert(0, str(repository()))
+    from scripts.magik_ci import bundle, databases
+
+    return bundle, databases
+
+
+def selectors():
+    path = repository() / "scripts/release/databases/select-published-release.py"
+    spec = importlib.util.spec_from_file_location("published_releases", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def names(kind, version):
+    if kind == "platform":
+        return f"mister-magik-platform-v0.{version}.zip", "platform-bundle-v0.2.json"
+    return f"mister-magik-game-databases-v{version}.zip", "game-databases-manifest.json"
+
+
+def verify(kind, release):
+    directory = Path(release["directory"])
+    archive, manifest = names(kind, release["version"])
+    checks = {}
+    for line in (directory / "SHA256SUMS").read_text().splitlines():
+        digest, name = line.split("  ", 1)
+        checks[name] = digest
+    if hashlib.sha256((directory / manifest).read_bytes()).hexdigest() != checks.get(
+        manifest
+    ):
+        raise ValueError(f"release checksum mismatch: {manifest}")
+    # Published checksum files describe ZIP members, not the ZIP container.
+    with zipfile.ZipFile(directory / archive) as stream:
+        members = stream.namelist()
+        if len(members) != len(set(members)):
+            raise ValueError("duplicate release archive member")
+        for name in members:
+            if Path(name).is_absolute() or ".." in Path(name).parts:
+                raise ValueError("unsafe release archive path")
+            if name != "SHA256SUMS" and not name.endswith("/"):
+                if hashlib.sha256(stream.read(name)).hexdigest() != checks.get(name):
+                    raise ValueError(f"release checksum mismatch: {name}")
+        if stream.read("SHA256SUMS") != (directory / "SHA256SUMS").read_bytes():
+            raise ValueError("release checksum file differs from archive")
+    bundle, databases = contracts()
+    if kind == "platform":
+        return bundle.verify(
+            directory / archive, directory / manifest, release["version"]
+        )
+    return databases.verify(
+        directory / archive,
+        directory / manifest,
+        directory / "SHA256SUMS",
+        release["version"],
+    )
+
+
+def desired():
+    path = root() / "desired.json"
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text())
+    for kind in ("platform", "databases"):
+        verify(kind, value[kind])
+    return value
+
+
+def update():
+    with lock(root() / "download.lock"):
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{REPOSITORY}/releases?per_page=100",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        pages = json.loads(result.stdout)
+        releases = (
+            [item for page in pages for item in page]
+            if pages and isinstance(pages[0], list)
+            else pages
+        )
+        selector = selectors()
+        platforms = selector.durable_platforms(releases)
+        selected = {
+            "platform": platforms[0] if platforms else None,
+            "databases": selector.select_game_databases(releases),
+        }
+        pair = {"repository": REPOSITORY}
+        for kind, release in selected.items():
+            if release is None:
+                raise ValueError(f"no published numbered {kind} release")
+            tag = release["tag_name"]
+            version = (
+                selector.platform_version(tag)
+                if kind == "platform"
+                else int(tag.removeprefix("game-databases-v"))
+            )
+            directory = root() / "releases" / REPOSITORY / tag
+            entry = {
+                "tag": tag,
+                "version": version,
+                "directory": str(directory.resolve()),
+            }
+            if directory.exists():
+                verify(kind, entry)
+                outcome = "cached"
+            else:
+                directory.parent.mkdir(parents=True, exist_ok=True)
+                with tempfile.TemporaryDirectory(
+                    dir=directory.parent, prefix="download-"
+                ) as temporary:
+                    args = [
+                        "gh",
+                        "release",
+                        "download",
+                        tag,
+                        "--repo",
+                        REPOSITORY,
+                        "--dir",
+                        temporary,
+                    ]
+                    for name in (*names(kind, version), "SHA256SUMS"):
+                        args.extend(["--pattern", name])
+                    subprocess.run(args, check=True, timeout=600)
+                    verify(kind, {**entry, "directory": temporary})
+                    os.rename(temporary, directory)
+                outcome = "downloaded"
+            pair[kind] = entry
+            print(f"{tag}: {outcome}, verified: {directory.resolve()}")
+        atomic_json(root() / "desired.json", pair)
+        print("Queued for all devices. Next: scripts/magik2 deploy --attended")
+    return 0

--- a/magik2/host/tests/test_deploy.py
+++ b/magik2/host/tests/test_deploy.py
@@ -63,7 +63,7 @@ def test_real_app_uses_the_same_delivery_with_its_own_artifact(monkeypatch, tmp_
     )
 
 
-def test_real_deploy_requires_input_proxy_but_mini_does_not(monkeypatch, tmp_path):
+def test_both_launchers_require_main_supervision(monkeypatch, tmp_path):
     from argparse import Namespace
     from magik2.apps import application
 
@@ -77,5 +77,5 @@ def test_real_deploy_requires_input_proxy_but_mini_does_not(monkeypatch, tmp_pat
     monkeypatch.setattr(cli, "ensure_application", lambda *args: True)
     monkeypatch.setattr(cli, "retain_diagnostics", lambda *args: None)
     assert cli.deploy(Namespace(app="magik"), create_run(tmp_path, "deploy", {})) == 0
-    assert "main-input-proxy" in required[0]
-    assert "main-input-proxy" not in application("mini-magik").agent_capabilities
+    assert "main-managed-magik" in required[0]
+    assert "main-managed-mini-v1" in application("mini-magik").agent_capabilities

--- a/magik2/host/tests/test_updates.py
+++ b/magik2/host/tests/test_updates.py
@@ -1,0 +1,300 @@
+from unittest.mock import Mock
+import hashlib
+import json
+import subprocess
+from types import SimpleNamespace
+import zipfile
+
+import pytest
+
+from magik2 import updates, update_deploy
+
+
+def test_numbered_release_selection_includes_prereleases():
+    selector = updates.selectors()
+    releases = [
+        {"tag_name": "platform-v0.10", "published_at": "2026", "prerelease": True},
+        {"tag_name": "platform-v0.11", "published_at": "2026", "draft": True},
+        {"tag_name": "platform-v0.9", "published_at": "2027"},
+        {"tag_name": "game-databases-v12", "published_at": "2026", "prerelease": True},
+    ]
+    assert selector.durable_platforms(releases)[0]["tag_name"] == "platform-v0.10"
+    assert selector.select_game_databases(releases)["tag_name"] == "game-databases-v12"
+
+
+def test_update_failure_preserves_previous_pair(tmp_path, monkeypatch):
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    updates.atomic_json(updates.root() / "desired.json", {"old": True})
+    monkeypatch.setattr(
+        updates.subprocess,
+        "run",
+        Mock(side_effect=subprocess.CalledProcessError(1, "gh")),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        updates.update()
+    assert json.loads((updates.root() / "desired.json").read_text()) == {"old": True}
+
+
+def test_verify_rejects_corrupt_assets_before_contracts(tmp_path, monkeypatch):
+    archive, manifest = updates.names("platform", 2)
+    for name in (archive, manifest):
+        (tmp_path / name).write_bytes(b"bad")
+    (tmp_path / "SHA256SUMS").write_text(f"{'0' * 64}  {archive}\n")
+    contracts = Mock()
+    monkeypatch.setattr(updates, "contracts", contracts)
+    with pytest.raises(ValueError, match="checksum"):
+        updates.verify("platform", {"directory": str(tmp_path), "version": 2})
+    contracts.assert_not_called()
+
+
+@pytest.fixture
+def deploy_case(tmp_path, monkeypatch):
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    manifest = tmp_path / "game-databases-manifest.json"
+    manifest.write_text("database")
+    pair = {
+        kind: {"tag": kind, "version": 2, "directory": str(tmp_path)}
+        for kind in ("platform", "databases")
+    }
+    current = {
+        "platform": {
+            "version": 2,
+            "verified": True,
+            "active": True,
+            "bundle_id": "bundle",
+        },
+        "databases": {
+            "version": 2,
+            "verified": True,
+            "hashes": {"manifest": hashlib.sha256(manifest.read_bytes()).hexdigest()},
+        },
+        "stages": [],
+        "boot_id": "boot",
+        "configured_main": "MiSTer_MagiKDev",
+        "running": {"executable_path": "/media/fat/MiSTer_MagiKDev"},
+    }
+    current["platform"]["hashes"] = {
+        name: "hash" for name in update_deploy.PLATFORM_MEMBERS
+    }
+    monkeypatch.setattr(
+        update_deploy,
+        "verify",
+        lambda *_: {
+            "bundle_id": "bundle",
+            "files": [
+                {"path": path, "sha256": "hash"}
+                for path in update_deploy.PLATFORM_MEMBERS.values()
+            ],
+        },
+    )
+    monkeypatch.setattr(update_deploy, "state", lambda *_: current)
+    monkeypatch.setattr(update_deploy, "ensure_arm_application", Mock())
+    publish = Mock()
+    monkeypatch.setattr(update_deploy, "publish", publish)
+    return pair, current, publish
+
+
+def test_current_pair_is_noop_on_multiple_devices(deploy_case, tmp_path):
+    pair, _, publish = deploy_case
+    for identity in ("one", "two"):
+        update_deploy.apply_updates(Mock(), identity, pair, tmp_path, False)
+    publish.assert_not_called()
+    assert len(list((updates.root() / "devices").glob("*.json"))) == 2
+
+
+def test_missing_attendance_prevents_all_publication(deploy_case, tmp_path):
+    pair, current, publish = deploy_case
+    current["platform"]["version"] = 1
+    with pytest.raises(RuntimeError, match="deploy --attended"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    publish.assert_not_called()
+
+
+def test_database_only_does_not_prepare_platform(deploy_case, tmp_path, monkeypatch):
+    pair, current, publish = deploy_case
+    current["databases"]["version"] = 1
+    prepare = Mock(side_effect=AssertionError("unexpected platform build"))
+    monkeypatch.setattr(update_deploy, "prepare", prepare)
+    monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
+    publish.side_effect = lambda *a, **kw: current["databases"].update(version=2)
+    update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    assert publish.call_args.kwargs == {"kind": "databases", "layout": "dev"}
+
+
+def test_ambiguous_stage_does_not_reboot(deploy_case, tmp_path):
+    pair, current, publish = deploy_case
+    current["stages"] = [
+        {"stage": "a" * 32, "pending": {"layout": "dev", "boot_id": "boot"}}
+    ]
+    agent = Mock()
+    with pytest.raises(RuntimeError, match="no reboot repeated"):
+        update_deploy.apply_updates(agent, "one", pair, tmp_path, True)
+    agent._request.assert_not_called()
+    publish.assert_not_called()
+
+
+def test_newer_invalid_release_never_downgrades():
+    with pytest.raises(RuntimeError, match="refusing downgrade"):
+        update_deploy.needed(
+            {"version": 3, "verified": False}, {"version": 2}, "platform", {}
+        )
+
+
+def test_platform_success_database_failure_retries_only_database(
+    deploy_case, tmp_path, monkeypatch
+):
+    pair, current, publish = deploy_case
+    current["platform"]["version"] = 1
+    current["databases"]["version"] = 1
+    prepare = Mock(return_value={"platform": tmp_path})
+    monkeypatch.setattr(update_deploy, "prepare", prepare)
+    monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
+
+    def fail_database(*args, **fields):
+        if fields["kind"] == "platform":
+            current["platform"]["version"] = 2
+        else:
+            raise RuntimeError("database transport lost")
+
+    publish.side_effect = fail_database
+    with pytest.raises(RuntimeError, match="transport lost"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, True)
+    assert (
+        updates.root()
+        / "devices"
+        / f"{hashlib.sha256(b'one').hexdigest()}-pending.json"
+    ).exists()
+    publish.reset_mock()
+    publish.side_effect = lambda *a, **kw: current["databases"].update(version=2)
+    update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    assert publish.call_count == 1
+    assert publish.call_args.kwargs["kind"] == "databases"
+    assert prepare.call_count == 1
+
+
+def test_archive_path_escape_rejected(tmp_path):
+    import zipfile
+
+    archive = tmp_path / "bad.zip"
+    with zipfile.ZipFile(archive, "w") as stream:
+        stream.writestr("../outside", "bad")
+    with pytest.raises(ValueError, match="unsafe"):
+        update_deploy.extract(archive, tmp_path / "output")
+    assert not (tmp_path / "outside").exists()
+
+
+def test_paginated_download_then_cache_reuse(tmp_path, monkeypatch):
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    validator = SimpleNamespace(verify=lambda *_: {})
+    monkeypatch.setattr(updates, "contracts", lambda: (validator, validator))
+    calls = []
+
+    def gh(args, **kwargs):
+        calls.append(args)
+        if args[1] == "api":
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    [
+                        [
+                            {
+                                "tag_name": "platform-v0.4",
+                                "published_at": "now",
+                                "prerelease": True,
+                            }
+                        ],
+                        [{"tag_name": "game-databases-v8", "published_at": "now"}],
+                    ]
+                )
+            )
+        kind, version = (
+            ("platform", 4) if args[3] == "platform-v0.4" else ("databases", 8)
+        )
+        directory = Path(args[args.index("--dir") + 1])
+        archive, manifest = updates.names(kind, version)
+        payload = b"{}"
+        checks = f"{hashlib.sha256(payload).hexdigest()}  {manifest}\n".encode()
+        (directory / manifest).write_bytes(payload)
+        (directory / "SHA256SUMS").write_bytes(checks)
+        with zipfile.ZipFile(directory / archive, "w") as stream:
+            stream.writestr(manifest, payload)
+            stream.writestr("SHA256SUMS", checks)
+        return SimpleNamespace(returncode=0)
+
+    from pathlib import Path
+
+    monkeypatch.setattr(updates.subprocess, "run", gh)
+    assert updates.update() == 0
+    pair = updates.desired()
+    assert pair["platform"]["version"] == 4
+    assert pair["databases"]["version"] == 8
+    assert updates.update() == 0
+    assert len([args for args in calls if args[1] == "release"]) == 2
+    assert len([args for args in calls if args[1] == "api"]) == 2
+
+
+def test_device_lock_serializes_same_identity(tmp_path, monkeypatch):
+    import threading
+
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    started, acquired = threading.Event(), threading.Event()
+
+    def second():
+        started.set()
+        with update_deploy.device_lock("same"):
+            acquired.set()
+
+    with update_deploy.device_lock("same"):
+        worker = threading.Thread(target=second)
+        worker.start()
+        assert started.wait(2)
+        assert not acquired.wait(0.05)
+        with update_deploy.device_lock("another"):
+            pass
+    worker.join(2)
+    assert acquired.is_set()
+
+
+def test_manager_build_uses_repository_root_and_manager_binary(tmp_path):
+    from magik2.build import ensure_arm_package, TARGET
+
+    package = tmp_path / "mister/tools/manager"
+    package.mkdir(parents=True)
+    artifact = package / "target" / TARGET / "release/mister-magik-manager"
+    commands, roots = [], []
+
+    def runner(command, **kwargs):
+        commands.append(command)
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_bytes(b"manager")
+        return SimpleNamespace(returncode=0)
+
+    result = ensure_arm_package(
+        package,
+        package / "target/cache.json",
+        runner=runner,
+        prepare=lambda repo, _: roots.append(repo) or "builder",
+    )
+    assert result.artifact == artifact
+    assert roots == [tmp_path]
+    assert "/workspace/mister/tools/manager" in commands[0]
+    assert commands[0][commands[0].index("--bin") + 1] == "mister-magik-manager"
+
+
+def test_unhealthy_installed_platform_is_not_rebooted(deploy_case, tmp_path):
+    pair, current, publish = deploy_case
+    current["platform"]["active"] = False
+    with pytest.raises(RuntimeError, match="no reboot attempted"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, True)
+    publish.assert_not_called()
+
+
+def test_local_main_change_requires_release_install_but_gui_change_does_not(
+    deploy_case, tmp_path
+):
+    pair, current, publish = deploy_case
+    current["platform"]["hashes"]["gui"] = "local edit"
+    update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    publish.assert_not_called()
+    current["platform"]["hashes"]["main"] = "different Main with same bundle id"
+    with pytest.raises(RuntimeError, match="deploy --attended"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)

--- a/magik2/probe/Cargo.lock
+++ b/magik2/probe/Cargo.lock
@@ -2612,6 +2612,7 @@ name = "mini-magik"
 version = "0.1.0"
 dependencies = [
  "fontique",
+ "mister-magik-framebuffer-scenes",
  "mister-magik-mister-runtime",
  "mister-magik-tooling-support",
  "slint",
@@ -2647,6 +2648,13 @@ dependencies = [
 [[package]]
 name = "mister-magik-core"
 version = "0.1.0"
+
+[[package]]
+name = "mister-magik-framebuffer-scenes"
+version = "0.1.0"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "mister-magik-framebuffer-stream"

--- a/magik2/probe/Cargo.toml
+++ b/magik2/probe/Cargo.toml
@@ -25,6 +25,7 @@ slint = { git = "https://github.com/slint-ui/slint", rev = "72cf74306784e7d15374
 
 [dependencies]
 mister-magik-tooling-support = { path = "../../crates/tooling-support" }
+mister-magik-framebuffer-scenes = { path = "../../crates/framebuffer-scenes" }
 mister-magik-mister-runtime = { path = "../../mister/platform/runtime", default-features = false, features = ["cached-rgb565-presenter", "framebuffer-lab"] }
 
 [build-dependencies]

--- a/magik2/probe/src/launcher_control.rs
+++ b/magik2/probe/src/launcher_control.rs
@@ -11,23 +11,28 @@ pub struct LauncherControl {
     count: usize,
     held: [[bool; 2]; 2],
     pub rearm_input: bool,
+    flip_taps: bool,
+    preview: Option<BrowseFrame>,
 }
 
 impl LauncherControl {
     pub fn new(count: usize) -> Self {
-        let mut browser = LauncherBrowser::new(count, 0);
+        let mut browser = LauncherBrowser::new(count, 0).with_flips(true);
         browser.neutral();
         Self {
             browser,
             count,
             held: [[false; 2]; 2],
             rearm_input: true,
+            flip_taps: true,
+            preview: None,
         }
     }
 
     pub fn reset(&mut self, home: bool) {
         let selected = if home { 0 } else { self.browser.selected() };
-        self.browser = LauncherBrowser::new(self.count, selected);
+        self.browser = LauncherBrowser::new(self.count, selected).with_flips(self.flip_taps);
+        self.preview = None;
         self.browser.neutral();
         self.held = [[false; 2]; 2];
         // Reopening the physical reader obtains a fresh authoritative held-key
@@ -36,6 +41,9 @@ impl LauncherControl {
     }
 
     pub fn input(&mut self, physical: bool, direction: BrowseDirection, down: bool, now: u64) {
+        if physical && down {
+            self.preview = None;
+        }
         let index = usize::from(direction == BrowseDirection::Right);
         let previous = self.held[0][index] || self.held[1][index];
         self.held[usize::from(physical)][index] = down;
@@ -49,7 +57,32 @@ impl LauncherControl {
     }
 
     pub fn frame(&mut self, now: u64) -> BrowseFrame {
-        self.browser.frame(now)
+        self.preview.unwrap_or_else(|| self.browser.frame(now))
+    }
+
+    pub fn is_preview(&self) -> bool {
+        self.preview.is_some()
+    }
+
+    pub fn configure(&mut self, flips: bool) {
+        self.flip_taps = flips;
+        self.reset(false);
+    }
+
+    pub fn preview(&mut self, right: bool, progress: u32) {
+        self.reset(true);
+        self.preview = Some(BrowseFrame {
+            selected: 0,
+            target: if right { 1 } else { self.count - 1 },
+            phase: mister_magik_framebuffer_scenes::launcher_navigation::BrowsePhase::Flipping,
+            direction: Some(if right {
+                BrowseDirection::Right
+            } else {
+                BrowseDirection::Left
+            }),
+            progress_millis: progress.min(460),
+            duration_millis: 460,
+        });
     }
 }
 
@@ -64,10 +97,10 @@ mod tests {
         control.input(true, BrowseDirection::Right, true, 0);
         control.input(false, BrowseDirection::Right, true, 20);
         control.input(false, BrowseDirection::Right, false, 30);
-        control.frame(180);
-        assert_eq!(control.frame(300).phase, BrowsePhase::Held);
-        control.input(true, BrowseDirection::Right, false, 320);
-        assert_eq!(control.frame(450).selected, 2);
+        assert_eq!(control.frame(300).phase, BrowsePhase::Flipping);
+        assert_eq!(control.frame(460).phase, BrowsePhase::Held);
+        control.input(true, BrowseDirection::Right, false, 500);
+        assert_eq!(control.frame(610).selected, 2);
         assert_eq!(control.frame(1000).phase, BrowsePhase::Settled);
     }
 
@@ -80,6 +113,6 @@ mod tests {
         assert_eq!(control.frame(1000).phase, BrowsePhase::Settled);
         control.input(false, BrowseDirection::Right, true, 1001);
         control.input(false, BrowseDirection::Right, false, 1002);
-        assert_eq!(control.frame(1181).selected, 1);
+        assert_eq!(control.frame(1461).selected, 1);
     }
 }

--- a/magik2/probe/src/launcher_control.rs
+++ b/magik2/probe/src/launcher_control.rs
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Consumer boundary: physical and test input use the same portable browser.
+use mister_magik_framebuffer_scenes::launcher_navigation::{
+    BrowseDirection, BrowseFrame, LauncherBrowser,
+};
+
+pub struct LauncherControl {
+    browser: LauncherBrowser,
+    count: usize,
+    held: [[bool; 2]; 2],
+    pub rearm_input: bool,
+}
+
+impl LauncherControl {
+    pub fn new(count: usize) -> Self {
+        let mut browser = LauncherBrowser::new(count, 0);
+        browser.neutral();
+        Self {
+            browser,
+            count,
+            held: [[false; 2]; 2],
+            rearm_input: true,
+        }
+    }
+
+    pub fn reset(&mut self, home: bool) {
+        let selected = if home { 0 } else { self.browser.selected() };
+        self.browser = LauncherBrowser::new(self.count, selected);
+        self.browser.neutral();
+        self.held = [[false; 2]; 2];
+        // Reopening the physical reader obtains a fresh authoritative held-key
+        // snapshot; it suppresses inherited holds until neutral independently.
+        self.rearm_input = true;
+    }
+
+    pub fn input(&mut self, physical: bool, direction: BrowseDirection, down: bool, now: u64) {
+        let index = usize::from(direction == BrowseDirection::Right);
+        let previous = self.held[0][index] || self.held[1][index];
+        self.held[usize::from(physical)][index] = down;
+        let next = self.held[0][index] || self.held[1][index];
+        if next && !previous {
+            self.browser.press(direction, now);
+        }
+        if previous && !next {
+            self.browser.release(direction);
+        }
+    }
+
+    pub fn frame(&mut self, now: u64) -> BrowseFrame {
+        self.browser.frame(now)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use mister_magik_framebuffer_scenes::launcher_navigation::BrowsePhase;
+
+    #[test]
+    fn test_release_cannot_release_physical_hold() {
+        let mut control = LauncherControl::new(5);
+        control.input(true, BrowseDirection::Right, true, 0);
+        control.input(false, BrowseDirection::Right, true, 20);
+        control.input(false, BrowseDirection::Right, false, 30);
+        control.frame(180);
+        assert_eq!(control.frame(300).phase, BrowsePhase::Held);
+        control.input(true, BrowseDirection::Right, false, 320);
+        assert_eq!(control.frame(450).selected, 2);
+        assert_eq!(control.frame(1000).phase, BrowsePhase::Settled);
+    }
+
+    #[test]
+    fn mode_or_disconnect_reset_clears_all_pending_input() {
+        let mut control = LauncherControl::new(5);
+        control.input(true, BrowseDirection::Left, true, 0);
+        control.reset(false);
+        assert!(control.rearm_input);
+        assert_eq!(control.frame(1000).phase, BrowsePhase::Settled);
+        control.input(false, BrowseDirection::Right, true, 1001);
+        control.input(false, BrowseDirection::Right, false, 1002);
+        assert_eq!(control.frame(1181).selected, 1);
+    }
+}

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -6,12 +6,16 @@
 use mister_magik_framebuffer_scenes::Rgb565Pixel as ScenePixel;
 use mister_magik_framebuffer_scenes::launcher::{LauncherCard, LauncherData, LauncherScene};
 use mister_magik_framebuffer_scenes::launcher_navigation::{
-    BrowseDirection, BrowsePhase, LauncherBrowser,
+    BrowseDirection, BrowseFrame, BrowsePhase,
 };
 use mister_magik_mister_runtime::display_plan::query_main_display_plan;
 use mister_magik_mister_runtime::framebuffer::hidden_latch::HiddenLatchPresenter;
 use mister_magik_mister_runtime::framebuffer::rgb565::Rgb565;
-use mister_magik_mister_runtime::main_input::{MainInputDirection, MainInputPhase, MainProxyInput};
+use mister_magik_mister_runtime::main_input::{
+    INPUT_BATCH_CAPACITY, MainInputDirection, MainInputPhase, MainProxyInput,
+};
+mod launcher_control;
+use launcher_control::LauncherControl;
 use slint::platform::software_renderer::{RepaintBufferType, Rgb565Pixel, SoftwareRenderer};
 use slint::platform::{EventLoopProxy, Platform, WindowAdapter};
 use slint::{EventLoopError, PhysicalSize, Window};
@@ -87,13 +91,6 @@ impl ProbeWindow {
             size: Cell::new(PhysicalSize::default()),
             event_loop: ProbeEventLoop::default(),
         })
-    }
-
-    fn draw_if_needed(&self, render: impl FnOnce(&SoftwareRenderer, bool)) -> bool {
-        self.event_loop.process_pending_callbacks();
-        let redraw_requested = self.redraw_pending.replace(false);
-        render(&self.renderer, redraw_requested);
-        redraw_requested
     }
 
     fn set_size(&self, size: PhysicalSize) {
@@ -191,19 +188,25 @@ fn main() -> Result<(), String> {
     ));
     let weak = probe.as_weak();
     probe.on_increment(move || {
-        if let Some(probe) = weak.upgrade() {
+        if let Some(probe) = weak.upgrade()
+            && !probe.get_launcher_mode()
+        {
             probe.set_counter(probe.get_counter() + 1);
         }
     });
     let weak = probe.as_weak();
     probe.on_reset(move || {
-        if let Some(probe) = weak.upgrade() {
+        if let Some(probe) = weak.upgrade()
+            && !probe.get_launcher_mode()
+        {
             probe.set_counter(0);
         }
     });
     let weak = probe.as_weak();
     probe.on_toggle_details(move || {
-        if let Some(probe) = weak.upgrade() {
+        if let Some(probe) = weak.upgrade()
+            && !probe.get_launcher_mode()
+        {
             probe.set_details_open(!probe.get_details_open());
         }
     });
@@ -211,7 +214,6 @@ fn main() -> Result<(), String> {
     let launcher_mode = Rc::new(Cell::new(true));
     let launcher_dirty = Rc::new(Cell::new(true));
     let launcher_scene = LauncherScene::new(width, height);
-    let launcher_cached = Rc::new(RefCell::new(None::<Vec<ScenePixel>>));
     let launcher_cards = [
         LauncherCard {
             name: "ARCADE",
@@ -239,85 +241,126 @@ fn main() -> Result<(), String> {
             colour: 0xb9a6,
         },
     ];
-    let launcher_browser = Rc::new(RefCell::new(LauncherBrowser::new(launcher_cards.len(), 0)));
-    launcher_browser.borrow_mut().neutral();
-    let launcher_input = Rc::new(RefCell::new(MainProxyInput::open().ok()));
-    probe.set_launcher_input_source(if launcher_input.borrow().is_some() {
-        "main-proxy".into()
-    } else {
-        "main-proxy-unavailable".into()
+    let mut prepared = launcher_scene.prepare(LauncherData {
+        cards: &launcher_cards,
+        selected: 0,
+        library_games: 6842,
+        collections: 18,
+        favourites: 126,
+        clock: "21:37",
     });
-    probe.set_launcher_mode(true);
-    probe.set_launcher_ready(false);
-    probe.set_launcher_selection("ARCADE".into());
-    let mode = launcher_mode.clone();
-    let dirty = launcher_dirty.clone();
-    let weak = probe.as_weak();
-    let timer = motion_timer.clone();
-    probe.on_show_launcher(move || {
-        mode.set(true);
-        dirty.set(true);
-        timer.stop();
-        if let Some(probe) = weak.upgrade() {
-            probe.set_launcher_mode(true);
-            probe.set_launcher_ready(false);
-            probe.set_motion_running(false);
-        }
-    });
+    let launcher_labels: Vec<slint::SharedString> =
+        launcher_cards.iter().map(|card| card.name.into()).collect();
+    let control = Rc::new(RefCell::new(LauncherControl::new(launcher_cards.len())));
     let launcher_epoch = Rc::new(Instant::now());
-    let weak = probe.as_weak();
-    let browser = launcher_browser.clone();
-    let dirty = launcher_dirty.clone();
-    let epoch = launcher_epoch.clone();
-    probe.on_launcher_left_down(move || {
-        browser
-            .borrow_mut()
-            .press(BrowseDirection::Left, epoch.elapsed().as_millis() as u64);
-        dirty.set(true);
-        if let Some(probe) = weak.upgrade() {
-            probe.set_launcher_motion_state("sliding".into());
-        }
-    });
-    let browser = launcher_browser.clone();
-    probe.on_launcher_left_up(move || browser.borrow_mut().release(BrowseDirection::Left));
-    let weak = probe.as_weak();
-    let browser = launcher_browser.clone();
-    let dirty = launcher_dirty.clone();
-    let epoch = launcher_epoch.clone();
-    probe.on_launcher_right_down(move || {
-        browser
-            .borrow_mut()
-            .press(BrowseDirection::Right, epoch.elapsed().as_millis() as u64);
-        dirty.set(true);
-        if let Some(probe) = weak.upgrade() {
-            probe.set_launcher_motion_state("sliding".into());
-        }
-    });
-    let browser = launcher_browser.clone();
-    probe.on_launcher_right_up(move || browser.borrow_mut().release(BrowseDirection::Right));
-    let browser = launcher_browser.clone();
-    let dirty = launcher_dirty.clone();
-    probe.on_launcher_input_reset(move || {
-        browser.borrow_mut().reset();
-        dirty.set(true);
-    });
-    let mode = launcher_mode.clone();
-    let dirty = launcher_dirty.clone();
-    let weak = probe.as_weak();
-    let timer = motion_timer.clone();
-    probe.on_show_probe(move || {
-        mode.set(false);
-        dirty.set(false);
-        timer.stop();
-        if let Some(probe) = weak.upgrade() {
-            probe.set_launcher_mode(false);
-            probe.set_launcher_ready(false);
-            probe.set_motion_running(false);
-        }
-    });
+    let measure_running = Rc::new(Cell::new(false));
+    let measure_direction = Rc::new(Cell::new(BrowseDirection::Right));
     let session = Rc::new(RefCell::new(
         Session::from_environment().ok_or("missing tooling state root")?,
     ));
+    probe.set_launcher_mode(true);
+    probe.set_launcher_ready(false);
+    probe.set_launcher_selection("ARCADE".into());
+
+    let install_mode = |launcher: bool| {
+        let mode = launcher_mode.clone();
+        let dirty = launcher_dirty.clone();
+        let control = control.clone();
+        let weak = probe.as_weak();
+        let timer = motion_timer.clone();
+        let measure = measure_running.clone();
+        let session = session.clone();
+        move || {
+            mode.set(launcher);
+            dirty.set(launcher);
+            control.borrow_mut().reset(false);
+            timer.stop();
+            measure.set(false);
+            let mut session = session.borrow_mut();
+            session.metrics.motion_started_ms = None;
+            session.metrics.window_start = None;
+            session.metrics.window = None;
+            if let Some(probe) = weak.upgrade() {
+                probe.set_launcher_mode(launcher);
+                probe.set_launcher_ready(false);
+                probe.set_motion_running(false);
+                probe.set_launcher_measurement("idle".into());
+            }
+        }
+    };
+    probe.on_show_launcher(install_mode(true));
+    probe.on_show_probe(install_mode(false));
+
+    let install_input = |direction, down| {
+        let control = control.clone();
+        let mode = launcher_mode.clone();
+        let epoch = launcher_epoch.clone();
+        move || {
+            if mode.get() {
+                control.borrow_mut().input(
+                    false,
+                    direction,
+                    down,
+                    epoch.elapsed().as_millis() as u64,
+                );
+            }
+        }
+    };
+    probe.on_launcher_left_down(install_input(BrowseDirection::Left, true));
+    probe.on_launcher_left_up(install_input(BrowseDirection::Left, false));
+    probe.on_launcher_right_down(install_input(BrowseDirection::Right, true));
+    probe.on_launcher_right_up(install_input(BrowseDirection::Right, false));
+    let reset_control = control.clone();
+    let dirty = launcher_dirty.clone();
+    let mode = launcher_mode.clone();
+    probe.on_launcher_input_reset(move || {
+        if mode.get() {
+            reset_control.borrow_mut().reset(true);
+            dirty.set(true);
+        }
+    });
+    let browser = control.clone();
+    let mode = launcher_mode.clone();
+    let epoch = launcher_epoch.clone();
+    let measure = measure_running.clone();
+    let direction = measure_direction.clone();
+    let session_for_launcher = session.clone();
+    let weak = probe.as_weak();
+    let dirty = launcher_dirty.clone();
+    probe.on_start_launcher_motion(move |right| {
+        if !mode.get() || measure.get() {
+            return;
+        }
+        let chosen = if right {
+            BrowseDirection::Right
+        } else {
+            BrowseDirection::Left
+        };
+        browser.borrow_mut().reset(true);
+        browser
+            .borrow_mut()
+            .input(false, chosen, true, epoch.elapsed().as_millis() as u64);
+        direction.set(chosen);
+        measure.set(true);
+        dirty.set(true);
+        let mut session = session_for_launcher.borrow_mut();
+        session.metrics.context["workload"] = "launcher-slide".into();
+        if let Some(context) = session.metrics.context.as_object_mut() {
+            for name in [
+                "launcher_telemetry_error",
+                "launcher_owned_vblanks",
+                "launcher_presented_vblanks",
+                "launcher_repeated_vblanks",
+                "launcher_ownership_losses",
+            ] {
+                context.remove(name);
+            }
+        }
+        session.begin();
+        if let Some(probe) = weak.upgrade() {
+            probe.set_launcher_measurement("running".into());
+        }
+    });
     {
         let mut session = session.borrow_mut();
         let context = &mut session.metrics.context;
@@ -335,12 +378,13 @@ fn main() -> Result<(), String> {
         let Some(probe) = weak.upgrade() else {
             return;
         };
-        if probe.get_motion_running() {
+        if probe.get_launcher_mode() || probe.get_motion_running() {
             return;
         }
         probe.set_motion_step(0);
         probe.set_motion_complete(false);
         probe.set_motion_running(true);
+        session_for_motion.borrow_mut().metrics.context["workload"] = "probe-motion".into();
         session_for_motion.borrow_mut().begin();
         let weak = probe.as_weak();
         timer.start(
@@ -355,184 +399,239 @@ fn main() -> Result<(), String> {
     });
 
     let mut cached = vec![Rgb565Pixel(0); width * height];
-    let mut launcher_input = launcher_input.borrow_mut().take();
-    let mut input_events = Vec::with_capacity(8);
-    let mut last_input_open_ms = 0_u64;
+    let mut scene_pixels = vec![ScenePixel(0); width * height];
+    let mut launcher_input: Option<MainProxyInput> = None;
+    let mut input_events = Vec::with_capacity(INPUT_BATCH_CAPACITY);
+    let mut next_input_open_ms = 0;
+    let mut last_presented: Option<BrowseFrame> = None;
+    let mut pending: Option<(Option<BrowseFrame>, Instant)> = None;
+    let mut telemetry_start: Option<(u32, u32, u32, u32)> = None;
     loop {
+        window.event_loop.process_pending_callbacks();
+        slint::platform::update_timers_and_animations();
+        if window.event_loop.terminated.load(Ordering::Acquire) {
+            return Ok(());
+        }
         let now_ms = launcher_epoch.elapsed().as_millis() as u64;
-        if let Some(input) = launcher_input.as_mut() {
-            if input.poll_into(&mut input_events).is_err() {
-                launcher_browser.borrow_mut().reset();
-                launcher_dirty.set(true);
-                launcher_input = None;
-                probe.set_launcher_input_source("main-proxy-unavailable".into());
+        if control.borrow().rearm_input {
+            control.borrow_mut().rearm_input = false;
+            launcher_input = None;
+            next_input_open_ms = 0;
+        }
+        if launcher_input.is_none() && now_ms >= next_input_open_ms {
+            next_input_open_ms = now_ms.saturating_add(1000);
+            match MainProxyInput::open() {
+                Ok(input) => launcher_input = Some(input),
+                Err(error) => {
+                    session.borrow_mut().metrics.context["input_error"] = error.to_string().into();
+                }
             }
-            for event in input_events.drain(..) {
-                let mut browser = launcher_browser.borrow_mut();
-                match (event.direction, event.phase) {
-                    (MainInputDirection::Left, MainInputPhase::Pressed) => {
-                        browser.press(BrowseDirection::Left, now_ms)
-                    }
-                    (MainInputDirection::Left, MainInputPhase::Released) => {
-                        browser.release(BrowseDirection::Left)
-                    }
-                    (MainInputDirection::Right, MainInputPhase::Pressed) => {
-                        browser.press(BrowseDirection::Right, now_ms)
-                    }
-                    (MainInputDirection::Right, MainInputPhase::Released) => {
-                        browser.release(BrowseDirection::Right)
+        }
+        if let Some(input) = launcher_input.as_mut() {
+            match input.poll_into(&mut input_events) {
+                Ok(()) => {
+                    if launcher_mode.get() {
+                        for event in input_events.drain(..) {
+                            let direction = match event.direction {
+                                MainInputDirection::Left => BrowseDirection::Left,
+                                MainInputDirection::Right => BrowseDirection::Right,
+                            };
+                            control.borrow_mut().input(
+                                true,
+                                direction,
+                                event.phase == MainInputPhase::Pressed,
+                                now_ms,
+                            );
+                        }
                     }
                 }
-                launcher_dirty.set(true);
+                Err(error) => {
+                    input_events.clear();
+                    control.borrow_mut().reset(false);
+                    control.borrow_mut().rearm_input = false;
+                    launcher_dirty.set(launcher_mode.get());
+                    launcher_input = None;
+                    next_input_open_ms = now_ms.saturating_add(1000);
+                    session.borrow_mut().metrics.context["input_error"] = error.to_string().into();
+                }
             }
-        } else if now_ms.saturating_sub(last_input_open_ms) >= 1_000 {
-            last_input_open_ms = now_ms;
-            if let Ok(input) = MainProxyInput::open() {
-                launcher_input = Some(input);
-                probe.set_launcher_input_source("main-proxy".into());
+        }
+        let input_source = match launcher_input.as_ref() {
+            Some(input) if input.ready() => "main-proxy",
+            Some(_) => "main-proxy-awaiting-neutral",
+            None => "main-proxy-unavailable",
+        };
+        if probe.get_launcher_input_source() != input_source {
+            probe.set_launcher_input_source(input_source.into());
+            session.borrow_mut().metrics.context["input_source"] = input_source.into();
+        }
+        let completed = session.borrow_mut().tick(width, height)?;
+        if measure_running.get() {
+            if session.borrow().metrics.window_start.is_none() {
+                telemetry_start = None;
             }
-        }
-        let launcher_frame = launcher_browser.borrow_mut().frame(now_ms);
-        if launcher_frame.phase != BrowsePhase::Settled {
-            launcher_dirty.set(true);
-        }
-        probe.set_launcher_motion_state(
-            match launcher_frame.phase {
-                BrowsePhase::Settled => "settled",
-                BrowsePhase::Sliding => "sliding",
-                BrowsePhase::Held => "held",
+            if telemetry_start.is_none() && session.borrow().metrics.window_start.is_some() {
+                match framebuffer.presentation_telemetry() {
+                    Ok(t)
+                        if t.lifetime_invariant_valid() && t.magik_ownership() && !t.pending() =>
+                    {
+                        telemetry_start = Some((
+                            t.owned_vblank_count,
+                            t.presented_vblank_count,
+                            t.repeated_vblank_count,
+                            t.ownership_loss_count,
+                        ));
+                    }
+                    _ => {
+                        session.borrow_mut().metrics.context["launcher_telemetry_error"] =
+                            "invalid start telemetry".into()
+                    }
+                }
             }
-            .into(),
-        );
-        if launcher_frame.selected < launcher_cards.len() {
-            probe.set_launcher_selection(launcher_cards[launcher_frame.selected].name.into());
-        }
-        if launcher_frame.target < launcher_cards.len() {
-            probe.set_launcher_target(launcher_cards[launcher_frame.target].name.into());
-        }
-        slint::platform::update_timers_and_animations();
-        if session.borrow_mut().tick(width, height)? {
+            if completed {
+                if let Some((owned, presented, repeated, losses)) = telemetry_start.take() {
+                    match framebuffer.presentation_telemetry() {
+                        Ok(t)
+                            if t.lifetime_invariant_valid()
+                                && t.magik_ownership()
+                                && !t.pending() =>
+                        {
+                            let mut session = session.borrow_mut();
+                            let c = &mut session.metrics.context;
+                            c["launcher_owned_vblanks"] =
+                                u64::from(t.owned_vblank_count.wrapping_sub(owned)).into();
+                            c["launcher_presented_vblanks"] =
+                                u64::from(t.presented_vblank_count.wrapping_sub(presented)).into();
+                            c["launcher_repeated_vblanks"] =
+                                u64::from(t.repeated_vblank_count.wrapping_sub(repeated)).into();
+                            c["launcher_ownership_losses"] =
+                                u64::from(t.ownership_loss_count.wrapping_sub(losses)).into();
+                        }
+                        _ => {
+                            session.borrow_mut().metrics.context["launcher_telemetry_error"] =
+                                "invalid end telemetry".into()
+                        }
+                    }
+                }
+                control
+                    .borrow_mut()
+                    .input(false, measure_direction.get(), false, now_ms);
+                measure_running.set(false);
+                probe.set_launcher_measurement("draining".into());
+            }
+        } else if completed {
             motion_timer.stop();
             probe.set_motion_running(false);
             probe.set_motion_complete(true);
         }
-        let session_for_frame = session.clone();
-        let mode_for_frame = launcher_mode.clone();
-        let dirty_for_frame = launcher_dirty.clone();
-        let probe_for_frame = probe.as_weak();
-        let launcher_cached_for_frame = launcher_cached.clone();
-        let launcher_frame_for_frame = launcher_frame;
-        let rendered = window.draw_if_needed(|renderer, redraw_requested| {
-            if mode_for_frame.get() {
-                if !dirty_for_frame.replace(false) {
-                    return;
-                }
-                *launcher_cached_for_frame.borrow_mut() = None;
+
+        let redraw_requested = window.redraw_pending.replace(false);
+        let frame = if pending.is_none() {
+            Some(control.borrow_mut().frame(now_ms))
+        } else {
+            None
+        };
+        if pending.is_none() {
+            let launcher_frame = frame.expect("no pending presentation");
+            let render_launcher = launcher_mode.get()
+                && (launcher_dirty.get() || last_presented != Some(launcher_frame));
+            if render_launcher || (!launcher_mode.get() && redraw_requested) {
                 let render_start = Instant::now();
-                if launcher_cached_for_frame.borrow().is_none() {
-                    *launcher_cached_for_frame.borrow_mut() = Some(
-                        launcher_scene.render_browse(
-                            LauncherData {
-                                cards: &launcher_cards,
-                                selected: launcher_frame_for_frame.selected,
-                                library_games: 6842,
-                                collections: 18,
-                                favourites: 126,
-                                clock: "21:37",
-                            },
-                            (launcher_frame_for_frame.phase != BrowsePhase::Settled)
-                                .then_some(launcher_frame_for_frame),
-                        ),
-                    );
-                }
-                let packed = launcher_cached_for_frame.borrow();
-                let packed = packed
-                    .as_deref()
-                    .expect("launcher cache was just populated");
-                for (destination, source) in cached.iter_mut().zip(packed) {
-                    *destination = Rgb565Pixel(source.0);
+                if render_launcher {
+                    probe.set_launcher_ready(false);
+                    prepared.render_into(launcher_frame, &mut scene_pixels);
+                    for (destination, source) in cached.iter_mut().zip(&scene_pixels) {
+                        *destination = Rgb565Pixel(source.0);
+                    }
+                } else {
+                    window.renderer.render(&mut cached, width);
                 }
                 let render_us = render_start.elapsed().as_micros() as u64;
                 let stride = framebuffer.stride_pixels();
                 for row in 0..height {
-                    let destination =
-                        &mut framebuffer.pixels_mut()[row * stride..row * stride + width];
-                    let source = &cached[row * width..(row + 1) * width];
-                    for (destination, source) in destination.iter_mut().zip(source) {
+                    for (destination, source) in framebuffer.pixels_mut()
+                        [row * stride..row * stride + width]
+                        .iter_mut()
+                        .zip(&cached[row * width..(row + 1) * width])
+                    {
                         *destination = Rgb565(source.0);
                     }
                 }
-                let mut session = session_for_frame.borrow_mut();
-                let metrics = &mut session.metrics;
-                metrics.last_render_us = render_us;
-                metrics.counters.render_us += render_us;
+                let mut session = session.borrow_mut();
+                session.metrics.last_render_us = render_us;
+                session.metrics.counters.render_us += render_us;
                 match framebuffer.post() {
-                    Ok(_) => metrics.counters.posts += 1,
+                    Ok(_) => {
+                        session.metrics.counters.posts += 1;
+                        pending = Some((render_launcher.then_some(launcher_frame), render_start));
+                    }
                     Err(error) => {
-                        metrics.counters.rejections += 1;
-                        metrics.error = Some(error.to_string());
-                        return;
+                        session.metrics.counters.rejections += 1;
+                        session.metrics.error = Some(error.to_string());
+                        launcher_dirty.set(true);
+                        window.redraw_pending.set(true);
                     }
                 }
-                match framebuffer.settle_pending() {
-                    Ok(Some(presented)) => {
-                        metrics.counters.flips += 1;
-                        metrics.counters.drops +=
-                            metrics.last_physical_drop_count.map_or(0, |previous| {
-                                u64::from(presented.drop_count.wrapping_sub(previous))
-                            });
-                        metrics.last_physical_drop_count = Some(presented.drop_count);
-                        metrics.counters.presentations += 1;
-                        metrics.counters.render_to_present_us +=
-                            render_start.elapsed().as_micros() as u64;
-                        if let Some(probe) = probe_for_frame.upgrade() {
-                            probe.set_launcher_ready(true);
-                        }
-                    }
-                    _ => metrics.error = Some("physical latch did not settle".into()),
-                }
-                return;
             }
-            if !redraw_requested {
-                return;
-            }
-            let render_start = Instant::now();
-            renderer.render(&mut cached, width);
-            let render_us = render_start.elapsed().as_micros() as u64;
-            for (destination, source) in framebuffer.pixels_mut().iter_mut().zip(&cached) {
-                *destination = Rgb565(source.0);
-            }
-            let mut session = session_for_frame.borrow_mut();
-            let metrics = &mut session.metrics;
-            match framebuffer.post() {
-                Ok(_) => metrics.counters.posts += 1,
-                Err(error) => {
-                    metrics.counters.rejections += 1;
-                    metrics.error = Some(error.to_string());
-                    return;
-                }
-            }
+        }
+        let mut presented_this_loop = false;
+        if let Some((posted_frame, started)) = pending {
             match framebuffer.settle_pending() {
-                Ok(Some(presented)) => {
+                Ok(Some(receipt)) => {
+                    pending = None;
+                    presented_this_loop = true;
+                    let mut session = session.borrow_mut();
+                    let metrics = &mut session.metrics;
                     metrics.counters.flips += 1;
+                    metrics.counters.presentations += 1;
                     metrics.counters.drops +=
                         metrics.last_physical_drop_count.map_or(0, |previous| {
-                            u64::from(presented.drop_count.wrapping_sub(previous))
+                            u64::from(receipt.drop_count.wrapping_sub(previous))
                         });
-                    metrics.last_physical_drop_count = Some(presented.drop_count);
+                    metrics.last_physical_drop_count = Some(receipt.drop_count);
+                    metrics.counters.render_to_present_us += started.elapsed().as_micros() as u64;
+                    if let Some(frame) = posted_frame {
+                        last_presented = Some(frame);
+                        launcher_dirty.set(false);
+                        if probe.get_launcher_selection() != launcher_labels[frame.selected] {
+                            probe.set_launcher_selection(launcher_labels[frame.selected].clone());
+                        }
+                        probe.set_launcher_selected_index(frame.selected as i32);
+                        if probe.get_launcher_target() != launcher_labels[frame.target] {
+                            probe.set_launcher_target(launcher_labels[frame.target].clone());
+                        }
+                        let phase = match frame.phase {
+                            BrowsePhase::Settled => "settled",
+                            BrowsePhase::Sliding => "sliding",
+                            BrowsePhase::Held => "held",
+                        };
+                        if probe.get_launcher_motion_state() != phase {
+                            probe.set_launcher_motion_state(phase.into());
+                        }
+                        probe.set_launcher_ready(frame.phase == BrowsePhase::Settled);
+                        if frame.phase == BrowsePhase::Settled
+                            && probe.get_launcher_measurement() == "draining"
+                        {
+                            probe.set_launcher_measurement("complete".into());
+                        }
+                    } else {
+                        last_presented = None;
+                    }
                 }
-                _ => {
-                    metrics.error = Some("physical latch did not settle".into());
-                    return;
+                Ok(None) => {
+                    session.borrow_mut().metrics.error =
+                        Some("posted frame missing pending latch".into());
+                    pending = None;
+                    launcher_dirty.set(true);
+                }
+                Err(error) => {
+                    session.borrow_mut().metrics.error = Some(error.to_string());
+                    // Retain pending state and retry settlement before touching a slot.
                 }
             }
-            metrics.counters.presentations += 1;
-            metrics.last_render_us = render_us;
-            metrics.counters.render_us += render_us;
-            metrics.counters.render_to_present_us += render_start.elapsed().as_micros() as u64;
-        });
+        }
         session.borrow_mut().preview(&cached, width, height);
-        if !rendered {
+        if !presented_this_loop {
             std::thread::sleep(Duration::from_millis(2));
         }
     }

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -153,8 +153,17 @@ impl Platform for ProbePlatform {
 }
 
 fn main() -> Result<(), String> {
-    let plan =
-        query_main_display_plan().map_err(|error| format!("resolve Main display: {error}"))?;
+    // A supervised child inherits Main's display contracts. Do not request the
+    // command FIFO while Main is waiting for this child's ready acknowledgement.
+    let plan = if std::env::var_os("MISTER_MAGIK_STARTUP_TOKEN").is_some() {
+        let mut fpga =
+            mister_magik_mister_runtime::fpga::Fpga::open().map_err(|e| e.to_string())?;
+        mister_magik_mister_runtime::display_plan::detect_runtime_display_plan(&mut fpga)
+            .map_err(|e| e.to_string())?
+            .plan
+    } else {
+        query_main_display_plan().map_err(|error| format!("resolve Main display: {error}"))?
+    };
     let (width, height) = (plan.fb_w, plan.fb_h);
     let (scan_width, scan_height) = (plan.scan_w, plan.scan_h);
     let mut framebuffer =
@@ -400,7 +409,16 @@ fn main() -> Result<(), String> {
 
     let mut cached = vec![Rgb565Pixel(0); width * height];
     let mut scene_pixels = vec![ScenePixel(0); width * height];
+    if std::env::var_os("MISTER_MAGIK_STARTUP_TOKEN").is_some() {
+        prepared.render_into(control.borrow_mut().frame(0), &mut scene_pixels);
+        let startup_pixels: Vec<_> = scene_pixels.iter().map(|p| Rgb565(p.0)).collect();
+        mister_magik_mister_runtime::main_ready::notify_main_ready(
+            &mut framebuffer,
+            &startup_pixels,
+        )?;
+    }
     let mut launcher_input: Option<MainProxyInput> = None;
+    let mut physical_input_edges = 0_u64;
     let mut input_events = Vec::with_capacity(INPUT_BATCH_CAPACITY);
     let mut next_input_open_ms = 0;
     let mut last_presented: Option<BrowseFrame> = None;
@@ -432,6 +450,13 @@ fn main() -> Result<(), String> {
                 Ok(()) => {
                     if launcher_mode.get() {
                         for event in input_events.drain(..) {
+                            physical_input_edges += 1;
+                            let mut session = session.borrow_mut();
+                            session.metrics.context["physical_input_edges"] =
+                                physical_input_edges.into();
+                            session.metrics.context["physical_input_last"] =
+                                format!("{:?}:{:?}", event.direction, event.phase).into();
+                            drop(session);
                             let direction = match event.direction {
                                 MainInputDirection::Left => BrowseDirection::Left,
                                 MainInputDirection::Right => BrowseDirection::Right,
@@ -592,6 +617,8 @@ fn main() -> Result<(), String> {
                     metrics.counters.render_to_present_us += started.elapsed().as_micros() as u64;
                     if let Some(frame) = posted_frame {
                         last_presented = Some(frame);
+                        metrics.context["selected_category"] =
+                            launcher_cards[frame.selected].name.into();
                         launcher_dirty.set(false);
                         if probe.get_launcher_selection() != launcher_labels[frame.selected] {
                             probe.set_launcher_selection(launcher_labels[frame.selected].clone());

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -217,7 +217,7 @@ fn main() -> Result<(), String> {
             colour: 0x88a6,
         },
         LauncherCard {
-            name: "SNK",
+            name: "SNK NEOGEO",
             games: 324,
             colour: 0x195f,
         },
@@ -251,6 +251,7 @@ fn main() -> Result<(), String> {
         if let Some(probe) = weak.upgrade() {
             probe.set_launcher_mode(true);
             probe.set_launcher_ready(false);
+            probe.set_motion_running(false);
         }
     });
     let mode = launcher_mode.clone();

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -5,9 +5,13 @@
 
 use mister_magik_framebuffer_scenes::Rgb565Pixel as ScenePixel;
 use mister_magik_framebuffer_scenes::launcher::{LauncherCard, LauncherData, LauncherScene};
+use mister_magik_framebuffer_scenes::launcher_navigation::{
+    BrowseDirection, BrowsePhase, LauncherBrowser,
+};
 use mister_magik_mister_runtime::display_plan::query_main_display_plan;
 use mister_magik_mister_runtime::framebuffer::hidden_latch::HiddenLatchPresenter;
 use mister_magik_mister_runtime::framebuffer::rgb565::Rgb565;
+use mister_magik_mister_runtime::main_input::{MainInputDirection, MainInputPhase, MainProxyInput};
 use slint::platform::software_renderer::{RepaintBufferType, Rgb565Pixel, SoftwareRenderer};
 use slint::platform::{EventLoopProxy, Platform, WindowAdapter};
 use slint::{EventLoopError, PhysicalSize, Window};
@@ -235,6 +239,14 @@ fn main() -> Result<(), String> {
             colour: 0xb9a6,
         },
     ];
+    let launcher_browser = Rc::new(RefCell::new(LauncherBrowser::new(launcher_cards.len(), 0)));
+    launcher_browser.borrow_mut().neutral();
+    let launcher_input = Rc::new(RefCell::new(MainProxyInput::open().ok()));
+    probe.set_launcher_input_source(if launcher_input.borrow().is_some() {
+        "main-proxy".into()
+    } else {
+        "main-proxy-unavailable".into()
+    });
     probe.set_launcher_mode(true);
     probe.set_launcher_ready(false);
     probe.set_launcher_selection("ARCADE".into());
@@ -251,6 +263,43 @@ fn main() -> Result<(), String> {
             probe.set_launcher_ready(false);
             probe.set_motion_running(false);
         }
+    });
+    let launcher_epoch = Rc::new(Instant::now());
+    let weak = probe.as_weak();
+    let browser = launcher_browser.clone();
+    let dirty = launcher_dirty.clone();
+    let epoch = launcher_epoch.clone();
+    probe.on_launcher_left_down(move || {
+        browser
+            .borrow_mut()
+            .press(BrowseDirection::Left, epoch.elapsed().as_millis() as u64);
+        dirty.set(true);
+        if let Some(probe) = weak.upgrade() {
+            probe.set_launcher_motion_state("sliding".into());
+        }
+    });
+    let browser = launcher_browser.clone();
+    probe.on_launcher_left_up(move || browser.borrow_mut().release(BrowseDirection::Left));
+    let weak = probe.as_weak();
+    let browser = launcher_browser.clone();
+    let dirty = launcher_dirty.clone();
+    let epoch = launcher_epoch.clone();
+    probe.on_launcher_right_down(move || {
+        browser
+            .borrow_mut()
+            .press(BrowseDirection::Right, epoch.elapsed().as_millis() as u64);
+        dirty.set(true);
+        if let Some(probe) = weak.upgrade() {
+            probe.set_launcher_motion_state("sliding".into());
+        }
+    });
+    let browser = launcher_browser.clone();
+    probe.on_launcher_right_up(move || browser.borrow_mut().release(BrowseDirection::Right));
+    let browser = launcher_browser.clone();
+    let dirty = launcher_dirty.clone();
+    probe.on_launcher_input_reset(move || {
+        browser.borrow_mut().reset();
+        dirty.set(true);
     });
     let mode = launcher_mode.clone();
     let dirty = launcher_dirty.clone();
@@ -306,7 +355,61 @@ fn main() -> Result<(), String> {
     });
 
     let mut cached = vec![Rgb565Pixel(0); width * height];
+    let mut launcher_input = launcher_input.borrow_mut().take();
+    let mut input_events = Vec::with_capacity(8);
+    let mut last_input_open_ms = 0_u64;
     loop {
+        let now_ms = launcher_epoch.elapsed().as_millis() as u64;
+        if let Some(input) = launcher_input.as_mut() {
+            if input.poll_into(&mut input_events).is_err() {
+                launcher_browser.borrow_mut().reset();
+                launcher_dirty.set(true);
+                launcher_input = None;
+                probe.set_launcher_input_source("main-proxy-unavailable".into());
+            }
+            for event in input_events.drain(..) {
+                let mut browser = launcher_browser.borrow_mut();
+                match (event.direction, event.phase) {
+                    (MainInputDirection::Left, MainInputPhase::Pressed) => {
+                        browser.press(BrowseDirection::Left, now_ms)
+                    }
+                    (MainInputDirection::Left, MainInputPhase::Released) => {
+                        browser.release(BrowseDirection::Left)
+                    }
+                    (MainInputDirection::Right, MainInputPhase::Pressed) => {
+                        browser.press(BrowseDirection::Right, now_ms)
+                    }
+                    (MainInputDirection::Right, MainInputPhase::Released) => {
+                        browser.release(BrowseDirection::Right)
+                    }
+                }
+                launcher_dirty.set(true);
+            }
+        } else if now_ms.saturating_sub(last_input_open_ms) >= 1_000 {
+            last_input_open_ms = now_ms;
+            if let Ok(input) = MainProxyInput::open() {
+                launcher_input = Some(input);
+                probe.set_launcher_input_source("main-proxy".into());
+            }
+        }
+        let launcher_frame = launcher_browser.borrow_mut().frame(now_ms);
+        if launcher_frame.phase != BrowsePhase::Settled {
+            launcher_dirty.set(true);
+        }
+        probe.set_launcher_motion_state(
+            match launcher_frame.phase {
+                BrowsePhase::Settled => "settled",
+                BrowsePhase::Sliding => "sliding",
+                BrowsePhase::Held => "held",
+            }
+            .into(),
+        );
+        if launcher_frame.selected < launcher_cards.len() {
+            probe.set_launcher_selection(launcher_cards[launcher_frame.selected].name.into());
+        }
+        if launcher_frame.target < launcher_cards.len() {
+            probe.set_launcher_target(launcher_cards[launcher_frame.target].name.into());
+        }
         slint::platform::update_timers_and_animations();
         if session.borrow_mut().tick(width, height)? {
             motion_timer.stop();
@@ -318,22 +421,29 @@ fn main() -> Result<(), String> {
         let dirty_for_frame = launcher_dirty.clone();
         let probe_for_frame = probe.as_weak();
         let launcher_cached_for_frame = launcher_cached.clone();
+        let launcher_frame_for_frame = launcher_frame;
         let rendered = window.draw_if_needed(|renderer, redraw_requested| {
             if mode_for_frame.get() {
                 if !dirty_for_frame.replace(false) {
                     return;
                 }
+                *launcher_cached_for_frame.borrow_mut() = None;
                 let render_start = Instant::now();
                 if launcher_cached_for_frame.borrow().is_none() {
-                    *launcher_cached_for_frame.borrow_mut() =
-                        Some(launcher_scene.render(LauncherData {
-                            cards: &launcher_cards,
-                            selected: 0,
-                            library_games: 6842,
-                            collections: 18,
-                            favourites: 126,
-                            clock: "21:37",
-                        }));
+                    *launcher_cached_for_frame.borrow_mut() = Some(
+                        launcher_scene.render_browse(
+                            LauncherData {
+                                cards: &launcher_cards,
+                                selected: launcher_frame_for_frame.selected,
+                                library_games: 6842,
+                                collections: 18,
+                                favourites: 126,
+                                clock: "21:37",
+                            },
+                            (launcher_frame_for_frame.phase != BrowsePhase::Settled)
+                                .then_some(launcher_frame_for_frame),
+                        ),
+                    );
                 }
                 let packed = launcher_cached_for_frame.borrow();
                 let packed = packed

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -3,6 +3,8 @@
 
 //! Deliberately small consumer application for Tooling 2.0.
 
+use mister_magik_framebuffer_scenes::Rgb565Pixel as ScenePixel;
+use mister_magik_framebuffer_scenes::launcher::{LauncherCard, LauncherData, LauncherScene};
 use mister_magik_mister_runtime::framebuffer::hidden_latch::HiddenLatchPresenter;
 use mister_magik_mister_runtime::framebuffer::mapped::MappedRgb565Framebuffer;
 use mister_magik_mister_runtime::framebuffer::rgb565::Rgb565;
@@ -204,6 +206,67 @@ fn main() -> Result<(), String> {
         }
     });
     let motion_timer = Rc::new(slint::Timer::default());
+    let launcher_mode = Rc::new(Cell::new(true));
+    let launcher_dirty = Rc::new(Cell::new(true));
+    let launcher_scene = LauncherScene::new(width, height);
+    let launcher_cached = Rc::new(RefCell::new(None::<Vec<ScenePixel>>));
+    let launcher_cards = [
+        LauncherCard {
+            name: "ARCADE",
+            games: 1752,
+            colour: 0x88a6,
+        },
+        LauncherCard {
+            name: "SNK",
+            games: 324,
+            colour: 0x195f,
+        },
+        LauncherCard {
+            name: "CONSOLES",
+            games: 842,
+            colour: 0xc5b5,
+        },
+        LauncherCard {
+            name: "HANDHELDS",
+            games: 126,
+            colour: 0x2c92,
+        },
+        LauncherCard {
+            name: "COMPUTERS",
+            games: 86,
+            colour: 0xb9a6,
+        },
+    ];
+    probe.set_launcher_mode(true);
+    probe.set_launcher_ready(false);
+    probe.set_launcher_selection("ARCADE".into());
+    let mode = launcher_mode.clone();
+    let dirty = launcher_dirty.clone();
+    let weak = probe.as_weak();
+    let timer = motion_timer.clone();
+    probe.on_show_launcher(move || {
+        mode.set(true);
+        dirty.set(true);
+        timer.stop();
+        if let Some(probe) = weak.upgrade() {
+            probe.set_launcher_mode(true);
+            probe.set_launcher_ready(false);
+        }
+    });
+    let mode = launcher_mode.clone();
+    let dirty = launcher_dirty.clone();
+    let weak = probe.as_weak();
+    let timer = motion_timer.clone();
+    probe.on_show_probe(move || {
+        mode.set(false);
+        dirty.set(false);
+        timer.stop();
+        if let Some(probe) = weak.upgrade() {
+            probe.set_launcher_mode(false);
+            probe.set_launcher_ready(false);
+            probe.set_motion_running(false);
+        }
+    });
     let session = Rc::new(RefCell::new(
         Session::from_environment().ok_or("missing tooling state root")?,
     ));
@@ -242,7 +305,75 @@ fn main() -> Result<(), String> {
             probe.set_motion_complete(true);
         }
         let session_for_frame = session.clone();
+        let mode_for_frame = launcher_mode.clone();
+        let dirty_for_frame = launcher_dirty.clone();
+        let probe_for_frame = probe.as_weak();
+        let launcher_cached_for_frame = launcher_cached.clone();
         let rendered = window.draw_if_needed(|renderer| {
+            if mode_for_frame.get() {
+                if !dirty_for_frame.replace(false) {
+                    return;
+                }
+                let render_start = Instant::now();
+                if launcher_cached_for_frame.borrow().is_none() {
+                    *launcher_cached_for_frame.borrow_mut() =
+                        Some(launcher_scene.render(LauncherData {
+                            cards: &launcher_cards,
+                            selected: 0,
+                            library_games: 6842,
+                            collections: 18,
+                            favourites: 126,
+                            clock: "21:37",
+                        }));
+                }
+                let packed = launcher_cached_for_frame.borrow();
+                let packed = packed
+                    .as_deref()
+                    .expect("launcher cache was just populated");
+                for (destination, source) in cached.iter_mut().zip(packed) {
+                    *destination = Rgb565Pixel(source.0);
+                }
+                let render_us = render_start.elapsed().as_micros() as u64;
+                let stride = framebuffer.stride_pixels();
+                for row in 0..height {
+                    let destination =
+                        &mut framebuffer.pixels_mut()[row * stride..row * stride + width];
+                    let source = &cached[row * width..(row + 1) * width];
+                    for (destination, source) in destination.iter_mut().zip(source) {
+                        *destination = Rgb565(source.0);
+                    }
+                }
+                let mut session = session_for_frame.borrow_mut();
+                let metrics = &mut session.metrics;
+                metrics.last_render_us = render_us;
+                metrics.counters.render_us += render_us;
+                match framebuffer.post() {
+                    Ok(_) => metrics.counters.posts += 1,
+                    Err(error) => {
+                        metrics.counters.rejections += 1;
+                        metrics.error = Some(error.to_string());
+                        return;
+                    }
+                }
+                match framebuffer.settle_pending() {
+                    Ok(Some(presented)) => {
+                        metrics.counters.flips += 1;
+                        metrics.counters.drops +=
+                            metrics.last_physical_drop_count.map_or(0, |previous| {
+                                u64::from(presented.drop_count.wrapping_sub(previous))
+                            });
+                        metrics.last_physical_drop_count = Some(presented.drop_count);
+                        metrics.counters.presentations += 1;
+                        metrics.counters.render_to_present_us +=
+                            render_start.elapsed().as_micros() as u64;
+                        if let Some(probe) = probe_for_frame.upgrade() {
+                            probe.set_launcher_ready(true);
+                        }
+                    }
+                    _ => metrics.error = Some("physical latch did not settle".into()),
+                }
+                return;
+            }
             let render_start = Instant::now();
             renderer.render(&mut cached, width);
             let render_us = render_start.elapsed().as_micros() as u64;

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -261,6 +261,35 @@ fn main() -> Result<(), String> {
     let launcher_labels: Vec<slint::SharedString> =
         launcher_cards.iter().map(|card| card.name.into()).collect();
     let control = Rc::new(RefCell::new(LauncherControl::new(launcher_cards.len())));
+    let reverse_flip = Rc::new(Cell::new(true));
+    {
+        let control = control.clone();
+        let dirty = launcher_dirty.clone();
+        let reverse = reverse_flip.clone();
+        let weak = probe.as_weak();
+        probe.on_configure_flips(move |flips, reversed| {
+            control.borrow_mut().configure(flips);
+            reverse.set(reversed);
+            dirty.set(true);
+            if let Some(probe) = weak.upgrade() {
+                probe.set_launcher_flip_mode(if flips { "perspective" } else { "slides" }.into());
+                probe.set_launcher_flip_mapping(if reversed { "reverse" } else { "normal" }.into());
+                probe.set_launcher_pose(-1);
+            }
+        });
+    }
+    {
+        let control = control.clone();
+        let dirty = launcher_dirty.clone();
+        let weak = probe.as_weak();
+        probe.on_preview_flip(move |right, progress| {
+            control.borrow_mut().preview(right, progress.max(0) as u32);
+            dirty.set(true);
+            if let Some(probe) = weak.upgrade() {
+                probe.set_launcher_pose(-1);
+            }
+        });
+    }
     let launcher_epoch = Rc::new(Instant::now());
     let measure_running = Rc::new(Cell::new(false));
     let measure_direction = Rc::new(Cell::new(BrowseDirection::Right));
@@ -279,8 +308,15 @@ fn main() -> Result<(), String> {
         let timer = motion_timer.clone();
         let measure = measure_running.clone();
         let session = session.clone();
+        let window = window.clone();
         move || {
             mode.set(launcher);
+            // Renderer mode is external to Slint's dependency graph. The shared
+            // output buffer currently contains custom pixels, not its last frame.
+            window
+                .renderer
+                .set_repaint_buffer_type(RepaintBufferType::NewBuffer);
+            window.request_redraw();
             dirty.set(launcher);
             control.borrow_mut().reset(false);
             timer.stop();
@@ -424,6 +460,7 @@ fn main() -> Result<(), String> {
     let mut last_presented: Option<BrowseFrame> = None;
     let mut pending: Option<(Option<BrowseFrame>, Instant)> = None;
     let mut telemetry_start: Option<(u32, u32, u32, u32)> = None;
+    let mut flip_sample = None;
     loop {
         window.event_loop.process_pending_callbacks();
         slint::platform::update_timers_and_animations();
@@ -558,18 +595,36 @@ fn main() -> Result<(), String> {
         };
         if pending.is_none() {
             let launcher_frame = frame.expect("no pending presentation");
+            if launcher_mode.get()
+                && launcher_frame.phase == BrowsePhase::Flipping
+                && !control.borrow().is_preview()
+                && flip_sample.is_none()
+                && let Ok(t) = framebuffer.presentation_telemetry()
+                && t.lifetime_invariant_valid()
+                && t.magik_ownership()
+                && !t.pending()
+            {
+                flip_sample = Some((t, session.borrow().metrics.counters.clone()));
+            }
+            if control.borrow().is_preview() || !launcher_mode.get() {
+                flip_sample = None;
+            }
             let render_launcher = launcher_mode.get()
                 && (launcher_dirty.get() || last_presented != Some(launcher_frame));
             if render_launcher || (!launcher_mode.get() && redraw_requested) {
                 let render_start = Instant::now();
                 if render_launcher {
                     probe.set_launcher_ready(false);
+                    prepared.set_reverse_flip(reverse_flip.get());
                     prepared.render_into(launcher_frame, &mut scene_pixels);
                     for (destination, source) in cached.iter_mut().zip(&scene_pixels) {
                         *destination = Rgb565Pixel(source.0);
                     }
                 } else {
                     window.renderer.render(&mut cached, width);
+                    window
+                        .renderer
+                        .set_repaint_buffer_type(RepaintBufferType::ReusedBuffer);
                 }
                 let render_us = render_start.elapsed().as_micros() as u64;
                 let stride = framebuffer.stride_pixels();
@@ -615,6 +670,40 @@ fn main() -> Result<(), String> {
                         });
                     metrics.last_physical_drop_count = Some(receipt.drop_count);
                     metrics.counters.render_to_present_us += started.elapsed().as_micros() as u64;
+                    if posted_frame.is_some_and(|frame| frame.phase != BrowsePhase::Flipping)
+                        && let Some((baseline, counters)) = flip_sample.take()
+                        && let Ok(t) = framebuffer.presentation_telemetry()
+                        && t.lifetime_invariant_valid()
+                        && t.magik_ownership()
+                        && !t.pending()
+                    {
+                        metrics.context["tap_flip_owned_vblanks"] = u64::from(
+                            t.owned_vblank_count
+                                .wrapping_sub(baseline.owned_vblank_count),
+                        )
+                        .into();
+                        metrics.context["tap_flip_presented_vblanks"] = u64::from(
+                            t.presented_vblank_count
+                                .wrapping_sub(baseline.presented_vblank_count),
+                        )
+                        .into();
+                        metrics.context["tap_flip_repeated_vblanks"] = u64::from(
+                            t.repeated_vblank_count
+                                .wrapping_sub(baseline.repeated_vblank_count),
+                        )
+                        .into();
+                        metrics.context["tap_flip_ownership_losses"] = u64::from(
+                            t.ownership_loss_count
+                                .wrapping_sub(baseline.ownership_loss_count),
+                        )
+                        .into();
+                        metrics.context["tap_flip_drops"] =
+                            (metrics.counters.drops - counters.drops).into();
+                        metrics.context["tap_flip_rejections"] =
+                            (metrics.counters.rejections - counters.rejections).into();
+                        metrics.context["tap_flip_render_us"] =
+                            (metrics.counters.render_us - counters.render_us).into();
+                    }
                     if let Some(frame) = posted_frame {
                         last_presented = Some(frame);
                         metrics.context["selected_category"] =
@@ -629,6 +718,7 @@ fn main() -> Result<(), String> {
                         }
                         let phase = match frame.phase {
                             BrowsePhase::Settled => "settled",
+                            BrowsePhase::Flipping => "flipping",
                             BrowsePhase::Sliding => "sliding",
                             BrowsePhase::Held => "held",
                         };
@@ -636,6 +726,8 @@ fn main() -> Result<(), String> {
                             probe.set_launcher_motion_state(phase.into());
                         }
                         probe.set_launcher_ready(frame.phase == BrowsePhase::Settled);
+                        probe.set_launcher_pose(frame.progress_millis as i32);
+                        metrics.context["motion_kind"] = phase.into();
                         if frame.phase == BrowsePhase::Settled
                             && probe.get_launcher_measurement() == "draining"
                         {

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -5,8 +5,8 @@
 
 use mister_magik_framebuffer_scenes::Rgb565Pixel as ScenePixel;
 use mister_magik_framebuffer_scenes::launcher::{LauncherCard, LauncherData, LauncherScene};
+use mister_magik_mister_runtime::display_plan::query_main_display_plan;
 use mister_magik_mister_runtime::framebuffer::hidden_latch::HiddenLatchPresenter;
-use mister_magik_mister_runtime::framebuffer::mapped::MappedRgb565Framebuffer;
 use mister_magik_mister_runtime::framebuffer::rgb565::Rgb565;
 use slint::platform::software_renderer::{RepaintBufferType, Rgb565Pixel, SoftwareRenderer};
 use slint::platform::{EventLoopProxy, Platform, WindowAdapter};
@@ -152,16 +152,17 @@ impl Platform for ProbePlatform {
 }
 
 fn main() -> Result<(), String> {
-    let direct_framebuffer =
-        MappedRgb565Framebuffer::open_current_rgb565().map_err(|error| error.to_string())?;
-    let width = direct_framebuffer.width();
-    let height = direct_framebuffer.height();
-    drop(direct_framebuffer);
-    let mut framebuffer = HiddenLatchPresenter::open(
-        u16::try_from(width).map_err(|error: std::num::TryFromIntError| error.to_string())?,
-        u16::try_from(height).map_err(|error: std::num::TryFromIntError| error.to_string())?,
-    )
-    .map_err(|error| error.to_string())?;
+    let plan =
+        query_main_display_plan().map_err(|error| format!("resolve Main display: {error}"))?;
+    let (width, height) = (plan.fb_w, plan.fb_h);
+    let (scan_width, scan_height) = (plan.scan_w, plan.scan_h);
+    let mut framebuffer =
+        HiddenLatchPresenter::open_for_plan(plan).map_err(|error| error.to_string())?;
+    eprintln!(
+        "mini-display source={width}x{height} destination={}x{} authority=main-display-state",
+        framebuffer.destination_width(),
+        framebuffer.destination_height(),
+    );
     let window = ProbeWindow::new();
     slint::platform::set_platform(Box::new(ProbePlatform {
         window: window.clone(),
@@ -268,6 +269,16 @@ fn main() -> Result<(), String> {
     let session = Rc::new(RefCell::new(
         Session::from_environment().ok_or("missing tooling state root")?,
     ));
+    {
+        let mut session = session.borrow_mut();
+        let context = &mut session.metrics.context;
+        context["source_width"] = (width as u64).into();
+        context["source_height"] = (height as u64).into();
+        context["scan_width"] = u64::from(scan_width).into();
+        context["scan_height"] = u64::from(scan_height).into();
+        context["destination_width"] = (framebuffer.destination_width() as u64).into();
+        context["destination_height"] = (framebuffer.destination_height() as u64).into();
+    }
     let timer = motion_timer.clone();
     let weak = probe.as_weak();
     let session_for_motion = session.clone();

--- a/magik2/probe/src/main.rs
+++ b/magik2/probe/src/main.rs
@@ -85,14 +85,11 @@ impl ProbeWindow {
         })
     }
 
-    fn draw_if_needed(&self, render: impl FnOnce(&SoftwareRenderer)) -> bool {
+    fn draw_if_needed(&self, render: impl FnOnce(&SoftwareRenderer, bool)) -> bool {
         self.event_loop.process_pending_callbacks();
-        if self.redraw_pending.replace(false) {
-            render(&self.renderer);
-            true
-        } else {
-            false
-        }
+        let redraw_requested = self.redraw_pending.replace(false);
+        render(&self.renderer, redraw_requested);
+        redraw_requested
     }
 
     fn set_size(&self, size: PhysicalSize) {
@@ -310,7 +307,7 @@ fn main() -> Result<(), String> {
         let dirty_for_frame = launcher_dirty.clone();
         let probe_for_frame = probe.as_weak();
         let launcher_cached_for_frame = launcher_cached.clone();
-        let rendered = window.draw_if_needed(|renderer| {
+        let rendered = window.draw_if_needed(|renderer, redraw_requested| {
             if mode_for_frame.get() {
                 if !dirty_for_frame.replace(false) {
                     return;
@@ -373,6 +370,9 @@ fn main() -> Result<(), String> {
                     }
                     _ => metrics.error = Some("physical latch did not settle".into()),
                 }
+                return;
+            }
+            if !redraw_requested {
                 return;
             }
             let render_start = Instant::now();

--- a/magik2/probe/ui/probe.slint
+++ b/magik2/probe/ui/probe.slint
@@ -41,6 +41,20 @@ export component Probe inherits Window {
     callback launcher-right-up();
     callback launcher-input-reset();
     callback start-launcher-motion(bool);
+    callback configure-flips(bool, bool);
+    callback preview-flip(bool, int);
+    in-out property <string> launcher-flip-mode: "perspective";
+    in-out property <string> launcher-flip-mapping: "reverse";
+    in-out property <int> launcher-pose: -1;
+    Text { width: 1px; height: 1px; opacity: 0; accessible-role: text; accessible-label: "launcher-flip-mode"; accessible-value: root.launcher-flip-mode; }
+    Text { width: 1px; height: 1px; opacity: 0; accessible-role: text; accessible-label: "launcher-flip-mapping"; accessible-value: root.launcher-flip-mapping; }
+    Text { width: 1px; height: 1px; opacity: 0; accessible-role: text; accessible-label: "launcher-pose"; accessible-value: "" + root.launcher-pose; }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-flips-reverse"; accessible-action-default => { root.configure-flips(true, true); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-flips-normal"; accessible-action-default => { root.configure-flips(true, false); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-slides-only"; accessible-action-default => { root.configure-flips(false, true); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-pose-right-early"; accessible-action-default => { root.preview-flip(true, 150); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-pose-right-late"; accessible-action-default => { root.preview-flip(true, 310); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-pose-left-early"; accessible-action-default => { root.preview-flip(false, 150); } }
 
     Rectangle {
         x: 16px; y: 16px; width: parent.width - 32px; height: 48px;

--- a/magik2/probe/ui/probe.slint
+++ b/magik2/probe/ui/probe.slint
@@ -19,16 +19,43 @@ export component Probe inherits Window {
     in-out property <int> motion-step: 0;
     in-out property <bool> motion-running: false;
     in-out property <bool> motion-complete: false;
+    in-out property <bool> launcher-mode: false;
+    in-out property <bool> launcher-ready: false;
+    in-out property <string> launcher-selection: "ARCADE";
+    in-out property <bool> launcher-fixtures: true;
     in property <string> build-label: "Mini-MagiK";
     callback increment();
     callback reset();
     callback toggle-details();
     callback start-motion();
+    callback show-probe();
+    callback show-launcher();
 
     Rectangle {
         x: 16px; y: 16px; width: parent.width - 32px; height: 48px;
         background: #1f2937; border-radius: 6px;
         Text { x: 14px; y: 13px; text: root.build-label; color: #dbeafe; font-size: 18px; accessible-role: text; accessible-label: "build-label"; accessible-value: root.build-label; }
+    }
+
+    launcher-mode-button := Rectangle {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: button; accessible-label: "show-launcher";
+        accessible-action-default => { root.show-launcher(); }
+    }
+    probe-mode-button := Rectangle {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: button; accessible-label: "show-probe";
+        accessible-action-default => { root.show-probe(); }
+    }
+    launcher-ready-state := Text {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-ready";
+        accessible-value: root.launcher-ready ? "presented" : "not-presented";
+    }
+    launcher-selection-state := Text {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-selection";
+        accessible-value: root.launcher-selection;
     }
 
     Rectangle {

--- a/magik2/probe/ui/probe.slint
+++ b/magik2/probe/ui/probe.slint
@@ -57,6 +57,11 @@ export component Probe inherits Window {
         accessible-role: text; accessible-label: "launcher-selection";
         accessible-value: root.launcher-selection;
     }
+    launcher-fixtures-state := Text {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-fixtures";
+        accessible-value: root.launcher-fixtures ? "fixture-data" : "catalog-data";
+    }
 
     Rectangle {
         x: 16px; y: 80px; width: 250px; height: 160px;

--- a/magik2/probe/ui/probe.slint
+++ b/magik2/probe/ui/probe.slint
@@ -23,6 +23,9 @@ export component Probe inherits Window {
     in-out property <bool> launcher-ready: false;
     in-out property <string> launcher-selection: "ARCADE";
     in-out property <bool> launcher-fixtures: true;
+    in-out property <string> launcher-target: "ARCADE";
+    in-out property <string> launcher-motion-state: "settled";
+    in-out property <string> launcher-input-source: "main-proxy-unavailable";
     in property <string> build-label: "Mini-MagiK";
     callback increment();
     callback reset();
@@ -30,6 +33,11 @@ export component Probe inherits Window {
     callback start-motion();
     callback show-probe();
     callback show-launcher();
+    callback launcher-left-down();
+    callback launcher-left-up();
+    callback launcher-right-down();
+    callback launcher-right-up();
+    callback launcher-input-reset();
 
     Rectangle {
         x: 16px; y: 16px; width: parent.width - 32px; height: 48px;
@@ -61,6 +69,21 @@ export component Probe inherits Window {
         x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
         accessible-role: text; accessible-label: "launcher-fixtures";
         accessible-value: root.launcher-fixtures ? "fixture-data" : "catalog-data";
+    }
+    launcher-target-state := Text {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-target";
+        accessible-value: root.launcher-target;
+    }
+    launcher-motion-state-state := Text {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-motion-state";
+        accessible-value: root.launcher-motion-state;
+    }
+    launcher-input-source-state := Text {
+        x: 0px; y: 0px; width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-input-source";
+        accessible-value: root.launcher-input-source;
     }
 
     Rectangle {

--- a/magik2/probe/ui/probe.slint
+++ b/magik2/probe/ui/probe.slint
@@ -26,6 +26,8 @@ export component Probe inherits Window {
     in-out property <string> launcher-target: "ARCADE";
     in-out property <string> launcher-motion-state: "settled";
     in-out property <string> launcher-input-source: "main-proxy-unavailable";
+    in-out property <string> launcher-measurement: "idle";
+    in-out property <int> launcher-selected-index: 0;
     in property <string> build-label: "Mini-MagiK";
     callback increment();
     callback reset();
@@ -38,6 +40,7 @@ export component Probe inherits Window {
     callback launcher-right-down();
     callback launcher-right-up();
     callback launcher-input-reset();
+    callback start-launcher-motion(bool);
 
     Rectangle {
         x: 16px; y: 16px; width: parent.width - 32px; height: 48px;
@@ -85,6 +88,24 @@ export component Probe inherits Window {
         accessible-role: text; accessible-label: "launcher-input-source";
         accessible-value: root.launcher-input-source;
     }
+    Text {
+        width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-selected-index";
+        accessible-value: "" + root.launcher-selected-index;
+    }
+    Text {
+        width: 1px; height: 1px; opacity: 0;
+        accessible-role: text; accessible-label: "launcher-measurement";
+        accessible-value: root.launcher-measurement;
+    }
+    // Automation actions only: the custom framebuffer never renders these.
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-left-down"; accessible-action-default => { root.launcher-left-down(); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-left-up"; accessible-action-default => { root.launcher-left-up(); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-right-down"; accessible-action-default => { root.launcher-right-down(); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-right-up"; accessible-action-default => { root.launcher-right-up(); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-input-reset"; accessible-action-default => { root.launcher-input-reset(); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-start-right-motion"; accessible-action-default => { root.start-launcher-motion(true); } }
+    Rectangle { width: 1px; height: 1px; opacity: 0; accessible-role: button; accessible-label: "launcher-start-left-motion"; accessible-action-default => { root.start-launcher-motion(false); } }
 
     Rectangle {
         x: 16px; y: 80px; width: 250px; height: 160px;

--- a/magik2/scenarios/actions.py
+++ b/magik2/scenarios/actions.py
@@ -33,12 +33,29 @@ def smoke(
         lambda: not _exists(application, "details-panel"), "details panel did not close"
     )
     one_element(application, "show-launcher").invoke_accessible_default_action()
+    one_element(application, "launcher-input-reset").invoke_accessible_default_action()
     ready = _text_element(application, "launcher-ready")
     _wait(lambda: _value_is(ready, "presented"), "launcher was not latched")
     selection = _text_element(application, "launcher-selection")
     _expect_value(selection, "ARCADE")
     fixtures = _text_element(application, "launcher-fixtures")
     _expect_value(fixtures, "fixture-data")
+    input_source = _text_element(application, "launcher-input-source")
+    _wait(lambda: _value_is(input_source, "main-proxy"), "Main mapped input is not ready")
+    # The native readiness gate verifies Main ownership. Do not run a device
+    # operation inside the test session: it owns the same lifecycle lane.
+    if not agent.status().fields.get("ready"):
+        raise AssertionError("Main-supervised Mini is not ready")
+    # Bounded navigation smoke, including the cyclic boundary in both directions.
+    for direction, expected in [
+        ("right", "SNK NEOGEO"), ("left", "ARCADE"),
+        ("left", "COMPUTERS"), ("right", "ARCADE"),
+        ("right", "SNK NEOGEO"),
+    ]:
+        try:
+            _mini_tap(application, direction, expected)
+        except AssertionError as error:
+            raise AssertionError(f"{error}; metrics={agent.metrics()}") from error
     fields, pixels = agent.capture_framebuffer()
     png, metadata = capture_png(fields, pixels, "raw")
     screenshot_path.write_bytes(png)
@@ -49,6 +66,9 @@ def smoke(
         "screenshot": screenshot_path.name,
         "capture_source": metadata["source"],
         "capture_sequence": metadata["frame_sequence"],
+        "selected_category": selection.accessible_value,
+        "input_source": input_source.accessible_value,
+        "physical_joystick_verified": False,
         **idle,
         **display,
     }
@@ -144,7 +164,7 @@ def validate_window(
         or value["latch_rejections"]
     ):
         raise AssertionError(
-            "physical presentation failed: drops, rejections, or unmatched latches"
+            f"physical presentation failed: drops, rejections, or unmatched latches: {value}"
         )
     return {**value, "physical_evidence_valid": True}
 
@@ -247,6 +267,67 @@ def launcher_smoke(application, screenshot_path, expected_sha256):
         raise AssertionError("launcher input unavailable: " + "; ".join(errors))
     screenshot(application, screenshot_path)
     return {"sha256": expected_sha256, "screenshot": screenshot_path.name}
+
+
+def _mini_tap(application, direction, expected):
+    # Resolve both handles first: walking the remote tree while pressed would
+    # turn a nominal tap into a real hold (and correctly trigger repeat).
+    down = one_element(application, f"launcher-{direction}-down")
+    up = one_element(application, f"launcher-{direction}-up")
+    down.invoke_accessible_default_action()
+    up.invoke_accessible_default_action()
+    selection = _text_element(application, "launcher-selection")
+    ready = _text_element(application, "launcher-ready")
+    try:
+        _wait(lambda: _value_is(selection, expected) and _value_is(ready, "presented"),
+              f"{direction} tap did not latch {expected}")
+    except AssertionError as error:
+        state = _text_element(application, "launcher-motion-state").accessible_value
+        target = _text_element(application, "launcher-target").accessible_value
+        raise AssertionError(f"{error}; selection={selection.accessible_value}, ready={ready.accessible_value}, state={state}, target={target}") from error
+
+
+def validate_launcher_motion(metrics, expected_sha256):
+    if metrics.get("sha256") != expected_sha256:
+        raise AssertionError("launcher measurement belongs to another artifact")
+    window = validate_window(metrics.get("window"), instrumented=False, seconds=5)
+    context = metrics.get("context", {})
+    names = ("launcher_owned_vblanks", "launcher_presented_vblanks",
+             "launcher_repeated_vblanks", "launcher_ownership_losses")
+    if (context.get("workload") != "launcher-slide"
+            or context.get("launcher_telemetry_error")
+            or any(type(context.get(name)) is not int or context[name] < 0 for name in names)):
+        raise AssertionError("launcher-specific physical telemetry is unavailable")
+    if (context["launcher_owned_vblanks"] <= 0
+            or context["launcher_owned_vblanks"] != context["launcher_presented_vblanks"] + context["launcher_repeated_vblanks"]
+            or context["launcher_ownership_losses"]):
+        raise AssertionError("launcher physical telemetry is inconsistent")
+    return {**window, **{name: context[name] for name in names},
+            "no_physical_repeats": context["launcher_repeated_vblanks"] == 0}
+
+
+def launcher_motion(application, agent, direction="right"):
+    """Device-clock launcher measurement, separate from the retained Slint demo."""
+    one_element(application, "show-launcher").invoke_accessible_default_action()
+    ready = _text_element(application, "launcher-ready")
+    _wait(lambda: _value_is(ready, "presented"), "launcher was not latched")
+    one_element(application, f"launcher-start-{direction}-motion").invoke_accessible_default_action()
+    # App supplies input through the same controller and chooses both measurement
+    # boundaries. No tree inspection/capture/metrics polling inside the window.
+    time.sleep(7.4)
+    state = _text_element(application, "launcher-measurement")
+    _wait(lambda: _value_is(state, "complete"), "launcher measurement did not settle", timeout=4)
+    time.sleep(0.25)
+    metrics = agent.metrics()
+    evidence = validate_launcher_motion(metrics, agent.expected_sha256)
+    idle = assert_static_idle(agent, agent.expected_sha256)
+    return {
+        **evidence, **idle,
+        "workload": "launcher-slide", "direction": direction,
+        "input": "automation-through-browser", "physical_joystick_verified": False,
+        "sha256": agent.expected_sha256,
+        "pid": metrics.get("pid"),
+    }
 
 
 def _press_key(application, text):

--- a/magik2/scenarios/actions.py
+++ b/magik2/scenarios/actions.py
@@ -8,7 +8,8 @@ from pathlib import Path
 from typing import Any
 
 from magik2.client import NativeAgent
-from magik2.testing import one_element, screenshot
+from magik2.capture import capture_png
+from magik2.testing import one_element
 
 
 def smoke(
@@ -18,6 +19,7 @@ def smoke(
     if not build.is_valid:
         raise AssertionError("build label is not valid")
     _expect_value(build, expected_sha256)
+    one_element(application, "show-probe").invoke_accessible_default_action()
     counter = one_element(application, "counter")
     _expect_value(counter, "0")
     one_element(application, "increment").invoke_accessible_default_action()
@@ -30,8 +32,20 @@ def smoke(
     _wait(
         lambda: not _exists(application, "details-panel"), "details panel did not close"
     )
-    screenshot(application, screenshot_path)
-    return {"build_label": build.accessible_label, "screenshot": screenshot_path.name}
+    one_element(application, "show-launcher").invoke_accessible_default_action()
+    ready = one_element(application, "launcher-ready")
+    _wait(lambda: _value_is(ready, "presented"), "launcher was not latched")
+    selection = one_element(application, "launcher-selection")
+    _expect_value(selection, "ARCADE")
+    fields, pixels = agent.capture_framebuffer()
+    png, metadata = capture_png(fields, pixels, "raw")
+    screenshot_path.write_bytes(png)
+    return {
+        "build_label": build.accessible_label,
+        "screenshot": screenshot_path.name,
+        "capture_source": metadata["source"],
+        "capture_sequence": metadata["frame_sequence"],
+    }
 
 
 def motion(
@@ -42,6 +56,7 @@ def motion(
     sleep: Callable[[float], None] = time.sleep,
 ) -> Mapping[str, object]:
     state = one_element(application, "motion-state")
+    one_element(application, "show-probe").invoke_accessible_default_action()
     if state.accessible_value not in {"idle", "complete"}:
         raise AssertionError("motion workload is already running")
     one_element(application, "start-motion").invoke_accessible_default_action()

--- a/magik2/scenarios/actions.py
+++ b/magik2/scenarios/actions.py
@@ -9,11 +9,11 @@ from typing import Any
 
 from magik2.client import NativeAgent
 from magik2.capture import capture_png
-from magik2.testing import one_element
+from magik2.testing import one_element, screenshot
 
 
 def smoke(
-    application: Any, screenshot_path: Path, expected_sha256: str
+    application: Any, agent: NativeAgent, screenshot_path: Path, expected_sha256: str
 ) -> Mapping[str, object]:
     build = one_element(application, "build-label")
     if not build.is_valid:
@@ -33,10 +33,12 @@ def smoke(
         lambda: not _exists(application, "details-panel"), "details panel did not close"
     )
     one_element(application, "show-launcher").invoke_accessible_default_action()
-    ready = one_element(application, "launcher-ready")
+    ready = _text_element(application, "launcher-ready")
     _wait(lambda: _value_is(ready, "presented"), "launcher was not latched")
-    selection = one_element(application, "launcher-selection")
+    selection = _text_element(application, "launcher-selection")
     _expect_value(selection, "ARCADE")
+    fixtures = _text_element(application, "launcher-fixtures")
+    _expect_value(fixtures, "fixture-data")
     fields, pixels = agent.capture_framebuffer()
     png, metadata = capture_png(fields, pixels, "raw")
     screenshot_path.write_bytes(png)
@@ -144,6 +146,22 @@ def _exists(application: Any, label: str) -> bool:
     except AssertionError:
         return False
     return True
+
+
+def _text_element(application: Any, label: str) -> Any:
+    window = application.first_window
+    if window is None:
+        raise AssertionError("probe exposed no Slint window")
+    matches = [
+        element
+        for element in window.root_element.query_descendants()
+        .match_inherits("Text")
+        .find_all()
+        if element.accessible_label == label
+    ]
+    if len(matches) != 1:
+        raise AssertionError(f"expected one Text element for {label!r}, got {len(matches)}")
+    return matches[0]
 
 
 def _wait(predicate: Callable[[], bool], failure: str, timeout: float = 3) -> None:

--- a/magik2/scenarios/actions.py
+++ b/magik2/scenarios/actions.py
@@ -43,13 +43,31 @@ def smoke(
     png, metadata = capture_png(fields, pixels, "raw")
     screenshot_path.write_bytes(png)
     idle = assert_static_idle(agent, expected_sha256)
+    display = validate_mini_display(agent.metrics(), metadata)
     return {
         "build_label": build.accessible_label,
         "screenshot": screenshot_path.name,
         "capture_source": metadata["source"],
         "capture_sequence": metadata["frame_sequence"],
         **idle,
+        **display,
     }
+
+
+def validate_mini_display(metrics, capture):
+    """A correct source capture alone cannot prove full-screen scaler placement."""
+    context = metrics.get("context")
+    if not isinstance(context, Mapping):
+        raise AssertionError("Mini omitted display geometry")
+    names = ("source_width", "source_height", "scan_width", "scan_height",
+             "destination_width", "destination_height")
+    if any(type(context.get(name)) is not int or context[name] <= 0 for name in names):
+        raise AssertionError("Mini display geometry is incomplete")
+    if (context["source_width"], context["source_height"]) != (capture["width"], capture["height"]):
+        raise AssertionError("Mini source geometry differs from latched capture")
+    if (context["destination_width"], context["destination_height"]) != (context["scan_width"], context["scan_height"]):
+        raise AssertionError("Mini scaler destination does not fill the scanout")
+    return {"display_geometry": {name: context[name] for name in names}}
 
 
 def motion(

--- a/magik2/scenarios/actions.py
+++ b/magik2/scenarios/actions.py
@@ -190,6 +190,10 @@ def assert_static_idle(agent: NativeAgent, expected_sha256: str) -> Mapping[str,
         raise AssertionError("static launcher reported presentation evidence error")
     return {
         "idle_static_verified": True,
+        "idle_baseline_sha256": baseline.get("sha256"),
+        "idle_sample_sha256": sample.get("sha256"),
+        "idle_baseline_pid": baseline.get("pid"),
+        "idle_sample_pid": sample.get("pid"),
         "idle_baseline_elapsed_ms": baseline_elapsed,
         "idle_sample_elapsed_ms": sample_elapsed,
         "idle_interval_ms": interval,

--- a/magik2/scenarios/actions.py
+++ b/magik2/scenarios/actions.py
@@ -42,11 +42,13 @@ def smoke(
     fields, pixels = agent.capture_framebuffer()
     png, metadata = capture_png(fields, pixels, "raw")
     screenshot_path.write_bytes(png)
+    idle = assert_static_idle(agent, expected_sha256)
     return {
         "build_label": build.accessible_label,
         "screenshot": screenshot_path.name,
         "capture_source": metadata["source"],
         "capture_sequence": metadata["frame_sequence"],
+        **idle,
     }
 
 
@@ -162,6 +164,39 @@ def _text_element(application: Any, label: str) -> Any:
     if len(matches) != 1:
         raise AssertionError(f"expected one Text element for {label!r}, got {len(matches)}")
     return matches[0]
+
+
+def assert_static_idle(agent: NativeAgent, expected_sha256: str) -> Mapping[str, object]:
+    """Prove a ready static scene remains idle while metrics keep publishing."""
+    time.sleep(0.25)
+    baseline = agent.metrics()
+    time.sleep(0.65)
+    sample = agent.metrics()
+    if baseline.get("sha256") != expected_sha256 or sample.get("sha256") != expected_sha256:
+        raise AssertionError("idle metrics belong to another application")
+    if baseline.get("pid") != sample.get("pid"):
+        raise AssertionError("application pid changed during static idle interval")
+    baseline_elapsed = baseline.get("elapsed_ms")
+    sample_elapsed = sample.get("elapsed_ms")
+    if not all(type(value) is int for value in (baseline_elapsed, sample_elapsed)):
+        raise AssertionError("idle metrics omitted application elapsed time")
+    interval = sample_elapsed - baseline_elapsed
+    if interval < 600:
+        raise AssertionError(f"idle metrics interval was only {interval}ms")
+    counters = ("presentations", "physical_latch_posts", "evidence_error")
+    if any(baseline.get(name) != sample.get(name) for name in counters):
+        raise AssertionError("static launcher changed presentation counters while idle")
+    if sample.get("evidence_error") is not None:
+        raise AssertionError("static launcher reported presentation evidence error")
+    return {
+        "idle_static_verified": True,
+        "idle_baseline_elapsed_ms": baseline_elapsed,
+        "idle_sample_elapsed_ms": sample_elapsed,
+        "idle_interval_ms": interval,
+        "idle_presentations": sample.get("presentations"),
+        "idle_physical_latch_posts": sample.get("physical_latch_posts"),
+        "idle_evidence_error": sample.get("evidence_error"),
+    }
 
 
 def _wait(predicate: Callable[[], bool], failure: str, timeout: float = 3) -> None:

--- a/magik2/scenarios/test_mini_display.py
+++ b/magik2/scenarios/test_mini_display.py
@@ -1,0 +1,29 @@
+"""Consumer-side regression for Mini's source-versus-scanout geometry."""
+
+import pytest
+from actions import validate_mini_display
+
+
+def geometry():
+    return {"context": {"source_width": 960, "source_height": 540,
+                        "scan_width": 1920, "scan_height": 1080,
+                        "destination_width": 1920, "destination_height": 1080}}
+
+
+def test_half_resolution_source_fills_full_scanout():
+    result = validate_mini_display(geometry(), {"width": 960, "height": 540})
+    assert result["display_geometry"]["destination_width"] == 1920
+
+
+def test_quarter_screen_destination_fails_even_with_correct_source_capture():
+    metrics = geometry()
+    metrics["context"].update(destination_width=960, destination_height=540)
+    with pytest.raises(AssertionError, match="does not fill"):
+        validate_mini_display(metrics, {"width": 960, "height": 540})
+
+
+def test_stale_or_missing_geometry_fails():
+    with pytest.raises(AssertionError, match="differs"):
+        validate_mini_display(geometry(), {"width": 640, "height": 480})
+    with pytest.raises(AssertionError, match="omitted"):
+        validate_mini_display({}, {"width": 960, "height": 540})

--- a/magik2/scenarios/test_mini_motion.py
+++ b/magik2/scenarios/test_mini_motion.py
@@ -1,0 +1,48 @@
+"""Reject stale/probe measurements and distinguish physical repeats from drops."""
+
+import pytest
+from actions import validate_launcher_motion
+
+
+def measurement():
+    return {"sha256": "expected", "context": {
+        "workload": "launcher-slide", "launcher_owned_vblanks": 300,
+        "launcher_presented_vblanks": 300, "launcher_repeated_vblanks": 0,
+        "launcher_ownership_losses": 0,
+    }, "window": {
+        "start_ms": 2000, "end_ms": 7000, "elapsed_ms": 5000,
+        "width": 960, "height": 540, "instrumented": False,
+        "presentations": 300, "render_us_total": 900000,
+        "render_to_present_us_total": 4990000, "physical_latch_posts": 300,
+        "physical_latch_flips": 300, "physical_drops": 0, "latch_rejections": 0,
+        "evidence_error": None, "drop_baseline_available": True,
+    }}
+
+
+def test_valid_launcher_measurement():
+    assert validate_launcher_motion(measurement(), "expected")["no_physical_repeats"]
+
+
+def test_repeats_are_reported_not_mislabelled_as_no_drops():
+    metrics = measurement()
+    metrics["context"].update(launcher_presented_vblanks=299, launcher_repeated_vblanks=1)
+    assert not validate_launcher_motion(metrics, "expected")["no_physical_repeats"]
+
+
+@pytest.mark.parametrize("field,value", [("workload", "probe-motion"),
+                                         ("launcher_ownership_losses", 1),
+                                         ("launcher_owned_vblanks", 301)])
+def test_invalid_or_wrong_workload_rejected(field, value):
+    metrics = measurement()
+    metrics["context"][field] = value
+    with pytest.raises(AssertionError):
+        validate_launcher_motion(metrics, "expected")
+
+
+def test_stale_artifact_and_missing_telemetry_rejected():
+    with pytest.raises(AssertionError):
+        validate_launcher_motion(measurement(), "other")
+    metrics = measurement()
+    del metrics["context"]["launcher_repeated_vblanks"]
+    with pytest.raises(AssertionError):
+        validate_launcher_motion(metrics, "expected")

--- a/magik2/scenarios/test_probe.py
+++ b/magik2/scenarios/test_probe.py
@@ -1,7 +1,7 @@
 """Consumer scenarios: the same pytest cases assert behavior and retain timings."""
 
 import pytest
-from actions import smoke, motion
+from actions import launcher_motion, motion, smoke
 from magik2.results import append_event
 
 
@@ -28,4 +28,14 @@ def test_motion_profile(application_session):
     append_event(
         run,
         {"phase": "motion", "outcome": "measured", "profile_id": profile_id, **result},
+    )
+
+
+@pytest.mark.parametrize("direction", ["right", "left"])
+def test_launcher_motion(application_session, direction):
+    application, agent, run, profile_id = application_session
+    result = launcher_motion(application, agent, direction)
+    append_event(
+        run,
+        {"phase": "launcher-motion", "outcome": "measured", **result},
     )

--- a/magik2/scenarios/test_probe.py
+++ b/magik2/scenarios/test_probe.py
@@ -7,7 +7,7 @@ from magik2.results import append_event
 
 def test_smoke(application_session):
     application, agent, run, profile_id = application_session
-    result = smoke(application, run / "smoke.png", agent.expected_sha256)
+    result = smoke(application, agent, run / "smoke.png", agent.expected_sha256)
     append_event(run, {"phase": "smoke", "outcome": "passed", **result})
 
 

--- a/mister/platform/runtime/src/display_plan.rs
+++ b/mister/platform/runtime/src/display_plan.rs
@@ -10,6 +10,32 @@ use std::io;
 pub const RUNTIME_SETTINGS_ENV: &str = "MISTER_MAGIK_RUNTIME_SETTINGS_V1";
 pub const RUNTIME_DISPLAY_ENV: &str = "MISTER_MAGIK_RUNTIME_DISPLAY_V1";
 
+/// Standalone consumers do not inherit Main's launcher environment. Query its
+/// active display mode rather than mistaking core UIO_GET_VRES timing for HDMI.
+#[cfg(any(feature = "app-runtime", feature = "framebuffer-lab"))]
+pub fn query_main_display_plan() -> io::Result<ResolvedDisplayPlan> {
+    use crate::main_command::{self, MainCommand};
+    let response = main_command::execute(&MainCommand::DisplayState)
+        .map_err(io::Error::other)?
+        .ok_or_else(|| io::Error::other("Main returned no active display state"))?;
+    plan_from_main_response(&response)
+}
+
+#[cfg(any(feature = "app-runtime", feature = "framebuffer-lab"))]
+fn plan_from_main_response(response: &str) -> io::Result<ResolvedDisplayPlan> {
+    let state = crate::display_control::parse_state_response(response)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    ResolvedDisplayPlan::from_mode_or_detected(&state.active_mode, None).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Main display mode {} has no resolved scanout geometry",
+                state.active_mode
+            ),
+        )
+    })
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct RuntimeDisplayPlan {
     pub plan: ResolvedDisplayPlan,
@@ -40,4 +66,32 @@ pub fn detect_runtime_display_plan(fpga: &mut Fpga) -> io::Result<RuntimeDisplay
             )
         })?;
     Ok(RuntimeDisplayPlan { plan, video })
+}
+
+#[cfg(all(test, any(feature = "app-runtime", feature = "framebuffer-lab")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn main_hdmi_contract_keeps_source_half_size_and_destination_full_size() {
+        let plan = plan_from_main_response(
+            "ok DisplayV1 schema=1 active=hdmi-1920x1080p60 pending=none phase=idle",
+        )
+        .unwrap();
+        assert_eq!((plan.fb_w, plan.fb_h), (960, 540));
+        assert_eq!((plan.scan_w, plan.scan_h), (1920, 1080));
+    }
+
+    #[test]
+    fn pixel_repeated_mode_uses_scan_coordinates_and_active_not_pending_mode() {
+        let plan = plan_from_main_response("ok DisplayV1 schema=1 active=hdmi-2560x1440p60 pending=hdmi-1920x1080p60 phase=provisional").unwrap();
+        assert_eq!((plan.output_w, plan.output_h), (2560, 1440));
+        assert_eq!((plan.scan_w, plan.scan_h), (1280, 1440));
+    }
+
+    #[test]
+    fn unresolved_mode_does_not_fall_back_to_core_or_source_timing() {
+        assert!(plan_from_main_response("ok DisplayV1 schema=1 active=auto").is_err());
+        assert!(plan_from_main_response("ok DisplayV1 schema=2 active=hdmi-1920x1080p60").is_err());
+    }
 }

--- a/mister/platform/runtime/src/framebuffer/hidden_latch.rs
+++ b/mister/platform/runtime/src/framebuffer/hidden_latch.rs
@@ -81,6 +81,9 @@ impl From<LatchFailure> for HiddenLatchError {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct HiddenLatchPresentReceipt {
+    pub active_base: u32,
+    pub route_epoch: u16,
+    pub receipt_crc: u16,
     pub slot_index: u8,
     pub sequence: u16,
     pub flip_count: u16,
@@ -113,6 +116,7 @@ pub struct CachedHiddenLatchCopyStats {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct PendingPresentation {
+    receipt_crc: u16,
     slot_index: u8,
     sequence: u16,
     base: u32,
@@ -328,6 +332,9 @@ impl HiddenLatchPresenter {
         self.pending = None;
         self.writable_slot = 1 - self.writable_slot;
         Ok(Some(HiddenLatchPresentReceipt {
+            active_base: after.active_base,
+            route_epoch: after.active_route_epoch,
+            receipt_crc: pending.receipt_crc,
             slot_index: pending.slot_index,
             sequence: pending.sequence,
             flip_count: after.flip_count,
@@ -377,6 +384,7 @@ impl HiddenLatchPresenter {
             .settle_us
             .saturating_add(receipt.status_us);
         self.pending = Some(PendingPresentation {
+            receipt_crc: receipt.receipt_crc,
             slot_index,
             sequence,
             base,

--- a/mister/platform/runtime/src/lib.rs
+++ b/mister/platform/runtime/src/lib.rs
@@ -27,6 +27,8 @@ pub mod lab_input;
 pub mod latch_readiness;
 #[cfg(any(feature = "app-runtime", feature = "framebuffer-lab"))]
 pub mod main_command;
+#[cfg(feature = "framebuffer-lab")]
+pub mod main_input;
 #[cfg(feature = "app-runtime")]
 pub mod runtime_state;
 #[cfg(feature = "app-runtime")]

--- a/mister/platform/runtime/src/lib.rs
+++ b/mister/platform/runtime/src/lib.rs
@@ -29,6 +29,8 @@ pub mod latch_readiness;
 pub mod main_command;
 #[cfg(feature = "framebuffer-lab")]
 pub mod main_input;
+#[cfg(feature = "framebuffer-lab")]
+pub mod main_ready;
 #[cfg(feature = "app-runtime")]
 pub mod runtime_state;
 #[cfg(feature = "app-runtime")]

--- a/mister/platform/runtime/src/lib.rs
+++ b/mister/platform/runtime/src/lib.rs
@@ -16,7 +16,7 @@ macro_rules! ui_logln {
 pub mod boot_analytics;
 #[cfg(feature = "app-runtime")]
 pub mod direct_reset_fault;
-#[cfg(feature = "app-runtime")]
+#[cfg(any(feature = "app-runtime", feature = "framebuffer-lab"))]
 pub mod display_control;
 pub mod display_plan;
 pub mod display_resolution;
@@ -25,7 +25,7 @@ pub mod framebuffer;
 #[cfg(all(feature = "framebuffer-lab", target_os = "linux"))]
 pub mod lab_input;
 pub mod latch_readiness;
-#[cfg(feature = "app-runtime")]
+#[cfg(any(feature = "app-runtime", feature = "framebuffer-lab"))]
 pub mod main_command;
 #[cfg(feature = "app-runtime")]
 pub mod runtime_state;

--- a/mister/platform/runtime/src/main_input.rs
+++ b/mister/platform/runtime/src/main_input.rs
@@ -1,24 +1,22 @@
-//! Small reader for Main's mapped virtual EV_KEY input device.
-//!
-//! This intentionally does not inspect raw joystick nodes or guess a layout.
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Bounded nonblocking reader for Main's already-mapped virtual EV_KEY device.
+//! No raw joystick fallback, grab, configuration or repeat generation.
 
 use std::fs::{File, OpenOptions};
 use std::io::{self, Read};
 use std::os::fd::AsRawFd;
-use std::path::Path;
 
 const EVENT_SIZE: usize = if cfg!(target_pointer_width = "64") {
     24
 } else {
     16
 };
-const EV_KEY: u16 = 1;
-const EV_SYN: u16 = 0;
-const SYN_DROPPED: u16 = 3;
+pub const INPUT_BATCH_CAPACITY: usize = 64;
 const KEY_LEFT: u16 = 105;
 const KEY_RIGHT: u16 = 106;
-const INPUT_PROXY_CAPABILITY: &str = "MISTER_MAGIK_INPUT_PROXY";
-const INPUT_PROXY_PROTOCOL: &str = "MISTER_MAGIK_INPUT_PROXY_PROTOCOL";
+// Linux EVIOCGKEY(64), matching the buffer passed below exactly.
 const EVIOCGKEY: libc::c_ulong = 0x8040_4518;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -26,37 +24,77 @@ pub enum MainInputDirection {
     Left,
     Right,
 }
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum MainInputPhase {
     Pressed,
     Released,
 }
-
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct MainInputEvent {
     pub direction: MainInputDirection,
     pub phase: MainInputPhase,
 }
-
+struct KeyState {
+    held: [bool; 2],
+    await_neutral: bool,
+}
+impl KeyState {
+    fn new(held: [bool; 2]) -> Self {
+        Self {
+            held,
+            await_neutral: held[0] || held[1],
+        }
+    }
+    fn event(&mut self, kind: u16, code: u16, value: i32) -> io::Result<Option<MainInputEvent>> {
+        if kind == 0 && code == 3 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Main input SYN_DROPPED; reopen required",
+            ));
+        }
+        if kind != 1 || !matches!(value, 0 | 1) {
+            return Ok(None);
+        }
+        let (index, direction) = match code {
+            KEY_LEFT => (0, MainInputDirection::Left),
+            KEY_RIGHT => (1, MainInputDirection::Right),
+            _ => return Ok(None),
+        };
+        let pressed = value == 1;
+        let changed = self.held[index] != pressed;
+        self.held[index] = pressed;
+        if self.await_neutral {
+            self.await_neutral = self.held[0] || self.held[1];
+            return Ok(None);
+        }
+        Ok(changed.then_some(MainInputEvent {
+            direction,
+            phase: if pressed {
+                MainInputPhase::Pressed
+            } else {
+                MainInputPhase::Released
+            },
+        }))
+    }
+}
 pub struct MainProxyInput {
     file: File,
-    await_neutral: bool,
-    left: bool,
-    right: bool,
+    keys: KeyState,
+    partial: [u8; EVENT_SIZE],
+    filled: usize,
 }
-
 impl MainProxyInput {
     pub fn open() -> io::Result<Self> {
-        if std::env::var(INPUT_PROXY_CAPABILITY).as_deref() != Ok("1")
+        if !cfg!(target_os = "linux")
+            || std::env::var("MISTER_MAGIK_INPUT_PROXY").as_deref() != Ok("1")
             || !matches!(
-                std::env::var(INPUT_PROXY_PROTOCOL).as_deref(),
+                std::env::var("MISTER_MAGIK_INPUT_PROXY_PROTOCOL").as_deref(),
                 Ok("2" | "3")
             )
         {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
-                "Main mapped input proxy is unavailable",
+                "Main mapped input proxy v2/v3 unavailable",
             ));
         }
         let path = discover_proxy().ok_or_else(|| {
@@ -67,134 +105,171 @@ impl MainProxyInput {
         })?;
         let file = OpenOptions::new().read(true).open(path)?;
         set_nonblocking(&file)?;
-        let mut input = Self {
+        let mut bits = [0_u8; 64];
+        // SAFETY: owned evdev descriptor; kernel writes at most the encoded 64 bytes.
+        if unsafe { libc::ioctl(file.as_raw_fd(), EVIOCGKEY, bits.as_mut_ptr()) } < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let held = [KEY_LEFT, KEY_RIGHT].map(|key| bits[key as usize / 8] & (1 << (key % 8)) != 0);
+        Ok(Self {
             file,
-            await_neutral: false,
-            left: false,
-            right: false,
-        };
-        input.refresh_held_snapshot();
-        Ok(input)
+            keys: KeyState::new(held),
+            partial: [0; EVENT_SIZE],
+            filled: 0,
+        })
     }
-
-    pub fn poll(&mut self) -> io::Result<Vec<MainInputEvent>> {
-        let mut events = Vec::new();
-        self.poll_into(&mut events)?;
-        Ok(events)
+    pub fn ready(&self) -> bool {
+        !self.keys.await_neutral
     }
-
+    /// At most 64 kernel events per call. Caller reuses a capacity-64 vector.
+    /// Any transport/desync error discards the entire untrusted batch.
     pub fn poll_into(&mut self, events: &mut Vec<MainInputEvent>) -> io::Result<()> {
         events.clear();
-        let mut bytes = [0_u8; EVENT_SIZE];
-        loop {
-            match self.file.read_exact(&mut bytes) {
-                Ok(()) => {
-                    let type_offset = if EVENT_SIZE == 24 { 16 } else { 8 };
-                    let code_offset = type_offset + 2;
-                    let value_offset = type_offset + 4;
-                    let event_type =
-                        u16::from_ne_bytes([bytes[type_offset], bytes[type_offset + 1]]) & 0x7fff;
-                    let code = u16::from_ne_bytes([bytes[code_offset], bytes[code_offset + 1]]);
-                    let value = i32::from_ne_bytes([
-                        bytes[value_offset],
-                        bytes[value_offset + 1],
-                        bytes[value_offset + 2],
-                        bytes[value_offset + 3],
-                    ]);
-                    if event_type == EV_SYN && code == SYN_DROPPED {
-                        self.left = false;
-                        self.right = false;
-                        self.await_neutral = true;
-                        return Err(io::Error::new(
-                            io::ErrorKind::Interrupted,
-                            "Main input resync required",
-                        ));
-                    }
-                    if event_type != EV_KEY || !(value == 0 || value == 1) {
-                        continue;
-                    }
-                    let Some(direction) = (match code {
-                        KEY_LEFT => Some(MainInputDirection::Left),
-                        KEY_RIGHT => Some(MainInputDirection::Right),
-                        _ => None,
-                    }) else {
-                        continue;
-                    };
-                    let pressed = value == 1;
-                    match direction {
-                        MainInputDirection::Left => self.left = pressed,
-                        MainInputDirection::Right => self.right = pressed,
-                    }
-                    if self.await_neutral {
-                        if !self.left && !self.right {
-                            self.await_neutral = false;
-                        }
-                        continue;
-                    }
-                    events.push(MainInputEvent {
-                        direction,
-                        phase: if pressed {
-                            MainInputPhase::Pressed
-                        } else {
-                            MainInputPhase::Released
-                        },
-                    });
+        let result = self.drain(events);
+        if result.is_err() {
+            events.clear();
+        }
+        result
+    }
+    fn drain(&mut self, events: &mut Vec<MainInputEvent>) -> io::Result<()> {
+        for _ in 0..INPUT_BATCH_CAPACITY {
+            match self.file.read(&mut self.partial[self.filled..]) {
+                Ok(0) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "Main input disconnected",
+                    ));
                 }
+                Ok(count) => self.filled += count,
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
                 Err(error) => return Err(error),
             }
+            if self.filled == EVENT_SIZE {
+                self.filled = 0;
+                let (kind, code, value) = parse_event(&self.partial);
+                if let Some(event) = self.keys.event(kind, code, value)? {
+                    events.push(event);
+                }
+            }
         }
-    }
-
-    fn refresh_held_snapshot(&mut self) {
-        let mut bits = [0_u8; 96];
-        // SAFETY: the file descriptor is owned and the kernel writes only the
-        // fixed EVIOCGKEY bitset represented by this buffer.
-        let result = unsafe {
-            libc::ioctl(
-                self.file.as_raw_fd(),
-                EVIOCGKEY,
-                bits.as_mut_ptr().cast::<libc::c_void>(),
-            )
-        };
-        if result < 0 {
-            self.await_neutral = true;
-            return;
-        }
-        self.left = bits[(KEY_LEFT / 8) as usize] & (1 << (KEY_LEFT % 8)) != 0;
-        self.right = bits[(KEY_RIGHT / 8) as usize] & (1 << (KEY_RIGHT % 8)) != 0;
-        self.await_neutral = self.left || self.right;
+        Ok(())
     }
 }
-
+fn parse_event(bytes: &[u8]) -> (u16, u16, i32) {
+    let offset = bytes.len() - 8;
+    (
+        u16::from_ne_bytes(bytes[offset..offset + 2].try_into().expect("event type")),
+        u16::from_ne_bytes(
+            bytes[offset + 2..offset + 4]
+                .try_into()
+                .expect("event code"),
+        ),
+        i32::from_ne_bytes(bytes[offset + 4..].try_into().expect("event value")),
+    )
+}
 fn discover_proxy() -> Option<String> {
-    let mut paths: Vec<_> = std::fs::read_dir("/dev/input").ok()?.flatten().collect();
+    let mut paths: Vec<_> = std::fs::read_dir("/sys/class/input")
+        .ok()?
+        .flatten()
+        .collect();
     paths.sort_by_key(|entry| entry.file_name());
     paths.into_iter().find_map(|entry| {
-        let path = entry.path();
-        if !path.file_name()?.to_string_lossy().starts_with("event") {
+        let name = entry.file_name();
+        let name = name.to_string_lossy();
+        let index = name.strip_prefix("event")?;
+        if index.is_empty() || !index.bytes().all(|byte| byte.is_ascii_digit()) {
             return None;
         }
-        let name = std::fs::read_to_string(
-            Path::new("/sys/class/input")
-                .join(path.file_name()?)
-                .join("device/name"),
-        )
-        .ok()?;
-        (name.trim() == "MiSTer virtual input").then(|| path.to_string_lossy().into_owned())
+        let device_name = std::fs::read_to_string(entry.path().join("device/name")).ok()?;
+        (device_name.trim() == "MiSTer virtual input").then(|| format!("/dev/input/{name}"))
     })
 }
-
 fn set_nonblocking(file: &File) -> io::Result<()> {
-    let fd = file.as_raw_fd();
-    // SAFETY: fd belongs to file and only its status flags are changed.
-    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
-    if flags < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    // SAFETY: fd belongs to file and only O_NONBLOCK is added.
-    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+    // SAFETY: both fcntl operations use an owned, live descriptor.
+    let flags = unsafe { libc::fcntl(file.as_raw_fd(), libc::F_GETFL) };
+    if flags < 0
+        || unsafe { libc::fcntl(file.as_raw_fd(), libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0
+    {
         return Err(io::Error::last_os_error());
     }
     Ok(())
+}
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn neutral_start_delivers_first_tap_and_ignores_repeats() {
+        let mut keys = KeyState::new([false; 2]);
+        assert_eq!(
+            keys.event(1, KEY_RIGHT, 1).unwrap().unwrap().phase,
+            MainInputPhase::Pressed
+        );
+        assert!(keys.event(1, KEY_RIGHT, 1).unwrap().is_none());
+        assert!(keys.event(1, KEY_RIGHT, 2).unwrap().is_none());
+        assert!(keys.event(1, KEY_RIGHT, -1).unwrap().is_none());
+        assert_eq!(
+            keys.event(1, KEY_RIGHT, 0).unwrap().unwrap().phase,
+            MainInputPhase::Released
+        );
+    }
+    #[test]
+    fn inherited_hold_requires_all_directions_neutral() {
+        let mut keys = KeyState::new([true, true]);
+        assert!(keys.event(1, KEY_LEFT, 0).unwrap().is_none());
+        assert!(keys.await_neutral);
+        assert!(keys.event(1, KEY_RIGHT, 0).unwrap().is_none());
+        assert!(!keys.await_neutral);
+        assert!(keys.event(1, KEY_LEFT, 1).unwrap().is_some());
+    }
+    #[test]
+    fn desync_is_a_reset_not_a_silent_lost_release() {
+        let mut keys = KeyState::new([false; 2]);
+        keys.event(1, KEY_RIGHT, 1).unwrap();
+        assert!(keys.event(0, 3, 0).is_err());
+        assert!(keys.event(4, 0, 12).unwrap().is_none());
+    }
+    #[test]
+    fn parses_both_linux_event_abis() {
+        for size in [16, 24] {
+            let mut bytes = vec![0; size];
+            bytes[size - 8..size - 6].copy_from_slice(&1_u16.to_ne_bytes());
+            bytes[size - 6..size - 4].copy_from_slice(&KEY_LEFT.to_ne_bytes());
+            bytes[size - 4..].copy_from_slice(&1_i32.to_ne_bytes());
+            assert_eq!(parse_event(&bytes), (1, KEY_LEFT, 1));
+        }
+    }
+
+    #[test]
+    fn partial_reads_are_retained_and_desync_discards_batch() {
+        use std::io::Write;
+        use std::os::fd::OwnedFd;
+        use std::os::unix::net::UnixStream;
+        let (reader, mut writer) = UnixStream::pair().unwrap();
+        reader.set_nonblocking(true).unwrap();
+        let mut input = MainProxyInput {
+            file: File::from(OwnedFd::from(reader)),
+            keys: KeyState::new([false; 2]),
+            partial: [0; EVENT_SIZE],
+            filled: 0,
+        };
+        let mut bytes = [0_u8; EVENT_SIZE];
+        bytes[EVENT_SIZE - 8..EVENT_SIZE - 6].copy_from_slice(&1_u16.to_ne_bytes());
+        bytes[EVENT_SIZE - 6..EVENT_SIZE - 4].copy_from_slice(&KEY_RIGHT.to_ne_bytes());
+        bytes[EVENT_SIZE - 4..].copy_from_slice(&1_i32.to_ne_bytes());
+        let mut events = Vec::with_capacity(INPUT_BATCH_CAPACITY);
+        writer.write_all(&bytes[..7]).unwrap();
+        input.poll_into(&mut events).unwrap();
+        assert!(events.is_empty());
+        writer.write_all(&bytes[7..]).unwrap();
+        input.poll_into(&mut events).unwrap();
+        assert_eq!(events.len(), 1);
+        bytes[EVENT_SIZE - 4..].copy_from_slice(&0_i32.to_ne_bytes());
+        writer.write_all(&bytes).unwrap();
+        bytes[EVENT_SIZE - 8..EVENT_SIZE - 6].copy_from_slice(&0_u16.to_ne_bytes());
+        bytes[EVENT_SIZE - 6..EVENT_SIZE - 4].copy_from_slice(&3_u16.to_ne_bytes());
+        writer.write_all(&bytes).unwrap();
+        assert!(input.poll_into(&mut events).is_err());
+        assert!(events.is_empty());
+    }
 }

--- a/mister/platform/runtime/src/main_input.rs
+++ b/mister/platform/runtime/src/main_input.rs
@@ -1,0 +1,200 @@
+//! Small reader for Main's mapped virtual EV_KEY input device.
+//!
+//! This intentionally does not inspect raw joystick nodes or guess a layout.
+
+use std::fs::{File, OpenOptions};
+use std::io::{self, Read};
+use std::os::fd::AsRawFd;
+use std::path::Path;
+
+const EVENT_SIZE: usize = if cfg!(target_pointer_width = "64") {
+    24
+} else {
+    16
+};
+const EV_KEY: u16 = 1;
+const EV_SYN: u16 = 0;
+const SYN_DROPPED: u16 = 3;
+const KEY_LEFT: u16 = 105;
+const KEY_RIGHT: u16 = 106;
+const INPUT_PROXY_CAPABILITY: &str = "MISTER_MAGIK_INPUT_PROXY";
+const INPUT_PROXY_PROTOCOL: &str = "MISTER_MAGIK_INPUT_PROXY_PROTOCOL";
+const EVIOCGKEY: libc::c_ulong = 0x8040_4518;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MainInputDirection {
+    Left,
+    Right,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MainInputPhase {
+    Pressed,
+    Released,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct MainInputEvent {
+    pub direction: MainInputDirection,
+    pub phase: MainInputPhase,
+}
+
+pub struct MainProxyInput {
+    file: File,
+    await_neutral: bool,
+    left: bool,
+    right: bool,
+}
+
+impl MainProxyInput {
+    pub fn open() -> io::Result<Self> {
+        if std::env::var(INPUT_PROXY_CAPABILITY).as_deref() != Ok("1")
+            || !matches!(
+                std::env::var(INPUT_PROXY_PROTOCOL).as_deref(),
+                Ok("2" | "3")
+            )
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Main mapped input proxy is unavailable",
+            ));
+        }
+        let path = discover_proxy().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "Main mapped input device not found",
+            )
+        })?;
+        let file = OpenOptions::new().read(true).open(path)?;
+        set_nonblocking(&file)?;
+        let mut input = Self {
+            file,
+            await_neutral: false,
+            left: false,
+            right: false,
+        };
+        input.refresh_held_snapshot();
+        Ok(input)
+    }
+
+    pub fn poll(&mut self) -> io::Result<Vec<MainInputEvent>> {
+        let mut events = Vec::new();
+        self.poll_into(&mut events)?;
+        Ok(events)
+    }
+
+    pub fn poll_into(&mut self, events: &mut Vec<MainInputEvent>) -> io::Result<()> {
+        events.clear();
+        let mut bytes = [0_u8; EVENT_SIZE];
+        loop {
+            match self.file.read_exact(&mut bytes) {
+                Ok(()) => {
+                    let type_offset = if EVENT_SIZE == 24 { 16 } else { 8 };
+                    let code_offset = type_offset + 2;
+                    let value_offset = type_offset + 4;
+                    let event_type =
+                        u16::from_ne_bytes([bytes[type_offset], bytes[type_offset + 1]]) & 0x7fff;
+                    let code = u16::from_ne_bytes([bytes[code_offset], bytes[code_offset + 1]]);
+                    let value = i32::from_ne_bytes([
+                        bytes[value_offset],
+                        bytes[value_offset + 1],
+                        bytes[value_offset + 2],
+                        bytes[value_offset + 3],
+                    ]);
+                    if event_type == EV_SYN && code == SYN_DROPPED {
+                        self.left = false;
+                        self.right = false;
+                        self.await_neutral = true;
+                        return Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "Main input resync required",
+                        ));
+                    }
+                    if event_type != EV_KEY || !(value == 0 || value == 1) {
+                        continue;
+                    }
+                    let Some(direction) = (match code {
+                        KEY_LEFT => Some(MainInputDirection::Left),
+                        KEY_RIGHT => Some(MainInputDirection::Right),
+                        _ => None,
+                    }) else {
+                        continue;
+                    };
+                    let pressed = value == 1;
+                    match direction {
+                        MainInputDirection::Left => self.left = pressed,
+                        MainInputDirection::Right => self.right = pressed,
+                    }
+                    if self.await_neutral {
+                        if !self.left && !self.right {
+                            self.await_neutral = false;
+                        }
+                        continue;
+                    }
+                    events.push(MainInputEvent {
+                        direction,
+                        phase: if pressed {
+                            MainInputPhase::Pressed
+                        } else {
+                            MainInputPhase::Released
+                        },
+                    });
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn refresh_held_snapshot(&mut self) {
+        let mut bits = [0_u8; 96];
+        // SAFETY: the file descriptor is owned and the kernel writes only the
+        // fixed EVIOCGKEY bitset represented by this buffer.
+        let result = unsafe {
+            libc::ioctl(
+                self.file.as_raw_fd(),
+                EVIOCGKEY,
+                bits.as_mut_ptr().cast::<libc::c_void>(),
+            )
+        };
+        if result < 0 {
+            self.await_neutral = true;
+            return;
+        }
+        self.left = bits[(KEY_LEFT / 8) as usize] & (1 << (KEY_LEFT % 8)) != 0;
+        self.right = bits[(KEY_RIGHT / 8) as usize] & (1 << (KEY_RIGHT % 8)) != 0;
+        self.await_neutral = self.left || self.right;
+    }
+}
+
+fn discover_proxy() -> Option<String> {
+    let mut paths: Vec<_> = std::fs::read_dir("/dev/input").ok()?.flatten().collect();
+    paths.sort_by_key(|entry| entry.file_name());
+    paths.into_iter().find_map(|entry| {
+        let path = entry.path();
+        if !path.file_name()?.to_string_lossy().starts_with("event") {
+            return None;
+        }
+        let name = std::fs::read_to_string(
+            Path::new("/sys/class/input")
+                .join(path.file_name()?)
+                .join("device/name"),
+        )
+        .ok()?;
+        (name.trim() == "MiSTer virtual input").then(|| path.to_string_lossy().into_owned())
+    })
+}
+
+fn set_nonblocking(file: &File) -> io::Result<()> {
+    let fd = file.as_raw_fd();
+    // SAFETY: fd belongs to file and only its status flags are changed.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    // SAFETY: fd belongs to file and only O_NONBLOCK is added.
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    Ok(())
+}

--- a/mister/platform/runtime/src/main_input.rs
+++ b/mister/platform/runtime/src/main_input.rs
@@ -85,18 +85,13 @@ pub struct MainProxyInput {
 }
 impl MainProxyInput {
     pub fn open() -> io::Result<Self> {
-        if !cfg!(target_os = "linux")
-            || std::env::var("MISTER_MAGIK_INPUT_PROXY").as_deref() != Ok("1")
-            || !matches!(
-                std::env::var("MISTER_MAGIK_INPUT_PROXY_PROTOCOL").as_deref(),
-                Ok("2" | "3")
-            )
-        {
+        if !cfg!(target_os = "linux") {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
                 "Main mapped input proxy v2/v3 unavailable",
             ));
         }
+        verify_capability()?;
         let path = discover_proxy().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
@@ -156,6 +151,43 @@ impl MainProxyInput {
         Ok(())
     }
 }
+
+fn verify_capability() -> io::Result<()> {
+    let enabled = std::env::var("MISTER_MAGIK_INPUT_PROXY").ok();
+    let protocol = std::env::var("MISTER_MAGIK_INPUT_PROXY_PROTOCOL").ok();
+    if enabled.is_some() || protocol.is_some() {
+        return if enabled.as_deref() == Some("1") && matches!(protocol.as_deref(), Some("2" | "3"))
+        {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "unsupported Main input environment capability",
+            ))
+        };
+    }
+    // Mini is launched by the isolated service, which currently forwards these
+    // variables only for the real app. Read the same existing Main authority
+    // used by that service; never infer mapping from raw joystick capabilities.
+    let text = std::fs::read_to_string("/tmp/mister-magik/main-status.json")?;
+    verify_status_capability(&text)
+}
+
+fn verify_status_capability(text: &str) -> io::Result<()> {
+    let status: serde_json::Value = serde_json::from_str(text)
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    if status["schema"] == "mister-magik-main-status-v2"
+        && status["command_channel"] == "ready"
+        && matches!(status["input_proxy_protocol"].as_u64(), Some(2 | 3))
+    {
+        Ok(())
+    } else {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "Main status does not advertise mapped input v2/v3",
+        ))
+    }
+}
 fn parse_event(bytes: &[u8]) -> (u16, u16, i32) {
     let offset = bytes.len() - 8;
     (
@@ -198,6 +230,20 @@ fn set_nonblocking(file: &File) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mini_reads_existing_main_capability_without_environment_forwarding() {
+        for protocol in [2, 3] {
+            assert!(verify_status_capability(&format!(r#"{{"schema":"mister-magik-main-status-v2","command_channel":"ready","input_proxy_protocol":{protocol}}}"#)).is_ok());
+        }
+        for status in [
+            r#"{}"#,
+            r#"{"schema":"mister-magik-main-status-v2","command_channel":"ready","input_proxy_protocol":1}"#,
+            r#"{"schema":"mister-magik-main-status-v2","command_channel":"starting","input_proxy_protocol":2}"#,
+        ] {
+            assert!(verify_status_capability(status).is_err());
+        }
+    }
     #[test]
     fn neutral_start_delivers_first_tap_and_ignores_repeats() {
         let mut keys = KeyState::new([false; 2]);

--- a/mister/platform/runtime/src/main_ready.rs
+++ b/mister/platform/runtime/src/main_ready.rs
@@ -1,0 +1,170 @@
+// Copyright (C) 2026 Nigel Breslaw
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Main's existing ready-v3 handshake for a custom RGB565 consumer.
+//! Mirrors the real launcher's two confirmed, alternating, nonblank frames.
+use crate::framebuffer::hidden_latch::{HiddenLatchPresentReceipt, HiddenLatchPresenter};
+use crate::framebuffer::rgb565::Rgb565;
+use std::io::Write;
+use std::os::unix::fs::OpenOptionsExt;
+use std::time::{Duration, Instant};
+
+fn advances(current: u16, previous: u16) -> bool {
+    let delta = current.wrapping_sub(previous);
+    delta != 0 && delta < 0x8000
+}
+
+fn valid_pair(a: HiddenLatchPresentReceipt, b: HiddenLatchPresentReceipt) -> bool {
+    matches!(a.slot_index, 1 | 2)
+        && matches!(b.slot_index, 1 | 2)
+        && a.slot_index != b.slot_index
+        && a.active_base != 0
+        && b.active_base != 0
+        && a.active_base != b.active_base
+        && advances(b.sequence, a.sequence)
+        && advances(b.route_epoch, a.route_epoch)
+}
+
+/// Startup only: never rebuilds textures or performs FIFO work on the motion path.
+pub fn notify_main_ready(
+    presenter: &mut HiddenLatchPresenter,
+    pixels: &[Rgb565],
+) -> Result<(), String> {
+    let Ok(token) = std::env::var("MISTER_MAGIK_STARTUP_TOKEN") else {
+        return Ok(());
+    };
+    if token.len() != 32
+        || !token
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+        || std::env::var("MISTER_MAGIK_READY_WIRE_VERSION").as_deref() != Ok("3")
+    {
+        return Err("invalid Main ready-v3 startup context".into());
+    }
+    let number = |name| -> Result<u64, String> {
+        std::env::var(name)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .filter(|n| *n > 0)
+            .ok_or_else(|| format!("missing Main startup field {name}"))
+    };
+    let main_pid = number("MISTER_MAGIK_MAIN_PID")?;
+    let generation = number("MISTER_MAGIK_MAIN_GENERATION")?;
+    let owner = number("MISTER_MAGIK_OWNER_EPOCH")?;
+    let fifo = std::env::var("MISTER_MAGIK_READY_FIFO").map_err(|e| e.to_string())?;
+    if fifo != "/tmp/mister-magik/launcher-ready-v2" {
+        return Err("unexpected Main readiness FIFO".into());
+    }
+    let (width, height, stride) = (
+        presenter.width(),
+        presenter.height(),
+        presenter.stride_pixels(),
+    );
+    if pixels.len() != width * height || !pixels.iter().any(|p| p.0 != 0) {
+        return Err("Main readiness requires a complete nonblank source frame".into());
+    }
+    let mut present = || {
+        for (dst, src) in presenter
+            .pixels_mut()
+            .chunks_exact_mut(stride)
+            .zip(pixels.chunks_exact(width))
+        {
+            dst[..width].copy_from_slice(src);
+        }
+        presenter.present().map_err(|e| e.to_string())
+    };
+    let first = present()?;
+    let second = present()?;
+    if !valid_pair(first, second) {
+        return Err("Main readiness receipts did not advance and alternate".into());
+    }
+    let pid = std::process::id();
+    let line = format!(
+        "ready-v3 token={token} pid={pid} main_pid={main_pid} main_generation={generation} owner_epoch={owner} protocol=5 capabilities=03ff base={:08x} width={width} height={height} stride={} first_sequence={} first_route_epoch={} first_slot={} first_receipt_crc={:04x} second_sequence={} second_route_epoch={} second_slot={} second_receipt_crc={:04x} source_nonblank=1\n",
+        second.active_base,
+        stride * 2,
+        first.sequence,
+        first.route_epoch,
+        first.slot_index,
+        first.receipt_crc,
+        second.sequence,
+        second.route_epoch,
+        second.slot_index,
+        second.receipt_crc
+    );
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        let sent = std::fs::OpenOptions::new()
+            .write(true)
+            .custom_flags(libc::O_NONBLOCK | libc::O_CLOEXEC)
+            .open(&fifo)
+            .and_then(|mut f| f.write(line.as_bytes()))
+            .is_ok_and(|n| n == line.len());
+        if sent {
+            break;
+        }
+        if Instant::now() >= deadline {
+            return Err("Main readiness FIFO timed out".into());
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    loop {
+        let status = std::fs::read("/tmp/mister-magik/main-status.json")
+            .ok()
+            .and_then(|b| serde_json::from_slice::<serde_json::Value>(&b).ok());
+        if status.is_some_and(|s| {
+            s["launcher_active"] == true
+                && s["launcher_pid"] == pid
+                && s["main_generation"] == generation
+                && s["fpga_owner"] == "magik"
+        }) {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            return Err("Main did not activate Mini after readiness".into());
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn readiness_requires_two_distinct_advancing_slots() {
+        let a = HiddenLatchPresentReceipt {
+            active_base: 4096,
+            route_epoch: 1,
+            receipt_crc: 10,
+            slot_index: 1,
+            sequence: 1,
+            flip_count: 1,
+            post_count: 1,
+            drop_count: 0,
+        };
+        let b = HiddenLatchPresentReceipt {
+            active_base: 8192,
+            route_epoch: 2,
+            slot_index: 2,
+            sequence: 2,
+            ..a
+        };
+        assert!(valid_pair(a, b));
+        assert!(!valid_pair(a, a));
+        assert!(!valid_pair(b, a));
+        assert!(!valid_pair(
+            a,
+            HiddenLatchPresentReceipt {
+                route_epoch: 1,
+                ..b
+            }
+        ));
+        assert!(!valid_pair(
+            a,
+            HiddenLatchPresentReceipt {
+                active_base: 0,
+                ..b
+            }
+        ));
+    }
+}


### PR DESCRIPTION
## Change

Add `scripts/magik2 update` to download and verify the latest numbered platform and database releases, then atomically queue the pair for this host's devices. The next real-MagiK `deploy --attended` installs outstanding Dev updates before starting the application; database-only changes need no attendance or reboot.

Deployment compares native installed identities and hashes with the pinned releases, preserves newer versions, and serializes each device's deployment. Separate publication journals support partial completion and bounded activation reconciliation. Native completion verifies the expected manifest and running Main before releasing backups. Ordinary GUI edits do not reinstall platform components.

## Validation

- 59 focused host tests passed across updates, deploy, publication operations, and builds.
- 3 focused native publication tests passed; Rust LSP diagnostics are clear.
- Formatting/lint and index-based pre-commit checks passed.
- Live download and repeat cache verification passed for platform-v0.41 and game-databases-v23 using isolated temporary state.

Hardware acceptance remains separately attended. No device installation, activation, or reboot was performed, and the user's normal desired-release queue was not changed.
