### PR TITLE
Queue published platform and database updates for deploy

### DIFF
--- a/docs/host-orchestration.md
+++ b/docs/host-orchestration.md
@@ -5,6 +5,9 @@ See [native operations](../magik/docs/native-operations.md).
 
 Host-only operations use existing Python tooling:
 
+- `scripts/magik update` downloads and queues the latest verified platform and
+  databases. The next `scripts/magik deploy --attended` installs outstanding Dev
+  updates before starting real MagiK; subsequent deploys skip verified releases.
 - `scripts/magik-ci dependencies sync PATH/Cargo.toml` resolves only the owning
   manifest and adjacent lockfile. `--package NAME` requests a targeted update.
 - `scripts/magik-ci clean --manifest PATH/Cargo.toml --package NAME` cleans that

--- a/magik/agent/src/lib.rs
+++ b/magik/agent/src/lib.rs
@@ -189,6 +189,7 @@ impl Agent {
             "catalog-operations-v1",
             "publication-v1",
             "platform-publication-v1",
+            "publication-state-v1",
             "transfer-check",
             "applications",
             "main-input-proxy",
@@ -322,12 +323,14 @@ impl Agent {
         }
         if matches!(
             request.op.as_str(),
-            "publication-commit" | "publication-control"
+            "publication-commit" | "publication-control" | "publication-state"
         ) {
             if body_length != 0 {
                 return Err(FrameError::BodyTooLarge);
             }
-            return if request.op == "publication-control" {
+            return if request.op == "publication-state" {
+                self.publication_state(stream, &request)
+            } else if request.op == "publication-control" {
                 self.publication_control(stream, &request)
             } else {
                 self.publish(stream, &request)

--- a/magik/agent/src/publication.rs
+++ b/magik/agent/src/publication.rs
@@ -24,6 +24,81 @@ const DATABASES: &[&str] = &[
     "game-databases-manifest.json",
 ];
 
+fn installed_state(fat: &Path, install_root: &Path) -> Result<Value, String> {
+    let paths = Layout::Development.paths();
+    let local = |path: &str| fat.join(path.strip_prefix("/media/fat/").expect("layout path"));
+    let mut platform = json!({"version":0,"verified":false});
+    let manifest_path = local(paths.manifest);
+    if manifest_path.exists() {
+        let text = fs::read_to_string(manifest_path).map_err(|e| e.to_string())?;
+        let manifest = parse(&text, Layout::Development, ValidationProfile::AgentStrict)
+            .map_err(|e| e.to_string())?;
+        let mut hashes = serde_json::Map::new();
+        let mut verified = true;
+        for (name, path) in paths.components() {
+            let hash = crate::media::hash(&local(path)).ok();
+            if !matches!(name, "gui" | "manager") {
+                verified &= hash.as_deref()
+                    == Some(
+                        manifest
+                            .required(&format!("{name}_sha256"))
+                            .map_err(|e| e.to_string())?,
+                    );
+            }
+            hashes.insert(name.to_owned(), json!(hash));
+        }
+        platform = json!({"version":manifest.required("platform_release_number").map_err(|e| e.to_string())?.parse::<u64>().map_err(|e| e.to_string())?,
+            "bundle_id":manifest.required("platform_bundle_id").map_err(|e| e.to_string())?,"verified":verified,"hashes":hashes});
+    }
+    let assets = local(paths.root).join("assets");
+    let mut databases = json!({"version":0,"verified":false});
+    let manifest_path = assets.join("game-databases-manifest.json");
+    if manifest_path.exists() {
+        let manifest: Value =
+            serde_json::from_slice(&fs::read(manifest_path).map_err(|e| e.to_string())?)
+                .map_err(|e| e.to_string())?;
+        let checks =
+            fs::read_to_string(assets.join("game-databases-SHA256SUMS")).unwrap_or_default();
+        let mut hashes = serde_json::Map::new();
+        let mut verified = manifest["format"] == "mister-magik-game-databases-manifest-v4";
+        for name in &DATABASES[..2] {
+            let hash = crate::media::hash(&assets.join(name)).ok();
+            let expected = checks
+                .lines()
+                .filter_map(|line| line.split_once("  "))
+                .find_map(|(hash, path)| (path == *name).then_some(hash));
+            verified &= expected.is_some() && hash.as_deref() == expected;
+            hashes.insert((*name).to_owned(), json!(hash));
+        }
+        hashes.insert(
+            "manifest".into(),
+            json!(crate::media::hash(
+                &assets.join("game-databases-manifest.json")
+            )?),
+        );
+        databases =
+            json!({"version":manifest["release_version"],"verified":verified,"hashes":hashes});
+    }
+    let mut stages = Vec::new();
+    let publication = install_root.join("publication");
+    if publication.exists() {
+        for entry in fs::read_dir(publication).map_err(|e| e.to_string())? {
+            let entry = entry.map_err(|e| e.to_string())?;
+            let pending = entry.path().join("pending.json");
+            if pending.exists() || entry.path().join("backup").exists() {
+                let detail = if pending.exists() {
+                    serde_json::from_slice::<Value>(&fs::read(pending).map_err(|e| e.to_string())?)
+                        .map_err(|e| e.to_string())?
+                } else {
+                    Value::Null
+                };
+                stages.push(json!({"stage":entry.file_name().to_string_lossy(),"pending":detail}));
+            }
+        }
+    }
+    Ok(json!({"platform":platform,"databases":databases,"stages":stages}))
+}
+
 fn stage(root: &Path, fields: &serde_json::Map<String, Value>) -> Result<PathBuf, String> {
     let id = fields
         .get("stage")
@@ -270,6 +345,49 @@ fn reload_healthy(previous: &Value, expected: &str) -> Result<(), String> {
 }
 
 impl crate::Agent {
+    pub(super) fn publication_state(
+        &self,
+        stream: &mut TcpStream,
+        request: &Envelope,
+    ) -> Result<(), FrameError> {
+        let _mutation = self.mutations.lock().expect("mutation state poisoned");
+        let result = (|| -> Result<Value, String> {
+            if request.fields.len() != 1 || request.fields["layout"] != "dev" {
+                return Err("publication-state requires layout=dev".into());
+            }
+            let mut state = installed_state(Path::new("/media/fat"), &self.install_root)?;
+            state["running"] = crate::device::status()?;
+            let paths = Layout::Development.paths();
+            let running_hash = state["running"]["pid"]
+                .as_u64()
+                .and_then(|pid| crate::media::hash(Path::new(&format!("/proc/{pid}/exe"))).ok());
+            state["platform"]["active"] = json!(
+                state["running"]["executable_path"] == paths.main
+                    && state["running"]["launcher_ready_phase"] == "ready"
+                    && state["running"]["scanout_slots_module_loaded"] == true
+                    && running_hash.is_some()
+                    && running_hash == crate::media::hash(Path::new(paths.main)).ok()
+                    && state["stages"]
+                        .as_array()
+                        .is_some_and(|stages| stages.is_empty())
+            );
+            state["configured_main"] = crate::mode::status()?["configured_main"].clone();
+            state["boot_id"] = json!(
+                fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e| e.to_string())?
+            );
+            Ok(state)
+        })();
+        let reply = match result {
+            Ok(fields) => response(&request.id, "publication-state", fields),
+            Err(error) => response(
+                &request.id,
+                "error",
+                json!({"code":"publication-state-failed","detail":error}),
+            ),
+        };
+        write_frame(stream, &reply, &[])
+    }
+
     pub(super) fn publication_control(
         &self,
         stream: &mut TcpStream,
@@ -289,6 +407,20 @@ impl crate::Agent {
             .map_err(|e| e.to_string())?;
             match request.fields.get("action").and_then(Value::as_str) {
                 Some("finish") => {
+                    if pending["kind"] == "databases" {
+                        let fields = json!({"stage":request.fields["stage"],"kind":"databases","layout":pending["layout"]});
+                        for (source, destination) in
+                            files(&self.install_root, fields.as_object().unwrap())?
+                        {
+                            if crate::media::hash(&source)? != crate::media::hash(&destination)? {
+                                return Err(
+                                    "database publication is incomplete; restore explicitly".into(),
+                                );
+                            }
+                        }
+                        fs::remove_dir_all(root).map_err(|e| e.to_string())?;
+                        return Ok(json!({"activated":true}));
+                    }
                     if pending["boot_id"]
                         == fs::read_to_string("/proc/sys/kernel/random/boot_id")
                             .map_err(|e| e.to_string())?
@@ -299,6 +431,18 @@ impl crate::Agent {
                     crate::mode::verify_platform(layout)?;
                     let state = crate::device::status()?;
                     let layout = Layout::parse(layout).map_err(|e| e.to_string())?;
+                    let expected = pending["manifest_sha256"].as_str().ok_or(
+                        "pending publication has no expected manifest; restore explicitly",
+                    )?;
+                    if crate::media::hash(Path::new(layout.paths().manifest))? != expected {
+                        return Err("activated manifest differs from staged publication".into());
+                    }
+                    let pid = state["pid"].as_u64().ok_or("Main PID missing")?;
+                    if crate::media::hash(Path::new(&format!("/proc/{pid}/exe")))?
+                        != crate::media::hash(Path::new(layout.paths().main))?
+                    {
+                        return Err("running Main differs from installed Main".into());
+                    }
                     if state["executable_path"] != layout.paths().main
                         || state["launcher_ready_phase"] != "ready"
                         || state["scanout_slots_module_loaded"] != true
@@ -392,8 +536,13 @@ impl crate::Agent {
             };
             let root = stage(&self.install_root, fields)?;
             let requires_reboot = fields["kind"] == "platform";
-            if requires_reboot {
-                let pending = json!({"layout":fields["layout"],"boot_id":fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e|e.to_string())?});
+            if requires_reboot || fields["kind"] == "databases" {
+                let expected_manifest = if requires_reboot {
+                    "manifest"
+                } else {
+                    "game-databases-manifest.json"
+                };
+                let pending = json!({"kind":fields["kind"],"layout":fields["layout"],"manifest_sha256":crate::media::hash(&root.join(expected_manifest))?,"boot_id":fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e|e.to_string())?});
                 fs::write(
                     root.join("pending.json"),
                     serde_json::to_vec(&pending).unwrap(),
@@ -457,6 +606,43 @@ impl crate::Agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn installed_state_hashes_databases_and_retains_interrupted_stage() {
+        let root =
+            std::env::temp_dir().join(format!("magik2-publication-state-{}", std::process::id()));
+        let fat = root.join("fat");
+        let assets = fat.join("mister-magik-dev/assets");
+        let install = root.join("agent");
+        fs::create_dir_all(&assets).unwrap();
+        let mut checks = String::new();
+        for name in &DATABASES[..2] {
+            fs::write(assets.join(name), b"content").unwrap();
+            checks.push_str(&format!(
+                "{}  {name}\n",
+                crate::media::hash(&assets.join(name)).unwrap()
+            ));
+        }
+        fs::write(assets.join("game-databases-SHA256SUMS"), checks).unwrap();
+        fs::write(
+            assets.join("game-databases-manifest.json"),
+            br#"{"format":"mister-magik-game-databases-manifest-v4","release_version":4}"#,
+        )
+        .unwrap();
+        let stage = install.join("publication").join("a".repeat(32));
+        fs::create_dir_all(stage.join("backup")).unwrap();
+        let state = installed_state(&fat, &install).unwrap();
+        assert_eq!(state["databases"]["verified"], true);
+        assert_eq!(state["databases"]["version"], 4);
+        assert_eq!(state["stages"].as_array().unwrap().len(), 1);
+        assert!(stage.join("backup").exists());
+        fs::write(assets.join(DATABASES[0]), b"corrupt").unwrap();
+        assert_eq!(
+            installed_state(&fat, &install).unwrap()["databases"]["verified"],
+            false
+        );
+        fs::remove_dir_all(root).unwrap();
+    }
+
     #[test]
     fn failed_activation_restores_original_artifact_set() {
         let root = std::env::temp_dir().join(format!("magik-publish-{}", std::process::id()));

--- a/magik/agent/src/publication.rs
+++ b/magik/agent/src/publication.rs
@@ -344,6 +344,52 @@ fn reload_healthy(previous: &Value, expected: &str) -> Result<(), String> {
     }
 }
 
+fn database_hashes(staged: &Path) -> Result<Value, String> {
+    let mut hashes = serde_json::Map::new();
+    for name in DATABASES {
+        hashes.insert(
+            (*name).to_owned(),
+            json!(crate::media::hash(&staged.join(name))?),
+        );
+    }
+    Ok(Value::Object(hashes))
+}
+
+fn finish_databases(staged: &Path, pending: &Value, assets: &Path) -> Result<(), String> {
+    let expected = pending["database_sha256"]
+        .as_object()
+        .ok_or("database publication has no persisted hashes; restore explicitly")?;
+    if expected.len() != DATABASES.len() {
+        return Err(
+            "database publication has incomplete persisted hashes; restore explicitly".into(),
+        );
+    }
+    for name in DATABASES {
+        let hash = expected
+            .get(*name)
+            .and_then(Value::as_str)
+            .ok_or("database publication has incomplete persisted hashes; restore explicitly")?;
+        if crate::media::hash(&assets.join(name))? != hash {
+            return Err("database publication is incomplete; restore explicitly".into());
+        }
+    }
+    fs::remove_dir_all(staged).map_err(|e| e.to_string())
+}
+
+fn platform_active(
+    state: &Value,
+    running_hash: Option<&str>,
+    installed_hash: Option<&str>,
+) -> bool {
+    state["running"]["executable_path"] == Layout::Development.paths().main
+        && state["running"]["scanout_slots_module_loaded"] == true
+        && running_hash.is_some()
+        && running_hash == installed_hash
+        && state["stages"]
+            .as_array()
+            .is_some_and(|stages| stages.is_empty())
+}
+
 impl crate::Agent {
     pub(super) fn publication_state(
         &self,
@@ -361,16 +407,13 @@ impl crate::Agent {
             let running_hash = state["running"]["pid"]
                 .as_u64()
                 .and_then(|pid| crate::media::hash(Path::new(&format!("/proc/{pid}/exe"))).ok());
-            state["platform"]["active"] = json!(
-                state["running"]["executable_path"] == paths.main
-                    && state["running"]["launcher_ready_phase"] == "ready"
-                    && state["running"]["scanout_slots_module_loaded"] == true
-                    && running_hash.is_some()
-                    && running_hash == crate::media::hash(Path::new(paths.main)).ok()
-                    && state["stages"]
-                        .as_array()
-                        .is_some_and(|stages| stages.is_empty())
-            );
+            // Application readiness is handled by deploy/start. Main and the
+            // module remain active while the launcher is idle in the stock menu.
+            state["platform"]["active"] = json!(platform_active(
+                &state,
+                running_hash.as_deref(),
+                crate::media::hash(Path::new(paths.main)).ok().as_deref(),
+            ));
             state["configured_main"] = crate::mode::status()?["configured_main"].clone();
             state["boot_id"] = json!(
                 fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e| e.to_string())?
@@ -408,17 +451,15 @@ impl crate::Agent {
             match request.fields.get("action").and_then(Value::as_str) {
                 Some("finish") => {
                     if pending["kind"] == "databases" {
-                        let fields = json!({"stage":request.fields["stage"],"kind":"databases","layout":pending["layout"]});
-                        for (source, destination) in
-                            files(&self.install_root, fields.as_object().unwrap())?
-                        {
-                            if crate::media::hash(&source)? != crate::media::hash(&destination)? {
-                                return Err(
-                                    "database publication is incomplete; restore explicitly".into(),
-                                );
-                            }
-                        }
-                        fs::remove_dir_all(root).map_err(|e| e.to_string())?;
+                        let layout = Layout::parse(
+                            pending["layout"].as_str().ok_or("pending layout absent")?,
+                        )
+                        .map_err(|e| e.to_string())?;
+                        finish_databases(
+                            &root,
+                            &pending,
+                            &Path::new(layout.paths().root).join("assets"),
+                        )?;
                         return Ok(json!({"activated":true}));
                     }
                     if pending["boot_id"]
@@ -542,7 +583,10 @@ impl crate::Agent {
                 } else {
                     "game-databases-manifest.json"
                 };
-                let pending = json!({"kind":fields["kind"],"layout":fields["layout"],"manifest_sha256":crate::media::hash(&root.join(expected_manifest))?,"boot_id":fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e|e.to_string())?});
+                let mut pending = json!({"kind":fields["kind"],"layout":fields["layout"],"manifest_sha256":crate::media::hash(&root.join(expected_manifest))?,"boot_id":fs::read_to_string("/proc/sys/kernel/random/boot_id").map_err(|e|e.to_string())?});
+                if fields["kind"] == "databases" {
+                    pending["database_sha256"] = database_hashes(&root)?;
+                }
                 fs::write(
                     root.join("pending.json"),
                     serde_json::to_vec(&pending).unwrap(),
@@ -606,6 +650,61 @@ impl crate::Agent {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn database_finish_uses_persisted_hashes_after_replacement() {
+        let root = std::env::temp_dir().join(format!("magik-db-finish-{}", std::process::id()));
+        let staged = root.join("stage");
+        let assets = root.join("assets");
+        fs::create_dir_all(&staged).unwrap();
+        fs::create_dir_all(&assets).unwrap();
+        for name in DATABASES {
+            fs::write(staged.join(name), format!("new {name}")).unwrap();
+            fs::write(assets.join(name), b"old").unwrap();
+        }
+        let pending = json!({"database_sha256":database_hashes(&staged).unwrap()});
+        fs::write(
+            staged.join("pending.json"),
+            serde_json::to_vec(&pending).unwrap(),
+        )
+        .unwrap();
+        let paths: Vec<_> = DATABASES
+            .iter()
+            .map(|name| (staged.join(name), assets.join(name)))
+            .collect();
+        replace(&paths, &staged.join("backup"), || Ok(())).unwrap();
+        // Simulate interruption after replacement, before stage cleanup. Every
+        // source has been renamed away, including the staged manifest.
+        assert!(DATABASES.iter().all(|name| !staged.join(name).exists()));
+        let persisted =
+            serde_json::from_slice(&fs::read(staged.join("pending.json")).unwrap()).unwrap();
+        fs::write(assets.join(DATABASES[0]), b"corrupt").unwrap();
+        assert!(finish_databases(&staged, &persisted, &assets).is_err());
+        assert!(staged.join("backup/transaction.json").exists());
+        fs::write(assets.join(DATABASES[0]), format!("new {}", DATABASES[0])).unwrap();
+        assert!(finish_databases(&staged, &json!({}), &assets).is_err());
+        assert!(staged.exists());
+        finish_databases(&staged, &persisted, &assets).unwrap();
+        assert!(!staged.exists());
+        assert!(DATABASES.iter().all(|name| assets.join(name).exists()));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn platform_activation_does_not_require_a_running_application() {
+        let mut state = json!({"running":{"executable_path":Layout::Development.paths().main,
+            "scanout_slots_module_loaded":true,"launcher_ready_phase":"idle"},"stages":[]});
+        assert!(platform_active(&state, Some("main"), Some("main")));
+        state["running"]["launcher_ready_phase"] = json!("ready");
+        assert!(platform_active(&state, Some("main"), Some("main")));
+        assert!(!platform_active(&state, Some("old"), Some("main")));
+        assert!(!platform_active(&state, None, None));
+        state["running"]["scanout_slots_module_loaded"] = json!(false);
+        assert!(!platform_active(&state, Some("main"), Some("main")));
+        state["running"]["scanout_slots_module_loaded"] = json!(true);
+        state["stages"] = json!([{"stage":"unfinished"}]);
+        assert!(!platform_active(&state, Some("main"), Some("main")));
+    }
+
     #[test]
     fn installed_state_hashes_databases_and_retains_interrupted_stage() {
         let root =

--- a/magik/docs/native-operations.md
+++ b/magik/docs/native-operations.md
@@ -32,6 +32,35 @@ Raw reports and failures are retained in the command's result directory.
 
 ## Independent platform entrypoint
 
+### Queue published releases for the next deploy
+
+Run `scripts/magik update` to download and verify the latest numbered platform
+and game-database releases from `NigelBreslaw/MiSTer-MagiK`. Published prereleases
+are included; drafts are excluded. The command does not contact the device.
+Both releases must verify before the shared desired pair changes. Downloads live
+under `$MISTER_MAGIK2_STATE/updates` (the normal shared state directory when unset).
+The output includes the database release directory usable with `catalog publish`.
+
+Run `scripts/magik deploy --attended` to install that pair on the selected MiSTer
+before starting real MagiK. A platform change requires running and selected Dev
+mode and one bounded reboot. Plain `deploy` stops before publication when attendance
+is needed. Database-only updates require no reboot or attendance. Installed hashes
+and versions determine what is outstanding; newer installed releases are never
+downgraded. Normal GUI edits do not reinstall the platform. Mini, `check`, and
+`watch` do not consume the queue.
+
+The desired pair remains available for other devices; each device has separate
+completion evidence. Platform and database publication journals are retained in
+separate subdirectories of the deploy result. If the platform succeeds and the
+database step fails, the next deploy retries only outstanding work. An interrupted
+platform transaction is finished automatically only when its saved host journal
+matches and a new boot is confirmed. Otherwise deployment stops with the stage ID
+for explicit inspection/restoration; it never repeats an ambiguous reboot.
+
+`update` errors preserve the previous desired pair. Corrupt cached releases fail
+verification rather than silently falling back. A deployment uses the desired
+pair captured when it starts, even if another update completes concurrently.
+
 Use `scripts/magik-platform`:
 
 - `platform --root DIR --layout dev|public --attended --activate-fpga`

--- a/magik/host/magik/build.py
+++ b/magik/host/magik/build.py
@@ -152,6 +152,10 @@ def write_build_cache(cache_file: Path, fingerprint: str, artifact: Path) -> Non
         temporary.unlink(missing_ok=True)
 
 
+def build_repository(package: Path) -> Path:
+    return package.resolve().parents[2 if package.name == "manager" else 1]
+
+
 def ensure_arm_package(
     package: Path,
     cache_file: Path,
@@ -165,7 +169,7 @@ def ensure_arm_package(
     from .storage import Storage
 
     storage = Storage(runner=runner)
-    with storage.build_session(package.resolve().parents[1]):
+    with storage.build_session(build_repository(package)):
         return _ensure_arm_package(
             package,
             cache_file,
@@ -192,9 +196,15 @@ def _ensure_arm_package(
         None,
     )
     profile = app.profile if app else "release"
-    binary = app.binary if app else "mister-magik-service"
+    binary = (
+        app.binary
+        if app
+        else "mister-magik-manager"
+        if package.name == "manager"
+        else "mister-magik-service"
+    )
     artifact = package / "target" / TARGET / profile / binary
-    repository = package.resolve().parents[1]
+    repository = build_repository(package)
     if (
         app
         and app.name == "magik"
@@ -222,7 +232,7 @@ def _ensure_arm_package(
             int((time.monotonic() - started) * 1000),
             fingerprint=fingerprint,
         )
-    repository = package.resolve().parents[1]
+    repository = build_repository(package)
     name = prepare(repository, runner)
     environment = []
     if app and app.name == "magik":

--- a/magik/host/magik/cli.py
+++ b/magik/host/magik/cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import argparse
+from contextlib import ExitStack
 import hashlib
 import os
+import subprocess
 import time
 import webbrowser
 from pathlib import Path
@@ -61,7 +63,10 @@ def main() -> int:
     )
     prepare = subcommands.add_parser("desktop-prepare")
     prepare.add_argument("--json", action="store_true", required=True)
-    subcommands.add_parser("deploy")
+    subcommands.add_parser("deploy").add_argument("--attended", action="store_true")
+    subcommands.add_parser(
+        "update", help="download and queue latest platform and databases"
+    )
     device_command = subcommands.add_parser("device")
     device_subcommands = device_command.add_subparsers(
         dest="device_command", required=True
@@ -111,6 +116,14 @@ def main() -> int:
     clean.add_argument("--apply", action="store_true")
     clean.add_argument("--all-idle", action="store_true")
     arguments = parser.parse_args()
+    if arguments.command == "update":
+        from .updates import update
+
+        try:
+            return update()
+        except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as error:
+            print(f"magik update: {error}", file=os.sys.stderr)
+            return 2
     if arguments.command == "storage":
         from .storage import run_storage
 
@@ -236,12 +249,34 @@ def dispatch(arguments, run) -> int:
 
 def deploy(_arguments: argparse.Namespace, run: Path) -> int:
     started = time.monotonic()
+    deployment_locks = ExitStack()
     try:
+        from .updates import desired
+
+        queued = desired() if _arguments.app == "magik" else None
         agent, status = connect_agent(
             run,
             REQUIRED_AGENT_CAPABILITIES
-            | application(_arguments.app).agent_capabilities,
+            | application(_arguments.app).agent_capabilities
+            | (
+                {"publication-state-v1", "publication-v1", "platform-publication-v1"}
+                if queued
+                else set()
+            ),
         )
+        if queued:
+            from .update_deploy import apply_updates, device_lock
+
+            deployment_locks.enter_context(device_lock(status.identity))
+            apply_updates(
+                agent,
+                status.identity,
+                queued,
+                run,
+                getattr(_arguments, "attended", False),
+                already_locked=True,
+            )
+            status = agent.status()
         append_event(
             run,
             {
@@ -273,6 +308,7 @@ def deploy(_arguments: argparse.Namespace, run: Path) -> int:
         print(f"magik deploy: {error} (result: {run})", file=os.sys.stderr)
         return 2
     finally:
+        deployment_locks.close()
         if "agent" in locals():
             retain_diagnostics(run, agent)
     print(f"magik deploy: application started (result: {run})")

--- a/magik/host/magik/publication.py
+++ b/magik/host/magik/publication.py
@@ -20,7 +20,9 @@ def publish(agent, run: Path, files: dict[str, Path], **fields):
     evidence = run / "publication.json"
 
     def save():
-        evidence.write_text(json.dumps(journal, indent=2) + "\n")
+        from .updates import atomic_json
+
+        atomic_json(evidence, journal)
 
     save()
     try:

--- a/magik/host/magik/update_deploy.py
+++ b/magik/host/magik/update_deploy.py
@@ -1,0 +1,282 @@
+"""Apply a pinned support-release pair before ordinary application deployment."""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import zipfile
+
+from .apps import repository
+from .build import ensure_arm_application, ensure_arm_package
+from .client import AgentError
+from .publication import publish
+from .updates import atomic_json, contracts, lock, names, root, verify
+
+PLATFORM_MEMBERS = {
+    "main": "main/MiSTer_MagiK",
+    "scanout_module": "scanout/mister_magik_scanout_slots.ko",
+    "scanout_metadata": "scanout/provenance.txt",
+    "latch_rbf": "fpga/patched/menu-magik-vblank-latch.rbf",
+    "latch_metadata": "fpga/patched/menu-magik-vblank-latch.metadata.txt",
+}
+
+
+def state(agent):
+    reply, _ = agent._request(
+        "publication-state", {"layout": "dev"}, attempts=2, timeout=60
+    )
+    if reply.operation != "publication-state":
+        raise AgentError.from_fields(reply.fields)
+    return dict(reply.fields)
+
+
+def extract(archive, destination):
+    with zipfile.ZipFile(archive) as stream:
+        for member in stream.infolist():
+            path = destination / member.filename
+            if not path.resolve().is_relative_to(destination.resolve()):
+                raise ValueError("unsafe release archive path")
+        stream.extractall(destination)
+
+
+def unique(directory, pattern):
+    paths = list(directory.rglob(pattern))
+    if len(paths) != 1:
+        raise ValueError(f"expected one {pattern} in {directory}")
+    return paths[0]
+
+
+def prepare(pair, directory):
+    contracts()
+    from scripts.magik_ci import manifest
+
+    platform = pair["platform"]
+    payload = verify("platform", platform)
+    extracted = directory / "platform"
+    extract(
+        Path(platform["directory"]) / names("platform", platform["version"])[0],
+        extracted,
+    )
+    package = repository() / "apps/mister"
+    gui = ensure_arm_application(package, package / "target/magik-build.json").artifact
+    package = repository() / "mister/tools/manager"
+    manager = ensure_arm_package(package, package / "target/magik-build.json").artifact
+    files = {
+        "main": unique(extracted / "main", "MiSTer_MagiK"),
+        "gui": gui,
+        "manager": manager,
+        "scanout_module": unique(extracted / "scanout", "*.ko"),
+        "scanout_metadata": unique(extracted / "scanout", "provenance.txt"),
+        "latch_rbf": extracted / "fpga/patched/menu-magik-vblank-latch.rbf",
+        "latch_metadata": extracted
+        / "fpga/patched/menu-magik-vblank-latch.metadata.txt",
+    }
+    subprocess.run(
+        [
+            str(repository() / "scripts/cargo"),
+            "build",
+            "--locked",
+            "--manifest-path",
+            str(repository() / "mister/platform/contracts/manifest/Cargo.toml"),
+            "--bin",
+            "platform-manifest-check",
+        ],
+        check=True,
+    )
+    manifest_path = directory / "platform-v3.manifest"
+    receipt = json.loads(
+        unique(extracted / "main", "main-component-v0.1.json").read_text()
+    )
+    revision = subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=repository(), text=True
+    ).strip()
+    primary = Path(
+        subprocess.check_output(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=repository(),
+            text=True,
+        ).strip()
+    ).parent
+    previous = os.environ.get("MISTER_MAGIK_MANIFEST_CHECK")
+    os.environ["MISTER_MAGIK_MANIFEST_CHECK"] = str(
+        primary
+        / "mister/platform/contracts/manifest/target/debug/platform-manifest-check"
+    )
+    try:
+        manifest.generate(
+            manifest_path,
+            files,
+            release_number=platform["version"],
+            bundle_id=payload["bundle_id"],
+            main_revision=receipt["source_revision"],
+            magik_revision=revision,
+            layout="dev",
+        )
+    finally:
+        if previous is None:
+            os.environ.pop("MISTER_MAGIK_MANIFEST_CHECK", None)
+        else:
+            os.environ["MISTER_MAGIK_MANIFEST_CHECK"] = previous
+    files["manifest"] = manifest_path
+    return files
+
+
+def database_files(pair, directory):
+    _, databases = contracts()
+    databases.extract_release(Path(pair["databases"]["directory"]), directory)
+    files = {
+        name: directory / name
+        for name in (
+            "magik-metadata-v1.bin",
+            "arcade-updater-index-v1.lz4b",
+            "game-databases-manifest.json",
+        )
+    }
+    files["game-databases-SHA256SUMS"] = directory / "SHA256SUMS"
+    return files
+
+
+def needed(installed, release, kind, payload):
+    version = int(installed.get("version") or 0)
+    if version > release["version"]:
+        if not installed.get("verified"):
+            raise AgentError(f"newer installed {kind} is invalid; refusing downgrade")
+        return False
+    matches = version == release["version"] and installed.get("verified")
+    if kind == "platform":
+        matches = matches and installed.get("bundle_id") == payload["bundle_id"]
+        expected = {entry["path"]: entry["sha256"] for entry in payload["files"]}
+        matches = matches and all(
+            installed.get("hashes", {}).get(name) == expected[path]
+            for name, path in PLATFORM_MEMBERS.items()
+        )
+    else:
+        manifest = Path(release["directory"]) / names(kind, release["version"])[1]
+        matches = (
+            matches
+            and installed.get("hashes", {}).get("manifest")
+            == hashlib.sha256(manifest.read_bytes()).hexdigest()
+        )
+    return not matches
+
+
+def device_lock(identity):
+    key = hashlib.sha256(identity.encode()).hexdigest()
+    return lock(root() / "devices" / f"{key}.lock")
+
+
+def apply_updates(agent, identity, pair, run, attended, *, already_locked=False):
+    device_key = hashlib.sha256(identity.encode()).hexdigest()
+    with nullcontext() if already_locked else device_lock(identity):
+        pending_path = root() / "devices" / f"{device_key}-pending.json"
+        previous = json.loads(pending_path.read_text()) if pending_path.exists() else {}
+        payloads = {
+            kind: verify(kind, pair[kind]) for kind in ("platform", "databases")
+        }
+        current = state(agent)
+        # A confirmed reboot may have completed while the previous host lost its reply.
+        for stage in current["stages"]:
+            pending = stage["pending"]
+            kind = (
+                "databases"
+                if pending and pending.get("kind") == "databases"
+                else "platform"
+            )
+            journal_path = Path(previous.get("run", "")) / kind / "publication.json"
+            journal = (
+                json.loads(journal_path.read_text())
+                if previous and journal_path.is_file()
+                else {}
+            )
+            if (
+                (attended or kind == "databases")
+                and journal.get("stage") == stage["stage"]
+                and pending
+                and pending.get("layout") == "dev"
+                and (
+                    kind == "databases" or pending.get("boot_id") != current["boot_id"]
+                )
+            ):
+                reply, _ = agent._request(
+                    "publication-control",
+                    {"stage": stage["stage"], "action": "finish", "attended": True},
+                    attempts=1,
+                    timeout=60,
+                )
+                if reply.operation != "publication-complete":
+                    raise AgentError.from_fields(reply.fields)
+            else:
+                raise AgentError(
+                    f"unfinished publication {stage['stage']}; inspect/restore the saved stage before retrying; no reboot repeated"
+                )
+        current = state(agent) if current["stages"] else current
+        platform_needed = needed(
+            current["platform"], pair["platform"], "platform", payloads["platform"]
+        )
+        databases_needed = needed(
+            current["databases"], pair["databases"], "databases", payloads["databases"]
+        )
+        if not platform_needed and current["platform"].get("active") is not True:
+            raise AgentError(
+                "installed platform is not active and healthy; inspect device state before deploying; no reboot attempted"
+            )
+        if platform_needed and not attended:
+            raise AgentError(
+                "queued platform update requires attendance; run: scripts/magik deploy --attended"
+            )
+        if platform_needed:
+            if (
+                current["configured_main"] != "MiSTer_MagiKDev"
+                or current["running"].get("executable_path")
+                != "/media/fat/MiSTer_MagiKDev"
+            ):
+                raise AgentError(
+                    "queued platform requires running and selected Dev mode; select the intended mode explicitly"
+                )
+        with tempfile.TemporaryDirectory(prefix="magik-update-") as temporary:
+            directory = Path(temporary)
+            db_files = (
+                database_files(pair, directory / "databases")
+                if databases_needed
+                else None
+            )
+            platform_files = prepare(pair, directory) if platform_needed else None
+            if databases_needed and not platform_needed:
+                package = repository() / "apps/mister"
+                ensure_arm_application(package, package / "target/magik-build.json")
+            if platform_files or db_files:
+                atomic_json(pending_path, {"desired": pair, "run": str(run.resolve())})
+            for kind, files in (("platform", platform_files), ("databases", db_files)):
+                if files is None:
+                    continue
+                evidence = run / kind
+                evidence.mkdir(exist_ok=True)
+                atomic_json(
+                    evidence / "run.json",
+                    {"operation": kind, "source": {"device_identity": identity}},
+                )
+                fields = {"kind": kind, "layout": "dev"}
+                if kind == "platform":
+                    fields.update(attended=True, activate_fpga=True)
+                print(f"Installing {pair[kind]['tag']}")
+                publish(agent, evidence, files, **fields)
+                current = state(agent)
+                if needed(current[kind], pair[kind], kind, payloads[kind]):
+                    raise AgentError(
+                        f"{kind} installation did not verify; evidence: {evidence}"
+                    )
+        atomic_json(
+            root() / "devices" / f"{device_key}.json",
+            {
+                "identity": identity,
+                "desired": pair,
+                "verified": current,
+                "run": str(run.resolve()),
+            },
+        )
+        pending_path.unlink(missing_ok=True)

--- a/magik/host/magik/updates.py
+++ b/magik/host/magik/updates.py
@@ -1,0 +1,192 @@
+"""Verified immutable support releases shared by this host's devices."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import fcntl
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import zipfile
+
+from .apps import repository
+from .token_store import state_root
+
+REPOSITORY = "NigelBreslaw/MiSTer-MagiK"
+
+
+@contextmanager
+def lock(path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a") as stream:
+        fcntl.flock(stream, fcntl.LOCK_EX)
+        yield
+
+
+def atomic_json(path, value):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(mode="w", dir=path.parent, delete=False) as stream:
+        temporary = Path(stream.name)
+        try:
+            json.dump(value, stream, indent=2)
+            stream.flush()
+            os.fsync(stream.fileno())
+            os.replace(temporary, path)
+            descriptor = os.open(path.parent, os.O_RDONLY)
+            try:
+                os.fsync(descriptor)
+            finally:
+                os.close(descriptor)
+        finally:
+            temporary.unlink(missing_ok=True)
+
+
+def root():
+    return state_root() / "updates"
+
+
+def contracts():
+    sys.path.insert(0, str(repository()))
+    from scripts.magik_ci import bundle, databases
+
+    return bundle, databases
+
+
+def selectors():
+    path = repository() / "scripts/release/databases/select-published-release.py"
+    spec = importlib.util.spec_from_file_location("published_releases", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def names(kind, version):
+    if kind == "platform":
+        return f"mister-magik-platform-v0.{version}.zip", "platform-bundle-v0.2.json"
+    return f"mister-magik-game-databases-v{version}.zip", "game-databases-manifest.json"
+
+
+def verify(kind, release):
+    directory = Path(release["directory"])
+    archive, manifest = names(kind, release["version"])
+    checks = {}
+    for line in (directory / "SHA256SUMS").read_text().splitlines():
+        digest, name = line.split("  ", 1)
+        checks[name] = digest
+    if hashlib.sha256((directory / manifest).read_bytes()).hexdigest() != checks.get(
+        manifest
+    ):
+        raise ValueError(f"release checksum mismatch: {manifest}")
+    # Published checksum files describe ZIP members, not the ZIP container.
+    with zipfile.ZipFile(directory / archive) as stream:
+        members = stream.namelist()
+        if len(members) != len(set(members)):
+            raise ValueError("duplicate release archive member")
+        for name in members:
+            if Path(name).is_absolute() or ".." in Path(name).parts:
+                raise ValueError("unsafe release archive path")
+            if name != "SHA256SUMS" and not name.endswith("/"):
+                if hashlib.sha256(stream.read(name)).hexdigest() != checks.get(name):
+                    raise ValueError(f"release checksum mismatch: {name}")
+        if stream.read("SHA256SUMS") != (directory / "SHA256SUMS").read_bytes():
+            raise ValueError("release checksum file differs from archive")
+    bundle, databases = contracts()
+    if kind == "platform":
+        return bundle.verify(
+            directory / archive, directory / manifest, release["version"]
+        )
+    return databases.verify(
+        directory / archive,
+        directory / manifest,
+        directory / "SHA256SUMS",
+        release["version"],
+    )
+
+
+def desired():
+    path = root() / "desired.json"
+    if not path.exists():
+        return None
+    value = json.loads(path.read_text())
+    for kind in ("platform", "databases"):
+        verify(kind, value[kind])
+    return value
+
+
+def update():
+    with lock(root() / "download.lock"):
+        result = subprocess.run(
+            [
+                "gh",
+                "api",
+                "--paginate",
+                "--slurp",
+                f"repos/{REPOSITORY}/releases?per_page=100",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        pages = json.loads(result.stdout)
+        releases = (
+            [item for page in pages for item in page]
+            if pages and isinstance(pages[0], list)
+            else pages
+        )
+        selector = selectors()
+        platforms = selector.durable_platforms(releases)
+        selected = {
+            "platform": platforms[0] if platforms else None,
+            "databases": selector.select_game_databases(releases),
+        }
+        pair = {"repository": REPOSITORY}
+        for kind, release in selected.items():
+            if release is None:
+                raise ValueError(f"no published numbered {kind} release")
+            tag = release["tag_name"]
+            version = (
+                selector.platform_version(tag)
+                if kind == "platform"
+                else int(tag.removeprefix("game-databases-v"))
+            )
+            directory = root() / "releases" / REPOSITORY / tag
+            entry = {
+                "tag": tag,
+                "version": version,
+                "directory": str(directory.resolve()),
+            }
+            if directory.exists():
+                verify(kind, entry)
+                outcome = "cached"
+            else:
+                directory.parent.mkdir(parents=True, exist_ok=True)
+                with tempfile.TemporaryDirectory(
+                    dir=directory.parent, prefix="download-"
+                ) as temporary:
+                    args = [
+                        "gh",
+                        "release",
+                        "download",
+                        tag,
+                        "--repo",
+                        REPOSITORY,
+                        "--dir",
+                        temporary,
+                    ]
+                    for name in (*names(kind, version), "SHA256SUMS"):
+                        args.extend(["--pattern", name])
+                    subprocess.run(args, check=True, timeout=600)
+                    verify(kind, {**entry, "directory": temporary})
+                    os.rename(temporary, directory)
+                outcome = "downloaded"
+            pair[kind] = entry
+            print(f"{tag}: {outcome}, verified: {directory.resolve()}")
+        atomic_json(root() / "desired.json", pair)
+        print("Queued for all devices. Next: scripts/magik deploy --attended")
+    return 0

--- a/magik/host/tests/test_updates.py
+++ b/magik/host/tests/test_updates.py
@@ -1,0 +1,300 @@
+from unittest.mock import Mock
+import hashlib
+import json
+import subprocess
+from types import SimpleNamespace
+import zipfile
+
+import pytest
+
+from magik import updates, update_deploy
+
+
+def test_numbered_release_selection_includes_prereleases():
+    selector = updates.selectors()
+    releases = [
+        {"tag_name": "platform-v0.10", "published_at": "2026", "prerelease": True},
+        {"tag_name": "platform-v0.11", "published_at": "2026", "draft": True},
+        {"tag_name": "platform-v0.9", "published_at": "2027"},
+        {"tag_name": "game-databases-v12", "published_at": "2026", "prerelease": True},
+    ]
+    assert selector.durable_platforms(releases)[0]["tag_name"] == "platform-v0.10"
+    assert selector.select_game_databases(releases)["tag_name"] == "game-databases-v12"
+
+
+def test_update_failure_preserves_previous_pair(tmp_path, monkeypatch):
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    updates.atomic_json(updates.root() / "desired.json", {"old": True})
+    monkeypatch.setattr(
+        updates.subprocess,
+        "run",
+        Mock(side_effect=subprocess.CalledProcessError(1, "gh")),
+    )
+    with pytest.raises(subprocess.CalledProcessError):
+        updates.update()
+    assert json.loads((updates.root() / "desired.json").read_text()) == {"old": True}
+
+
+def test_verify_rejects_corrupt_assets_before_contracts(tmp_path, monkeypatch):
+    archive, manifest = updates.names("platform", 2)
+    for name in (archive, manifest):
+        (tmp_path / name).write_bytes(b"bad")
+    (tmp_path / "SHA256SUMS").write_text(f"{'0' * 64}  {archive}\n")
+    contracts = Mock()
+    monkeypatch.setattr(updates, "contracts", contracts)
+    with pytest.raises(ValueError, match="checksum"):
+        updates.verify("platform", {"directory": str(tmp_path), "version": 2})
+    contracts.assert_not_called()
+
+
+@pytest.fixture
+def deploy_case(tmp_path, monkeypatch):
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    manifest = tmp_path / "game-databases-manifest.json"
+    manifest.write_text("database")
+    pair = {
+        kind: {"tag": kind, "version": 2, "directory": str(tmp_path)}
+        for kind in ("platform", "databases")
+    }
+    current = {
+        "platform": {
+            "version": 2,
+            "verified": True,
+            "active": True,
+            "bundle_id": "bundle",
+        },
+        "databases": {
+            "version": 2,
+            "verified": True,
+            "hashes": {"manifest": hashlib.sha256(manifest.read_bytes()).hexdigest()},
+        },
+        "stages": [],
+        "boot_id": "boot",
+        "configured_main": "MiSTer_MagiKDev",
+        "running": {"executable_path": "/media/fat/MiSTer_MagiKDev"},
+    }
+    current["platform"]["hashes"] = {
+        name: "hash" for name in update_deploy.PLATFORM_MEMBERS
+    }
+    monkeypatch.setattr(
+        update_deploy,
+        "verify",
+        lambda *_: {
+            "bundle_id": "bundle",
+            "files": [
+                {"path": path, "sha256": "hash"}
+                for path in update_deploy.PLATFORM_MEMBERS.values()
+            ],
+        },
+    )
+    monkeypatch.setattr(update_deploy, "state", lambda *_: current)
+    monkeypatch.setattr(update_deploy, "ensure_arm_application", Mock())
+    publish = Mock()
+    monkeypatch.setattr(update_deploy, "publish", publish)
+    return pair, current, publish
+
+
+def test_current_pair_is_noop_on_multiple_devices(deploy_case, tmp_path):
+    pair, _, publish = deploy_case
+    for identity in ("one", "two"):
+        update_deploy.apply_updates(Mock(), identity, pair, tmp_path, False)
+    publish.assert_not_called()
+    assert len(list((updates.root() / "devices").glob("*.json"))) == 2
+
+
+def test_missing_attendance_prevents_all_publication(deploy_case, tmp_path):
+    pair, current, publish = deploy_case
+    current["platform"]["version"] = 1
+    with pytest.raises(RuntimeError, match="deploy --attended"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    publish.assert_not_called()
+
+
+def test_database_only_does_not_prepare_platform(deploy_case, tmp_path, monkeypatch):
+    pair, current, publish = deploy_case
+    current["databases"]["version"] = 1
+    prepare = Mock(side_effect=AssertionError("unexpected platform build"))
+    monkeypatch.setattr(update_deploy, "prepare", prepare)
+    monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
+    publish.side_effect = lambda *a, **kw: current["databases"].update(version=2)
+    update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    assert publish.call_args.kwargs == {"kind": "databases", "layout": "dev"}
+
+
+def test_ambiguous_stage_does_not_reboot(deploy_case, tmp_path):
+    pair, current, publish = deploy_case
+    current["stages"] = [
+        {"stage": "a" * 32, "pending": {"layout": "dev", "boot_id": "boot"}}
+    ]
+    agent = Mock()
+    with pytest.raises(RuntimeError, match="no reboot repeated"):
+        update_deploy.apply_updates(agent, "one", pair, tmp_path, True)
+    agent._request.assert_not_called()
+    publish.assert_not_called()
+
+
+def test_newer_invalid_release_never_downgrades():
+    with pytest.raises(RuntimeError, match="refusing downgrade"):
+        update_deploy.needed(
+            {"version": 3, "verified": False}, {"version": 2}, "platform", {}
+        )
+
+
+def test_platform_success_database_failure_retries_only_database(
+    deploy_case, tmp_path, monkeypatch
+):
+    pair, current, publish = deploy_case
+    current["platform"]["version"] = 1
+    current["databases"]["version"] = 1
+    prepare = Mock(return_value={"platform": tmp_path})
+    monkeypatch.setattr(update_deploy, "prepare", prepare)
+    monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
+
+    def fail_database(*args, **fields):
+        if fields["kind"] == "platform":
+            current["platform"]["version"] = 2
+        else:
+            raise RuntimeError("database transport lost")
+
+    publish.side_effect = fail_database
+    with pytest.raises(RuntimeError, match="transport lost"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, True)
+    assert (
+        updates.root()
+        / "devices"
+        / f"{hashlib.sha256(b'one').hexdigest()}-pending.json"
+    ).exists()
+    publish.reset_mock()
+    publish.side_effect = lambda *a, **kw: current["databases"].update(version=2)
+    update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    assert publish.call_count == 1
+    assert publish.call_args.kwargs["kind"] == "databases"
+    assert prepare.call_count == 1
+
+
+def test_archive_path_escape_rejected(tmp_path):
+    import zipfile
+
+    archive = tmp_path / "bad.zip"
+    with zipfile.ZipFile(archive, "w") as stream:
+        stream.writestr("../outside", "bad")
+    with pytest.raises(ValueError, match="unsafe"):
+        update_deploy.extract(archive, tmp_path / "output")
+    assert not (tmp_path / "outside").exists()
+
+
+def test_paginated_download_then_cache_reuse(tmp_path, monkeypatch):
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    validator = SimpleNamespace(verify=lambda *_: {})
+    monkeypatch.setattr(updates, "contracts", lambda: (validator, validator))
+    calls = []
+
+    def gh(args, **kwargs):
+        calls.append(args)
+        if args[1] == "api":
+            return SimpleNamespace(
+                stdout=json.dumps(
+                    [
+                        [
+                            {
+                                "tag_name": "platform-v0.4",
+                                "published_at": "now",
+                                "prerelease": True,
+                            }
+                        ],
+                        [{"tag_name": "game-databases-v8", "published_at": "now"}],
+                    ]
+                )
+            )
+        kind, version = (
+            ("platform", 4) if args[3] == "platform-v0.4" else ("databases", 8)
+        )
+        directory = Path(args[args.index("--dir") + 1])
+        archive, manifest = updates.names(kind, version)
+        payload = b"{}"
+        checks = f"{hashlib.sha256(payload).hexdigest()}  {manifest}\n".encode()
+        (directory / manifest).write_bytes(payload)
+        (directory / "SHA256SUMS").write_bytes(checks)
+        with zipfile.ZipFile(directory / archive, "w") as stream:
+            stream.writestr(manifest, payload)
+            stream.writestr("SHA256SUMS", checks)
+        return SimpleNamespace(returncode=0)
+
+    from pathlib import Path
+
+    monkeypatch.setattr(updates.subprocess, "run", gh)
+    assert updates.update() == 0
+    pair = updates.desired()
+    assert pair["platform"]["version"] == 4
+    assert pair["databases"]["version"] == 8
+    assert updates.update() == 0
+    assert len([args for args in calls if args[1] == "release"]) == 2
+    assert len([args for args in calls if args[1] == "api"]) == 2
+
+
+def test_device_lock_serializes_same_identity(tmp_path, monkeypatch):
+    import threading
+
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))
+    started, acquired = threading.Event(), threading.Event()
+
+    def second():
+        started.set()
+        with update_deploy.device_lock("same"):
+            acquired.set()
+
+    with update_deploy.device_lock("same"):
+        worker = threading.Thread(target=second)
+        worker.start()
+        assert started.wait(2)
+        assert not acquired.wait(0.05)
+        with update_deploy.device_lock("another"):
+            pass
+    worker.join(2)
+    assert acquired.is_set()
+
+
+def test_manager_build_uses_repository_root_and_manager_binary(tmp_path):
+    from magik.build import ensure_arm_package, TARGET
+
+    package = tmp_path / "mister/tools/manager"
+    package.mkdir(parents=True)
+    artifact = package / "target" / TARGET / "release/mister-magik-manager"
+    commands, roots = [], []
+
+    def runner(command, **kwargs):
+        commands.append(command)
+        artifact.parent.mkdir(parents=True, exist_ok=True)
+        artifact.write_bytes(b"manager")
+        return SimpleNamespace(returncode=0)
+
+    result = ensure_arm_package(
+        package,
+        package / "target/cache.json",
+        runner=runner,
+        prepare=lambda repo, _: roots.append(repo) or "builder",
+    )
+    assert result.artifact == artifact
+    assert roots == [tmp_path]
+    assert "/workspace/mister/tools/manager" in commands[0]
+    assert commands[0][commands[0].index("--bin") + 1] == "mister-magik-manager"
+
+
+def test_unhealthy_installed_platform_is_not_rebooted(deploy_case, tmp_path):
+    pair, current, publish = deploy_case
+    current["platform"]["active"] = False
+    with pytest.raises(RuntimeError, match="no reboot attempted"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, True)
+    publish.assert_not_called()
+
+
+def test_local_main_change_requires_release_install_but_gui_change_does_not(
+    deploy_case, tmp_path
+):
+    pair, current, publish = deploy_case
+    current["platform"]["hashes"]["gui"] = "local edit"
+    update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    publish.assert_not_called()
+    current["platform"]["hashes"]["main"] = "different Main with same bundle id"
+    with pytest.raises(RuntimeError, match="deploy --attended"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)

--- a/magik/host/tests/test_updates.py
+++ b/magik/host/tests/test_updates.py
@@ -102,6 +102,48 @@ def test_current_pair_is_noop_on_multiple_devices(deploy_case, tmp_path):
     assert len(list((updates.root() / "devices").glob("*.json"))) == 2
 
 
+def test_queued_deploy_starts_idle_application(deploy_case, tmp_path, monkeypatch):
+    from argparse import Namespace
+    from magik import cli
+    from magik.build import BuildResult
+    from magik.compatibility import AgentStatus
+    from magik.protocol import sha256_hex
+    from magik.results import create_run
+
+    pair, current, publish = deploy_case
+    current["running"]["launcher_ready_phase"] = "idle"
+    artifact = tmp_path / "application"
+    artifact.write_bytes(b"application")
+    status = AgentStatus(
+        "device",
+        frozenset(),
+        {
+            "running": False,
+            "ready": False,
+            "artifacts": {"magik": sha256_hex(b"application")},
+        },
+    )
+    agent = Mock()
+    agent.status.return_value = status
+    monkeypatch.setattr(updates, "desired", lambda: pair)
+    monkeypatch.setattr(cli, "connect_agent", lambda *_: (agent, status))
+    monkeypatch.setattr(
+        cli, "ensure_arm_application", lambda *_: BuildResult(artifact, False, 0)
+    )
+    monkeypatch.setattr(cli, "retain_diagnostics", lambda *_: None)
+    assert (
+        cli.deploy(
+            Namespace(app="magik", attended=False), create_run(tmp_path, "deploy", {})
+        )
+        == 0
+    )
+    publish.assert_not_called()
+    agent.upload.assert_not_called()
+    agent.start.assert_called_once_with(
+        expected_sha256=sha256_hex(b"application"), restart=False
+    )
+
+
 def test_missing_attendance_prevents_all_publication(deploy_case, tmp_path):
     pair, current, publish = deploy_case
     current["platform"]["version"] = 1


### PR DESCRIPTION
## Change

Add `scripts/magik update` to download and verify the latest numbered platform and database releases, then atomically queue the pair for this host's devices. The next real-MagiK `deploy --attended` installs outstanding Dev updates before starting the application; database-only changes need no attendance or reboot.

Deployment compares native installed identities and hashes with the pinned releases, preserves newer versions, and serializes each device's deployment. Separate publication journals support partial completion and bounded activation reconciliation. Native completion verifies the expected manifest and running Main before releasing backups. Ordinary GUI edits do not reinstall platform components.

## Validation

- 59 focused host tests passed across updates, deploy, publication operations, and builds.
- 3 focused native publication tests passed; Rust LSP diagnostics are clear.
- Formatting/lint and index-based pre-commit checks passed.
- Live download and repeat cache verification passed for platform-v0.41 and game-databases-v23 using isolated temporary state.

Hardware acceptance remains separately attended. No device installation, activation, or reboot was performed, and the user's normal desired-release queue was not changed.
