### PR TITLE
Make release updates one command with native boot recovery

### DIFF
--- a/.github/workflows/magik.yml
+++ b/.github/workflows/magik.yml
@@ -20,7 +20,7 @@ jobs:
           python-version: "3.12"
       - run: python -m pip install uv ruff==0.11.8
       # These are host-only fixtures; the private on-device test driver is unused.
-      - run: uv export --frozen --project magik/host --no-emit-project --no-emit-package slint-testing --output-file /tmp/magik-host-requirements.txt > /dev/null
+      - run: uv export --frozen --extra mcp --project magik/host --no-emit-project --no-emit-package slint-testing --output-file /tmp/magik-host-requirements.txt > /dev/null
       - run: uv pip install --system -r /tmp/magik-host-requirements.txt
       - run: ruff format --check magik/host magik/scenarios
       - run: ruff check --select E4,E7,E9,F magik/host magik/scenarios

--- a/magik/agent/src/lib.rs
+++ b/magik/agent/src/lib.rs
@@ -12,6 +12,7 @@ mod media;
 mod mode;
 mod publication;
 mod sd;
+mod service_boot;
 mod telemetry;
 mod upload;
 mod wire;
@@ -190,6 +191,7 @@ impl Agent {
             "publication-v1",
             "platform-publication-v1",
             "publication-state-v1",
+            "service-boot-v1",
             "transfer-check",
             "applications",
             "main-input-proxy",
@@ -303,6 +305,41 @@ impl Agent {
             );
         }
 
+        if matches!(
+            request.op.as_str(),
+            "service-boot-state" | "service-boot-install"
+        ) {
+            if body_length != 0 {
+                return Err(FrameError::BodyTooLarge);
+            }
+            let _mutation = self.mutations.lock().expect("mutation state poisoned");
+            let fat = Path::new("/media/fat");
+            let init = Path::new("/etc/init.d/S99user");
+            let result = if request.op == "service-boot-install" {
+                if self.install_root != fat.join("mister-magik2") {
+                    Err(std::io::Error::other(
+                        "boot registration requires the standard service root",
+                    ))
+                } else {
+                    service_boot::install(fat, init)
+                }
+            } else {
+                Ok(())
+            };
+            let reply = match result {
+                Ok(()) => response(
+                    &request.id,
+                    "service-boot-state",
+                    serde_json::json!({"ready":service_boot::ready(fat, init)}),
+                ),
+                Err(error) => response(
+                    &request.id,
+                    "error",
+                    serde_json::json!({"code":"service-boot-failed","detail":error.to_string()}),
+                ),
+            };
+            return write_frame(stream, &reply, &[]);
+        }
         if request.op == "publication-upload" {
             let _mutation = self.mutations.lock().expect("mutation state poisoned");
             let result = publication::receive(

--- a/magik/agent/src/main.rs
+++ b/magik/agent/src/main.rs
@@ -21,8 +21,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         PathBuf::from(root),
         PathBuf::from(state_root),
     ));
-    agent.start_observation_receiver()?;
     let listener = TcpListener::bind(format!("0.0.0.0:{port}"))?;
+    // A duplicate boot launch must not disturb the running observation receiver.
+    agent.start_observation_receiver()?;
     let active = Arc::new(AtomicUsize::new(0));
     for connection in listener.incoming() {
         match connection {

--- a/magik/agent/src/publication.rs
+++ b/magik/agent/src/publication.rs
@@ -543,6 +543,12 @@ impl crate::Agent {
                 }
             }
             if fields["kind"] == "platform" {
+                if !crate::service_boot::ready(
+                    Path::new("/media/fat"),
+                    Path::new("/etc/init.d/S99user"),
+                ) {
+                    return Err("native service boot registration must be verified before platform publication".into());
+                }
                 let selected = crate::mode::status()?["configured_main"]
                     .as_str()
                     .unwrap_or("")

--- a/magik/agent/src/service_boot.rs
+++ b/magik/agent/src/service_boot.rs
@@ -1,0 +1,201 @@
+//! Fixed native service boot registration. Never changes boot mode or reboots.
+use std::fs::{self, File, OpenOptions};
+use std::io::{self, Write};
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+const HOOK: &str = "# MiSTer MagiK native service boot v1\n/bin/sh /media/fat/mister-magik2/start-service.sh || :\n# End MiSTer MagiK native service boot v1\n";
+const SCRIPT: &str = "#!/bin/sh\nset -eu\nexport MISTER_MAGIK2_INSTALL_ROOT=/media/fat/mister-magik2\nexport MISTER_MAGIK2_STATE_ROOT=/tmp/mister-magik2\nMISTER_MAGIK2_TOKEN=$(cat /media/fat/mister-magik2/token)\nexport MISTER_MAGIK2_TOKEN\n[ -n \"$MISTER_MAGIK2_TOKEN\" ]\nmkdir -p /tmp/mister-magik2\nnohup /media/fat/mister-magik2/mister-magik-service </dev/null >>/tmp/mister-magik2/agent.log 2>&1 &\n";
+
+fn regular(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) if !metadata.file_type().is_file() => {
+            Err(io::Error::other("boot path is not a regular file"))
+        }
+        Ok(_) => Ok(()),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn atomic(path: &Path, data: &[u8], mode: u32) -> io::Result<()> {
+    regular(path)?;
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_err(io::Error::other)?
+        .as_nanos();
+    let temporary = path.with_extension(format!("magik-next-{}-{nonce}", std::process::id()));
+    // Unique siblings leave an interrupted write harmless; never follow links.
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temporary)?;
+    let result = (|| {
+        file.write_all(data)?;
+        file.set_permissions(fs::Permissions::from_mode(mode))?;
+        file.sync_all()?;
+        fs::rename(&temporary, path)?;
+        File::open(path.parent().unwrap())?.sync_all()
+    })();
+    if result.is_err() {
+        let _ = fs::remove_file(temporary);
+    }
+    result
+}
+
+fn startup(original: &str) -> io::Result<String> {
+    let (header, rest) = if original.starts_with("#!") {
+        original
+            .split_once('\n')
+            .ok_or_else(|| io::Error::other("invalid startup shebang"))?
+    } else {
+        ("#!/bin/sh", original)
+    };
+    if rest.starts_with(HOOK) {
+        return Ok(original.to_owned());
+    }
+    if original.contains("MiSTer MagiK native service boot")
+        || original.contains("mister-magik2/start-service.sh")
+    {
+        return Err(io::Error::other(
+            "unrecognized service boot hook; inspect startup file",
+        ));
+    }
+    Ok(format!("{header}\n{HOOK}{rest}"))
+}
+
+pub fn ready(fat: &Path, init: &Path) -> bool {
+    let startup_path = fat.join("linux/user-startup.sh");
+    let script = fat.join("mister-magik2/start-service.sh");
+    init.is_file()
+        && fs::metadata(fat.join("mister-magik2/mister-magik-service"))
+            .is_ok_and(|m| m.is_file() && m.permissions().mode() & 0o111 != 0)
+        && fs::read_to_string(fat.join("mister-magik2/token")).is_ok_and(|t| !t.trim().is_empty())
+        && regular(&startup_path).is_ok()
+        && regular(&script).is_ok()
+        && fs::read_to_string(&script).ok().as_deref() == Some(SCRIPT)
+        && fs::read_to_string(&startup_path).ok().is_some_and(|text| {
+            text.split_once('\n')
+                .is_some_and(|(_, rest)| rest.starts_with(HOOK))
+        })
+        && fs::metadata(startup_path).is_ok_and(|m| m.permissions().mode() & 0o111 != 0)
+}
+
+pub fn install(fat: &Path, init: &Path) -> io::Result<()> {
+    if !init.is_file() {
+        return Err(io::Error::other("MiSTer S99user boot hook is unavailable"));
+    }
+    let root = fat.join("mister-magik2");
+    if !root.join("mister-magik-service").is_file() || fs::read(root.join("token"))?.is_empty() {
+        return Err(io::Error::other(
+            "native service binary or token unavailable",
+        ));
+    }
+    let path = fat.join("linux/user-startup.sh");
+    regular(&path)?;
+    let original = match fs::read_to_string(&path) {
+        Ok(text) => text,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => "#!/bin/sh\n".to_owned(),
+        Err(error) => return Err(error),
+    };
+    let updated = startup(&original)?;
+    fs::create_dir_all(path.parent().unwrap())?;
+    if updated != original {
+        let backup = root.join("user-startup.before-magik");
+        if !backup.exists() {
+            atomic(&backup, original.as_bytes(), 0o600)?;
+        }
+    }
+    if fs::read_to_string(root.join("start-service.sh"))
+        .ok()
+        .as_deref()
+        != Some(SCRIPT)
+    {
+        atomic(&root.join("start-service.sh"), SCRIPT.as_bytes(), 0o700)?;
+    }
+    if !ready(fat, init) {
+        let mode = fs::metadata(&path)
+            .map(|m| m.permissions().mode())
+            .unwrap_or(0o755)
+            | 0o100;
+        atomic(&path, updated.as_bytes(), mode)?;
+    }
+    if !ready(fat, init) {
+        return Err(io::Error::other("service boot registration did not verify"));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn startup_preserves_user_commands_and_precedes_exit() {
+        let original = "#!/bin/bash\necho user\nexit 0\n";
+        let changed = startup(original).unwrap();
+        assert!(changed.ends_with("echo user\nexit 0\n"));
+        assert_eq!(startup(&changed).unwrap(), changed);
+        assert!(startup("#!/bin/sh\n# MiSTer MagiK native service boot unknown\n").is_err());
+    }
+
+    #[test]
+    fn installs_verifies_and_preserves_backup() {
+        let directory =
+            std::env::temp_dir().join(format!("magik-service-boot-test-{}", std::process::id()));
+        fs::create_dir(&directory).unwrap();
+        let fat = directory.as_path();
+        fs::create_dir_all(fat.join("mister-magik2")).unwrap();
+        fs::create_dir_all(fat.join("linux")).unwrap();
+        fs::write(fat.join("mister-magik2/token"), "token").unwrap();
+        fs::write(fat.join("mister-magik2/mister-magik-service"), "binary").unwrap();
+        fs::set_permissions(
+            fat.join("mister-magik2/mister-magik-service"),
+            fs::Permissions::from_mode(0o700),
+        )
+        .unwrap();
+        let init = fat.join("S99user");
+        assert!(install(fat, &init).is_err());
+        fs::write(&init, "init").unwrap();
+        fs::write(fat.join("linux/user-startup.sh"), "#!/bin/bash\nexit 0\n").unwrap();
+        install(fat, &init).unwrap();
+        assert!(ready(fat, &init));
+        install(fat, &init).unwrap();
+        assert_eq!(
+            fs::read_to_string(fat.join("mister-magik2/user-startup.before-magik")).unwrap(),
+            "#!/bin/bash\nexit 0\n"
+        );
+        fs::write(fat.join("mister-magik2/start-service.sh"), "corrupt").unwrap();
+        assert!(!ready(fat, &init));
+        // An interrupted atomic write must not block a subsequent registration.
+        fs::write(
+            fat.join("linux/user-startup.magik-next-abandoned"),
+            "partial",
+        )
+        .unwrap();
+        install(fat, &init).unwrap();
+        assert!(ready(fat, &init));
+        assert!(
+            std::process::Command::new("/bin/sh")
+                .arg("-n")
+                .arg(fat.join("mister-magik2/start-service.sh"))
+                .status()
+                .unwrap()
+                .success()
+        );
+        // Never replace an operator's symlink or its target.
+        fs::remove_file(fat.join("linux/user-startup.sh")).unwrap();
+        fs::write(fat.join("operator-startup"), "preserve").unwrap();
+        std::os::unix::fs::symlink(
+            fat.join("operator-startup"),
+            fat.join("linux/user-startup.sh"),
+        )
+        .unwrap();
+        assert!(install(fat, &init).is_err());
+        assert_eq!(
+            fs::read_to_string(fat.join("operator-startup")).unwrap(),
+            "preserve"
+        );
+        fs::remove_dir_all(directory).unwrap();
+    }
+}

--- a/magik/docs/native-operations.md
+++ b/magik/docs/native-operations.md
@@ -32,11 +32,13 @@ Raw reports and failures are retained in the command's result directory.
 
 ## Independent platform entrypoint
 
-### Queue published releases for the next deploy
+### Update published releases in one command
 
-Run `scripts/magik update` to download and verify the latest numbered platform
+Run `scripts/magik update --attended` to download, verify and deploy the latest numbered platform
 and game-database releases from `NigelBreslaw/MiSTer-MagiK`. Published prereleases
-are included; drafts are excluded. The command does not contact the device.
+are included; drafts are excluded. Use `scripts/magik update --download-only`
+to queue releases without contacting the device. Plain `update` installs database-only
+changes, but requests attendance before a required platform activation.
 Both releases must verify before the shared desired pair changes. Downloads live
 under `$MISTER_MAGIK2_STATE/updates` (the normal shared state directory when unset).
 The output includes the database release directory usable with `catalog publish`.
@@ -57,7 +59,20 @@ platform transaction is finished automatically only when its saved host journal
 matches and a new boot is confirmed. Otherwise deployment stops with the stage ID
 for explicit inspection/restoration; it never repeats an ambiguous reboot.
 
-`update` errors preserve the previous desired pair. Corrupt cached releases fail
+Before platform replacement, native `service-boot-state`/`service-boot-install`
+operations verify/register the service through MiSTer's `linux/user-startup.sh`
+hook. Existing commands are preserved, with the original saved as
+`mister-magik2/user-startup.before-magik`. No boot-mode changes or reboot loops
+are added. Reboot rediscovery is native-only and bound to the selected board.
+Unavailable service recovery is separate from platform activation; never repeat
+an ambiguous reboot to recover connectivity.
+
+Host download and build preparation check disk headroom before proceeding.
+The CLI uses its frozen lock; private Slint testing dependencies are installed
+only for `check`, not update/deploy. Build errors retain container diagnostics.
+
+Download/verification errors preserve the previous desired pair; installation
+errors retain the newly verified desired pair for recovery. Corrupt cached releases fail
 verification rather than silently falling back. A deployment uses the desired
 pair captured when it starts, even if another update completes concurrently.
 

--- a/magik/host/magik/build.py
+++ b/magik/host/magik/build.py
@@ -93,6 +93,9 @@ def _ensure_arm_package(
             check=True,
         )
     started = time.monotonic()
+    from .preflight import require_space
+
+    require_space(repository, 8 * 1024**3, "ARM build")
     name = prepare(repository, runner)
     environment = []
     if app and app.name == "magik":

--- a/magik/host/magik/cli.py
+++ b/magik/host/magik/cli.py
@@ -64,9 +64,11 @@ def main() -> int:
     prepare = subcommands.add_parser("desktop-prepare")
     prepare.add_argument("--json", action="store_true", required=True)
     subcommands.add_parser("deploy").add_argument("--attended", action="store_true")
-    subcommands.add_parser(
-        "update", help="download and queue latest platform and databases"
+    update_command = subcommands.add_parser(
+        "update", help="download, queue and install latest platform and databases"
     )
+    update_command.add_argument("--attended", action="store_true")
+    update_command.add_argument("--download-only", action="store_true")
     device_command = subcommands.add_parser("device")
     device_subcommands = device_command.add_subparsers(
         dest="device_command", required=True
@@ -120,7 +122,13 @@ def main() -> int:
         from .updates import update
 
         try:
-            return update()
+            pair = update(return_pair=True)
+            if arguments.download_only:
+                print("Next: scripts/magik deploy --attended")
+                return 0
+            # Pin this invocation's verified pair, not a later concurrent update.
+            arguments.desired_pair = pair
+            arguments.command = "deploy"
         except (OSError, ValueError, RuntimeError, subprocess.SubprocessError) as error:
             print(f"magik update: {error}", file=os.sys.stderr)
             return 2
@@ -253,13 +261,22 @@ def deploy(_arguments: argparse.Namespace, run: Path) -> int:
     try:
         from .updates import desired
 
-        queued = desired() if _arguments.app == "magik" else None
+        queued = (
+            getattr(_arguments, "desired_pair", None) or desired()
+            if _arguments.app == "magik"
+            else None
+        )
         agent, status = connect_agent(
             run,
             REQUIRED_AGENT_CAPABILITIES
             | application(_arguments.app).agent_capabilities
             | (
-                {"publication-state-v1", "publication-v1", "platform-publication-v1"}
+                {
+                    "publication-state-v1",
+                    "publication-v1",
+                    "platform-publication-v1",
+                    "service-boot-v1",
+                }
                 if queued
                 else set()
             ),
@@ -267,10 +284,13 @@ def deploy(_arguments: argparse.Namespace, run: Path) -> int:
         if queued:
             from .update_deploy import apply_updates, device_lock
 
-            deployment_locks.enter_context(device_lock(status.identity))
+            from .device_profile import device_identity
+
+            identity = device_identity(status.fields.get("device_identity"))
+            deployment_locks.enter_context(device_lock(identity))
             apply_updates(
                 agent,
-                status.identity,
+                identity,
                 queued,
                 run,
                 getattr(_arguments, "attended", False),

--- a/magik/host/magik/device.py
+++ b/magik/host/magik/device.py
@@ -196,6 +196,9 @@ def reboot_device(arguments, run, *, agent=None):
     if not boot_id:
         raise AgentError("cannot identify current boot; reboot not sent")
     report = {"before": before}
+    from .device_profile import DeviceProfile
+
+    profile = DeviceProfile.load()
     try:
         # Never replay this mutation if its acknowledgement is lost.
         try:
@@ -233,7 +236,15 @@ def reboot_device(arguments, run, *, agent=None):
 
                     rediscovered = True
                     try:
-                        resolved = resolve_device()
+                        if profile is None:
+                            raise DiscoveryError(
+                                "missing board identity; native rediscovery skipped"
+                            )
+                        resolved = resolve_device(
+                            native_only=True,
+                            expected_identity=profile.identity,
+                            timeout=min(8, max(0.1, deadline - time.monotonic())),
+                        )
                         agent.host = resolved.address
                         record_device(run, resolved.identity, resolved.address)
                     except DiscoveryError as discovery_error:

--- a/magik/host/magik/discovery.py
+++ b/magik/host/magik/discovery.py
@@ -110,16 +110,24 @@ def local_candidates() -> list[str]:
 
 
 def resolve_device(
-    address: str | None = None, *, select: bool = False
+    address: str | None = None,
+    *,
+    select: bool = False,
+    native_only: bool = False,
+    expected_identity: str | None = None,
+    timeout: float | None = None,
 ) -> ResolvedDevice:
     remembered = DeviceProfile.load()
     explicit = address or os.environ.get("MISTER_IP")
     username = os.environ.get("MISTER_USER") or (
         remembered.username if remembered else "root"
     )
-    supplied = os.environ.get("MISTER_PASS")
+    supplied = None if native_only else os.environ.get("MISTER_PASS")
     password = supplied
-    deadline = time.monotonic() + DISCOVERY_SECONDS
+    deadline = time.monotonic() + (DISCOVERY_SECONDS if timeout is None else timeout)
+    expected = expected_identity or (
+        remembered.identity if remembered and not select else None
+    )
     errors: list[Exception] = []
 
     def probe(candidate: str) -> ResolvedDevice | None:
@@ -147,7 +155,7 @@ def resolve_device(
                 raise
             except (OSError, ValueError, EOFError):
                 return None
-        if remembered and not select and identity != remembered.identity:
+        if expected and identity != expected:
             return None
         return ResolvedDevice(identity, candidate, username)
 
@@ -172,11 +180,9 @@ def resolve_device(
             identity = native_identity(initial, 0.4)
         except (OSError, RuntimeError, ValueError):
             identity = None
-        if identity is not None and (
-            not remembered or select or identity == remembered.identity
-        ):
+        if identity is not None and (not expected or identity == expected):
             return accept(ResolvedDevice(identity, initial, username))
-    if password is None and remembered:
+    if password is None and remembered and not native_only:
         password = Keychain().load(remembered.identity, username)
     if initial:
         found = probe(initial)

--- a/magik/host/magik/preflight.py
+++ b/magik/host/magik/preflight.py
@@ -1,0 +1,16 @@
+"""Fail before expensive preparation when conservative disk headroom is absent."""
+
+from pathlib import Path
+import shutil
+
+
+def require_space(path: Path, required: int, operation: str):
+    existing = path.resolve()
+    while not existing.exists():
+        existing = existing.parent
+    free = shutil.disk_usage(existing).free
+    if free < required:
+        raise RuntimeError(
+            f"{operation}: {path.resolve()} needs {required / 1024**3:.1f} GiB free; "
+            f"only {free / 1024**3:.1f} GiB available. Free space and rerun; no automatic deletion."
+        )

--- a/magik/host/magik/publication.py
+++ b/magik/host/magik/publication.py
@@ -185,7 +185,14 @@ def platform(arguments, run):
             raise ValueError(
                 "local Main requires a clean committed source checkout matching the manifest"
             )
-    agent, _ = connect_agent(run, {"publication-v1", "platform-publication-v1"})
+    required = {"publication-v1", "platform-publication-v1"}
+    if arguments.kind == "platform":
+        required.add("service-boot-v1")
+    agent, _ = connect_agent(run, required)
+    if arguments.kind == "platform":
+        from .update_deploy import ensure_service_boot
+
+        ensure_service_boot(agent)
     fields = dict(
         kind=arguments.kind, layout=arguments.layout, attended=arguments.attended
     )

--- a/magik/host/magik/storage.py
+++ b/magik/host/magik/storage.py
@@ -130,9 +130,18 @@ class Storage:
         )
 
     def command(self, *args: str):
-        return self.runner(
-            ["container", *args], check=True, capture_output=True, text=True, timeout=30
-        )
+        try:
+            return self.runner(
+                ["container", *args],
+                check=True,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.CalledProcessError as error:
+            raise RuntimeError(
+                f"container {' '.join(args[:2])} failed: {error.stderr or error.stdout or error}"
+            ) from error
 
     def containers(self) -> list[dict]:
         entries = json.loads(self.command("list", "--all", "--format", "json").stdout)
@@ -254,13 +263,17 @@ class Storage:
                 if existing["status"]["state"] == "stopped":
                     self.command("start", name)
             else:
+                from .preflight import require_space
+
+                require_space(repository, 8 * 1024**3, "ARM build preparation")
+                require_space(self.data_root, 8 * 1024**3, "container build storage")
                 if image not in self.images():
                     self.runner(
                         [
                             "container",
                             "build",
                             "--tag",
-                            image,
+                            f"docker.io/library/{image}",
                             "--file",
                             str(repository / "magik/build/Containerfile"),
                             str(repository / "magik/build"),
@@ -270,7 +283,7 @@ class Storage:
                 cache = Path(
                     os.environ.get(
                         "MISTER_MAGIK2_BUILD_CACHE",
-                        str(Path.home() / ".cache/mister-magik/cargo"),
+                        str(Path.home() / ".cache/mister-magik2/cargo"),
                     )
                 ).expanduser()
                 mounts = ["--volume", f"{repository}:/workspace"]
@@ -297,7 +310,7 @@ class Storage:
                     "--memory",
                     "4g",
                     *mounts,
-                    image,
+                    f"docker.io/library/{image}",
                     "sleep",
                     "infinity",
                 )

--- a/magik/host/magik/update_deploy.py
+++ b/magik/host/magik/update_deploy.py
@@ -221,9 +221,14 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
                     # one referring to an actual unfinished stage on this board.
                     for kind in ("platform", "databases"):
                         journal = evidence.parent / kind / "publication.json"
-                        if journal.is_file() and json.loads(journal.read_text()).get(
-                            "stage"
-                        ) in {stage["stage"] for stage in current["stages"]}:
+                        if not journal.is_file():
+                            continue
+                        decoded = json.loads(journal.read_text())
+                        if not isinstance(decoded, dict):
+                            continue
+                        if decoded.get("stage") in {
+                            stage["stage"] for stage in current["stages"]
+                        }:
                             matches.append(saved)
                             break
                 except (OSError, ValueError, KeyError, TypeError):

--- a/magik/host/magik/update_deploy.py
+++ b/magik/host/magik/update_deploy.py
@@ -170,6 +170,30 @@ def device_lock(identity):
     return lock(root() / "devices" / f"{key}.lock")
 
 
+def ensure_service_boot(agent):
+    reply, _ = agent._request("service-boot-state", {}, attempts=2, timeout=10)
+    if reply.operation != "service-boot-state":
+        raise AgentError.from_fields(reply.fields)
+    if reply.fields.get("ready") is not True:
+        # Idempotent fixed boot registration; reconcile a lost mutation reply.
+        try:
+            reply, _ = agent._request(
+                "service-boot-install", {}, attempts=1, timeout=15
+            )
+            if reply.operation != "service-boot-state":
+                raise AgentError.from_fields(reply.fields)
+        except (OSError, TimeoutError):
+            pass
+        reply, _ = agent._request("service-boot-state", {}, attempts=2, timeout=10)
+        if (
+            reply.operation != "service-boot-state"
+            or reply.fields.get("ready") is not True
+        ):
+            raise AgentError(
+                "native service boot registration is not verified; platform not installed"
+            )
+
+
 def apply_updates(agent, identity, pair, run, attended, *, already_locked=False):
     device_key = hashlib.sha256(identity.encode()).hexdigest()
     with nullcontext() if already_locked else device_lock(identity):
@@ -179,6 +203,40 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
             kind: verify(kind, pair[kind]) for kind in ("platform", "databases")
         }
         current = state(agent)
+        if not previous and current["stages"]:
+            # Older hosts incorrectly keyed journals by service version. Adopt only
+            # evidence whose parent deployment names this physical board; do not
+            # delete the shared legacy journal or trust its filename.
+            matches = []
+            for candidate in pending_path.parent.glob("*-pending.json"):
+                try:
+                    saved = json.loads(candidate.read_text())
+                    evidence = Path(saved["run"]) / "run.json"
+                    if (
+                        json.loads(evidence.read_text())["source"]["device_identity"]
+                        != identity
+                    ):
+                        continue
+                    # Old receipts may survive a finished deployment. Only adopt
+                    # one referring to an actual unfinished stage on this board.
+                    for kind in ("platform", "databases"):
+                        journal = evidence.parent / kind / "publication.json"
+                        if journal.is_file() and json.loads(journal.read_text()).get(
+                            "stage"
+                        ) in {stage["stage"] for stage in current["stages"]}:
+                            matches.append(saved)
+                            break
+                except (OSError, ValueError, KeyError, TypeError):
+                    # Unrelated/partial host evidence is not authority to mutate.
+                    # Unmatched native stages still fail closed below.
+                    continue
+            if len(matches) > 1:
+                raise AgentError(
+                    "multiple pending deployments for this board; reconcile explicitly"
+                )
+            if matches:
+                previous = matches[0]
+                atomic_json(pending_path, previous)
         # A confirmed reboot may have completed while the previous host lost its reply.
         for stage in current["stages"]:
             pending = stage["pending"]
@@ -240,12 +298,18 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
                 )
         with tempfile.TemporaryDirectory(prefix="magik-update-") as temporary:
             directory = Path(temporary)
+            if platform_needed or databases_needed:
+                from .preflight import require_space
+
+                require_space(directory, 2 * 1024**3, "release preparation")
             db_files = (
                 database_files(pair, directory / "databases")
                 if databases_needed
                 else None
             )
             platform_files = prepare(pair, directory) if platform_needed else None
+            if platform_needed:
+                ensure_service_boot(agent)
             if databases_needed and not platform_needed:
                 package = repository() / "apps/mister"
                 ensure_arm_application(package)

--- a/magik/host/magik/updates.py
+++ b/magik/host/magik/updates.py
@@ -118,7 +118,7 @@ def desired():
     return value
 
 
-def update():
+def update(*, return_pair=False):
     with lock(root() / "download.lock"):
         result = subprocess.run(
             [
@@ -165,6 +165,10 @@ def update():
                 verify(kind, entry)
                 outcome = "cached"
             else:
+                from .preflight import require_space
+
+                size = sum(asset.get("size", 0) for asset in release.get("assets", []))
+                require_space(directory, size + 512 * 1024**2, "release download")
                 directory.parent.mkdir(parents=True, exist_ok=True)
                 with tempfile.TemporaryDirectory(
                     dir=directory.parent, prefix="download-"
@@ -188,5 +192,7 @@ def update():
             pair[kind] = entry
             print(f"{tag}: {outcome}, verified: {directory.resolve()}")
         atomic_json(root() / "desired.json", pair)
-        print("Queued for all devices. Next: scripts/magik deploy --attended")
-    return 0
+        print("Queued for all devices.")
+        if not return_pair:
+            print("Next: scripts/magik deploy --attended")
+    return pair if return_pair else 0

--- a/magik/host/pyproject.toml
+++ b/magik/host/pyproject.toml
@@ -3,7 +3,11 @@ name = "mister-magik-host"
 version = "0.1.0"
 description = "Independent host tooling for the MiSTer MagiK probe"
 requires-python = ">=3.12"
-dependencies = ["paramiko>=4,<6", "slint-testing==0.3", "pytest>=8", "mcp>=1,<3"]
+dependencies = ["paramiko>=4,<6"]
+
+[project.optional-dependencies]
+testing = ["slint-testing==0.3", "pytest>=8"]
+mcp = ["mcp>=1,<3"]
 
 [[tool.uv.index]]
 name = "slint-private"

--- a/magik/host/tests/test_cli_defaults.py
+++ b/magik/host/tests/test_cli_defaults.py
@@ -1,4 +1,43 @@
 from magik import cli
+from unittest.mock import Mock
+import pytest
+
+
+@pytest.mark.parametrize(
+    "flags,deploys", [([], True), (["--attended"], True), (["--download-only"], False)]
+)
+def test_update_downloads_and_pins_exact_pair(monkeypatch, tmp_path, flags, deploys):
+    from magik import updates
+
+    pair = {"platform": {"version": 41}, "databases": {"version": 23}}
+    monkeypatch.setenv("MISTER_MAGIK2_RESULTS", str(tmp_path))
+    monkeypatch.setattr("sys.argv", ["scripts/magik", "update", *flags])
+    download = Mock(return_value=pair)
+    monkeypatch.setattr(updates, "update", download)
+    monkeypatch.setattr(
+        updates, "desired", Mock(side_effect=AssertionError("snapshot reread"))
+    )
+    dispatch = Mock(return_value=0)
+    monkeypatch.setattr(cli, "dispatch", dispatch)
+    assert cli.main() == 0
+    download.assert_called_once_with(return_pair=True)
+    assert dispatch.call_count == int(deploys)
+    if deploys:
+        arguments = dispatch.call_args.args[0]
+        assert arguments.desired_pair is pair
+        assert arguments.command == "deploy"
+        assert arguments.attended == ("--attended" in flags)
+
+
+def test_failed_download_never_deploys(monkeypatch):
+    monkeypatch.setattr("sys.argv", ["scripts/magik", "update", "--attended"])
+    monkeypatch.setattr(
+        "magik.updates.update", Mock(side_effect=RuntimeError("offline"))
+    )
+    dispatch = Mock()
+    monkeypatch.setattr(cli, "dispatch", dispatch)
+    assert cli.main() == 2
+    dispatch.assert_not_called()
 
 
 def test_everyday_check_is_real_smoke_and_prints_dev_target(

--- a/magik/host/tests/test_deploy.py
+++ b/magik/host/tests/test_deploy.py
@@ -64,6 +64,7 @@ def test_real_app_uses_the_same_delivery_with_its_own_artifact(monkeypatch, tmp_
 
 
 def test_real_deploy_requires_input_proxy_but_mini_does_not(monkeypatch, tmp_path):
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path / "state"))
     from argparse import Namespace
     from magik.apps import application
 

--- a/magik/host/tests/test_device_operations.py
+++ b/magik/host/tests/test_device_operations.py
@@ -134,3 +134,40 @@ def test_failed_platform_reboot_keeps_recoverable_stage(monkeypatch, tmp_path):
         publish(agent, tmp_path, {}, kind="platform", layout="dev", attended=True)
     assert agent._request.call_count == reboot.call_count == 1
     assert json.loads((tmp_path / "publication.json").read_text())["stage"]
+
+
+def test_reboot_timeout_uses_only_native_discovery_and_never_replays(
+    monkeypatch, tmp_path
+):
+    import time
+    from magik import discovery
+    from magik.device_profile import DeviceProfile
+
+    monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path / "state"))
+    DeviceProfile("02:12:34:56:78:90", "192.168.1.2", "root").save()
+    tick = iter(range(1000))
+    monkeypatch.setattr(time, "monotonic", lambda: next(tick))
+    monkeypatch.setattr(time, "sleep", lambda _: None)
+    agent = Mock()
+    agent.device_operation.side_effect = [
+        {"boot_id": {"text": "original"}},
+        {"reboot_requested": True},
+    ] + [ConnectionRefusedError("offline")] * 100
+    discover = Mock(side_effect=discovery.DiscoveryError("offline"))
+    monkeypatch.setattr(discovery, "resolve_device", discover)
+    with pytest.raises(AgentError, match="do not replay"):
+        device.reboot_device(SimpleNamespace(attended=True), tmp_path, agent=agent)
+    assert (
+        sum(
+            call.args[0] == "device-reboot"
+            for call in agent.device_operation.call_args_list
+        )
+        == 1
+    )
+    assert discover.call_count == 1
+    assert discover.call_args.kwargs["native_only"] is True
+    assert discover.call_args.kwargs["expected_identity"] == "02:12:34:56:78:90"
+    assert (
+        json.loads((tmp_path / "reboot.json").read_text())["discovery_error"]
+        == "offline"
+    )

--- a/magik/host/tests/test_discovery.py
+++ b/magik/host/tests/test_discovery.py
@@ -10,6 +10,24 @@ from magik.token_store import TokenStore
 IDENTITY = "02:12:34:56:78:90"
 
 
+def test_native_only_recovery_never_reads_credentials_or_uses_ssh(monkeypatch):
+    from unittest.mock import Mock
+
+    DeviceProfile(IDENTITY, "192.168.1.99", "root").save()
+    monkeypatch.setenv("MISTER_PASS", "must-not-use")
+    keychain = Mock(side_effect=AssertionError("credential fallback"))
+    ssh = Mock(side_effect=AssertionError("SSH fallback"))
+    monkeypatch.setattr(discovery, "Keychain", keychain)
+    monkeypatch.setattr(discovery, "SshBootstrap", ssh)
+    monkeypatch.setattr(
+        discovery, "native_identity", Mock(side_effect=ConnectionRefusedError())
+    )
+    with pytest.raises(discovery.DiscoveryError):
+        discovery.resolve_device(native_only=True, expected_identity=IDENTITY)
+    keychain.assert_not_called()
+    ssh.assert_not_called()
+
+
 @pytest.fixture(autouse=True)
 def isolated(monkeypatch, tmp_path):
     monkeypatch.setenv("MISTER_MAGIK2_STATE", str(tmp_path))

--- a/magik/host/tests/test_preflight.py
+++ b/magik/host/tests/test_preflight.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+import subprocess
+import pytest
+from magik import preflight
+from magik.storage import Storage
+
+
+def test_no_space_reports_before_preparation(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        preflight.shutil, "disk_usage", lambda _: SimpleNamespace(free=100)
+    )
+    with pytest.raises(RuntimeError, match="Free space and rerun"):
+        preflight.require_space(tmp_path / "not-created", 1024**3, "download")
+    assert not (tmp_path / "not-created").exists()
+
+
+def test_container_failure_retains_stderr():
+    runner = Mock(
+        side_effect=subprocess.CalledProcessError(
+            1, ["container", "run"], stderr="internalError: mount"
+        )
+    )
+    with pytest.raises(RuntimeError, match="internalError: mount"):
+        Storage(runner=runner).command("run", "image")

--- a/magik/host/tests/test_storage.py
+++ b/magik/host/tests/test_storage.py
@@ -83,7 +83,7 @@ class ContainerHost:
             item["configuration"]["labels"] = labels
             self.entries.append(item)
         elif args[0] == "build":
-            ref = args[args.index("--tag") + 1]
+            ref = args[args.index("--tag") + 1].removeprefix("docker.io/library/")
             self.images[ref] = "sha256:" + ref.split(":")[1]
         elif args[:2] == ["system", "df"]:
             output = "{}"

--- a/magik/host/tests/test_updates.py
+++ b/magik/host/tests/test_updates.py
@@ -10,6 +10,34 @@ import pytest
 from magik import updates, update_deploy
 
 
+def test_boot_registration_reconciles_lost_reply_without_replay():
+    agent = Mock()
+
+    def reply(ready):
+        return SimpleNamespace(
+            operation="service-boot-state", fields={"ready": ready}
+        ), b""
+
+    agent._request.side_effect = [reply(False), TimeoutError("reply lost"), reply(True)]
+    update_deploy.ensure_service_boot(agent)
+    assert [call.args[0] for call in agent._request.call_args_list] == [
+        "service-boot-state",
+        "service-boot-install",
+        "service-boot-state",
+    ]
+    assert agent._request.call_args_list[1].kwargs["attempts"] == 1
+
+
+def test_boot_registration_must_verify():
+    agent = Mock()
+    agent._request.return_value = (
+        SimpleNamespace(operation="service-boot-state", fields={"ready": False}),
+        b"",
+    )
+    with pytest.raises(RuntimeError, match="not verified"):
+        update_deploy.ensure_service_boot(agent)
+
+
 def test_numbered_release_selection_includes_prereleases():
     selector = updates.selectors()
     releases = [
@@ -102,6 +130,15 @@ def test_current_pair_is_noop_on_multiple_devices(deploy_case, tmp_path):
     assert len(list((updates.root() / "devices").glob("*.json"))) == 2
 
 
+def test_unrelated_corrupt_journal_does_not_block_current_device(deploy_case, tmp_path):
+    pair, _, publish = deploy_case
+    directory = updates.root() / "devices"
+    directory.mkdir(parents=True)
+    (directory / "other-pending.json").write_text("interrupted")
+    update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    publish.assert_not_called()
+
+
 def test_queued_deploy_starts_idle_application(deploy_case, tmp_path, monkeypatch):
     from argparse import Namespace
     from magik import cli
@@ -115,9 +152,10 @@ def test_queued_deploy_starts_idle_application(deploy_case, tmp_path, monkeypatc
     artifact = tmp_path / "application"
     artifact.write_bytes(b"application")
     status = AgentStatus(
-        "device",
+        "0.1.0",
         frozenset(),
         {
+            "device_identity": "e2:b1:0a:86:84:3c",
             "running": False,
             "ready": False,
             "artifacts": {"magik": sha256_hex(b"application")},
@@ -142,6 +180,62 @@ def test_queued_deploy_starts_idle_application(deploy_case, tmp_path, monkeypatc
     agent.start.assert_called_once_with(
         expected_sha256=sha256_hex(b"application"), restart=False
     )
+    assert (
+        updates.root()
+        / "devices"
+        / f"{hashlib.sha256(b'e2:b1:0a:86:84:3c').hexdigest()}.json"
+    ).exists()
+    assert not (
+        updates.root() / "devices" / f"{hashlib.sha256(b'0.1.0').hexdigest()}.json"
+    ).exists()
+
+
+@pytest.mark.parametrize("board_matches", [True, False])
+def test_legacy_journal_recovery_requires_board_and_stage(
+    deploy_case, tmp_path, board_matches
+):
+    pair, current, publish = deploy_case
+    previous_run = tmp_path / "previous"
+    updates.atomic_json(
+        previous_run / "run.json",
+        {"source": {"device_identity": "one" if board_matches else "another"}},
+    )
+    updates.atomic_json(previous_run / "platform/publication.json", {"stage": "a" * 32})
+    legacy = (
+        updates.root()
+        / "devices"
+        / f"{hashlib.sha256(b'0.1.0').hexdigest()}-pending.json"
+    )
+    updates.atomic_json(legacy, {"desired": pair, "run": str(previous_run)})
+    current["stages"] = [
+        {
+            "stage": "a" * 32,
+            "pending": {
+                "kind": "platform",
+                "layout": "dev",
+                "boot_id": "previous-boot",
+            },
+        }
+    ]
+    agent = Mock()
+
+    def finish(*args, **kwargs):
+        assert args[0] == "publication-control"
+        assert args[1]["action"] == "finish"
+        assert kwargs["attempts"] == 1
+        current["stages"] = []
+        return SimpleNamespace(operation="publication-complete", fields={}), b""
+
+    agent._request.side_effect = finish
+    if board_matches:
+        update_deploy.apply_updates(agent, "one", pair, tmp_path, True)
+        agent._request.assert_called_once()
+    else:
+        with pytest.raises(RuntimeError, match="no reboot repeated"):
+            update_deploy.apply_updates(agent, "one", pair, tmp_path, True)
+        agent._request.assert_not_called()
+    publish.assert_not_called()
+    assert legacy.exists()
 
 
 def test_missing_attendance_prevents_all_publication(deploy_case, tmp_path):
@@ -189,6 +283,7 @@ def test_platform_success_database_failure_retries_only_database(
     current["platform"]["version"] = 1
     current["databases"]["version"] = 1
     prepare = Mock(return_value={"platform": tmp_path})
+    monkeypatch.setattr(update_deploy, "ensure_service_boot", Mock())
     monkeypatch.setattr(update_deploy, "prepare", prepare)
     monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
 

--- a/magik/host/tests/test_updates.py
+++ b/magik/host/tests/test_updates.py
@@ -191,8 +191,9 @@ def test_queued_deploy_starts_idle_application(deploy_case, tmp_path, monkeypatc
 
 
 @pytest.mark.parametrize("board_matches", [True, False])
+@pytest.mark.parametrize("malformed_journal", [[], None, True, 17, "not-an-object"])
 def test_legacy_journal_recovery_requires_board_and_stage(
-    deploy_case, tmp_path, board_matches
+    deploy_case, tmp_path, monkeypatch, board_matches, malformed_journal
 ):
     pair, current, publish = deploy_case
     previous_run = tmp_path / "previous"
@@ -207,6 +208,22 @@ def test_legacy_journal_recovery_requires_board_and_stage(
         / f"{hashlib.sha256(b'0.1.0').hexdigest()}-pending.json"
     )
     updates.atomic_json(legacy, {"desired": pair, "run": str(previous_run)})
+    malformed_run = tmp_path / "malformed"
+    updates.atomic_json(
+        malformed_run / "run.json", {"source": {"device_identity": "one"}}
+    )
+    updates.atomic_json(malformed_run / "platform/publication.json", malformed_journal)
+    malformed = legacy.parent / "malformed-pending.json"
+    updates.atomic_json(malformed, {"desired": pair, "run": str(malformed_run)})
+    # Visit the malformed same-board candidate first regardless of filesystem order.
+    original_glob = update_deploy.Path.glob
+    monkeypatch.setattr(
+        update_deploy.Path,
+        "glob",
+        lambda path, pattern: iter([malformed, legacy])
+        if path == legacy.parent and pattern == "*-pending.json"
+        else original_glob(path, pattern),
+    )
     current["stages"] = [
         {
             "stage": "a" * 32,

--- a/magik/host/uv.lock
+++ b/magik/host/uv.lock
@@ -397,8 +397,14 @@ name = "mister-magik-host"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "mcp" },
     { name = "paramiko" },
+]
+
+[package.optional-dependencies]
+mcp = [
+    { name = "mcp" },
+]
+testing = [
     { name = "pytest" },
     { name = "slint-testing" },
 ]
@@ -410,11 +416,12 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "mcp", specifier = ">=1,<2" },
+    { name = "mcp", marker = "extra == 'mcp'", specifier = ">=1,<3" },
     { name = "paramiko", specifier = ">=4,<6" },
-    { name = "pytest", specifier = ">=8" },
-    { name = "slint-testing", specifier = "==0.3", index = "https://testing.slint.dev/simple/" },
+    { name = "pytest", marker = "extra == 'testing'", specifier = ">=8" },
+    { name = "slint-testing", marker = "extra == 'testing'", specifier = "==0.3", index = "https://testing.slint.dev/simple/" },
 ]
+provides-extras = ["testing", "mcp"]
 
 [package.metadata.requires-dev]
 dev = [{ name = "pytest", specifier = ">=8" }]

--- a/scripts/magik
+++ b/scripts/magik
@@ -6,4 +6,9 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export PYTHONPATH="$ROOT/magik/host${PYTHONPATH:+:$PYTHONPATH}"
-exec uv run --project "$ROOT/magik/host" python -m magik.cli "$@"
+UV_ARGS=(--frozen --no-dev)
+case "${1:-}" in
+    check) UV_ARGS+=(--extra testing) ;;
+    mcp) UV_ARGS+=(--extra mcp) ;;
+esac
+exec uv run "${UV_ARGS[@]}" --project "$ROOT/magik/host" python -m magik.cli "$@"


### PR DESCRIPTION
## Summary

- Make `scripts/magik update --attended` download, verify, queue and deploy an immutable release pair in one invocation. Retain `--download-only`; database-only updates need no reboot or attendance.
- Register and verify native service boot startup before platform replacement. Preserve the existing user startup script and backup; use native-only, identity-bound reboot rediscovery. Never replay an ambiguous reboot.
- Key deployment locks and receipts by physical board identity, not the service version. Reconcile legacy journals only against the same board and unfinished native stage; ignore unrelated corrupt evidence.
- Keep private Slint testing dependencies out of update/deploy, use the frozen host lock, check disk headroom, reuse the stable Cargo cache and retain container error output with canonical image references.

## Local validation

- `PYTHONPATH=magik/host uv run --frozen --project magik/host --extra mcp python -m pytest magik/host/tests scripts/tests/test_publication.py -q` — 209 tests passed.
- `scripts/cargo test --manifest-path magik/agent/Cargo.toml --lib` — 46 tests passed using local socket fixtures.
- `scripts/cargo clippy --manifest-path magik/agent/Cargo.toml --all-targets -- -D warnings` — passed.
- Python formatting/lint, shell syntax, staged diff checks and pre-commit checks passed.
- `scripts/magik update --download-only` — verified cached platform v0.41 and databases v23 through the normal runtime, without private testing-package access or device contact.

Regression coverage includes boot registration/backup preservation, symlink refusal, interrupted writes, lost setup replies, native-only reboot timeout, exact desired-pair pinning, per-board receipts, legacy recovery, corrupt unrelated journals, no-op deployment, database-only changes and platform-success/database-failure retries.

## Hardware acceptance still required

This PR is locally tested, not hardware-qualified. No device changes or reboot were performed during this validation. The earlier hardware delivery remains interrupted after its one requested reboot; it must be reconciled after native service connectivity is restored. An attended acceptance run must verify installed platform/database identities and launcher health, then prove a second deployment does not reinstall the platform or reboot.
