### PR TITLE
Harden recovered delivery and clarify runtime verification

### DIFF
--- a/magik/agent/src/lib.rs
+++ b/magik/agent/src/lib.rs
@@ -191,6 +191,7 @@ impl Agent {
             "publication-v1",
             "platform-publication-v1",
             "publication-state-v1",
+            "publication-runtime-evidence-v1",
             "service-boot-v1",
             "transfer-check",
             "applications",

--- a/magik/agent/src/publication.rs
+++ b/magik/agent/src/publication.rs
@@ -390,6 +390,19 @@ fn platform_active(
             .is_some_and(|stages| stages.is_empty())
 }
 
+fn runtime_verification(
+    state: &Value,
+    running_main: Option<&str>,
+    installed_main: Option<&str>,
+) -> Value {
+    json!({
+        "main": {"sha256": running_main, "matches_installed": running_main.zip(installed_main).map(|(running, installed)| running == installed)},
+        "scanout_module": {"loaded": state["running"]["scanout_slots_module_loaded"], "identity_verified": null, "reason": "loaded module build identity is not exposed"},
+        "fpga": {"identity_verified": null, "reason": "loaded bitstream build identity is not exposed"},
+        "linux_kernel": {"managed": false}
+    })
+}
+
 impl crate::Agent {
     pub(super) fn publication_state(
         &self,
@@ -407,12 +420,15 @@ impl crate::Agent {
             let running_hash = state["running"]["pid"]
                 .as_u64()
                 .and_then(|pid| crate::media::hash(Path::new(&format!("/proc/{pid}/exe"))).ok());
+            let installed_hash = crate::media::hash(Path::new(paths.main)).ok();
+            state["platform"]["runtime_verification"] =
+                runtime_verification(&state, running_hash.as_deref(), installed_hash.as_deref());
             // Application readiness is handled by deploy/start. Main and the
             // module remain active while the launcher is idle in the stock menu.
             state["platform"]["active"] = json!(platform_active(
                 &state,
                 running_hash.as_deref(),
-                crate::media::hash(Path::new(paths.main)).ok().as_deref(),
+                installed_hash.as_deref(),
             ));
             state["configured_main"] = crate::mode::status()?["configured_main"].clone();
             state["boot_id"] = json!(
@@ -699,6 +715,19 @@ mod tests {
     fn platform_activation_does_not_require_a_running_application() {
         let mut state = json!({"running":{"executable_path":Layout::Development.paths().main,
             "scanout_slots_module_loaded":true,"launcher_ready_phase":"idle"},"stages":[]});
+        let evidence = runtime_verification(&state, Some("main"), Some("main"));
+        assert_eq!(evidence["main"]["matches_installed"], true);
+        assert_eq!(evidence["scanout_module"]["loaded"], true);
+        assert!(evidence["scanout_module"]["identity_verified"].is_null());
+        assert!(evidence["fpga"]["identity_verified"].is_null());
+        assert_eq!(evidence["linux_kernel"]["managed"], false);
+        assert_eq!(
+            runtime_verification(&state, Some("old"), Some("main"))["main"]["matches_installed"],
+            false
+        );
+        assert!(
+            runtime_verification(&state, None, Some("main"))["main"]["matches_installed"].is_null()
+        );
         assert!(platform_active(&state, Some("main"), Some("main")));
         state["running"]["launcher_ready_phase"] = json!("ready");
         assert!(platform_active(&state, Some("main"), Some("main")));

--- a/magik/docs/build-storage.md
+++ b/magik/docs/build-storage.md
@@ -61,6 +61,12 @@ Unlabeled old `magik-*` containers appear as migration candidates. They are
 excluded from automatic cleanup; updating the tooling creates a separately
 named managed container instead of taking over an old one.
 
+Recognized `magik2-v1-*` containers and valid `magik2-build:*` image records are
+shown as `legacy-retained`, not ownership errors. They are never adopted, stopped,
+or deleted by this manager, including `clean --all-idle --apply`. Inspect them and
+arrange explicit cleanup separately. Malformed or changed image metadata still
+reports an error and remains protected.
+
 ## Initial and occasional maintenance
 
 Use a quiet build window for legacy resources and the shared image builder.

--- a/magik/docs/native-operations.md
+++ b/magik/docs/native-operations.md
@@ -59,7 +59,14 @@ platform transaction is finished automatically only when its saved host journal
 matches and a new boot is confirmed. Otherwise deployment stops with the stage ID
 for explicit inspection/restoration; it never repeats an ambiguous reboot.
 
-Before platform replacement, native `service-boot-state`/`service-boot-install`
+Every real-MagiK deployment with queued releases checks native boot registration,
+including already-current devices and recovered platform transactions. Missing
+registration is repaired idempotently before further publication or a completion
+receipt. Database-only/current-platform registration needs no attendance or reboot;
+platform activation still requires attendance. Receipts include `service_boot`.
+This verifies startup configuration, not a witnessed successful future boot.
+
+Native `service-boot-state`/`service-boot-install`
 operations verify/register the service through MiSTer's `linux/user-startup.sh`
 hook. Existing commands are preserved, with the original saved as
 `mister-magik2/user-startup.before-magik`. No boot-mode changes or reboot loops
@@ -70,6 +77,21 @@ an ambiguous reboot to recover connectivity.
 Host download and build preparation check disk headroom before proceeding.
 The CLI uses its frozen lock; private Slint testing dependencies are installed
 only for `check`, not update/deploy. Build errors retain container diagnostics.
+CLI output is unbuffered; discovery, download, reconciliation, preparation and
+installation phases are emitted as they happen.
+
+### What verification proves
+
+`publication-state` includes `platform.runtime_verification` under the
+`publication-runtime-evidence-v1` capability. Installed artifact hashes and
+the platform's existing `verified` flag describe files, not every running component.
+Main's running `/proc/PID/exe` SHA-256 is reported with `matches_installed`.
+The scanout module's `loaded` flag is separate from its unknown loaded build
+identity; FPGA identity is likewise unknown. `identity_verified: null` means
+unsupported evidence, not success. The Linux kernel image is not managed by this
+platform update (the scanout `.ko` is a kernel module). The CLI explicitly reports
+these limits; older responses without runtime evidence are reported as unavailable.
+Hardware acceptance must still verify a service return after an attended boot.
 
 Download/verification errors preserve the previous desired pair; installation
 errors retain the newly verified desired pair for recovery. Corrupt cached releases fail

--- a/magik/host/magik/cli.py
+++ b/magik/host/magik/cli.py
@@ -273,6 +273,7 @@ def deploy(_arguments: argparse.Namespace, run: Path) -> int:
             | (
                 {
                     "publication-state-v1",
+                    "publication-runtime-evidence-v1",
                     "publication-v1",
                     "platform-publication-v1",
                     "service-boot-v1",

--- a/magik/host/magik/storage.py
+++ b/magik/host/magik/storage.py
@@ -159,6 +159,9 @@ class Storage:
         }
 
     def owned(self, entry: dict) -> tuple[Path, str] | None:
+        if re.fullmatch(r"magik2-v1-[0-9a-f]{12}-[0-9a-f]{12}", entry["id"]):
+            # Known retired namespace is retained, never adopted or auto-deleted.
+            return None
         config = entry["configuration"]
         labels = config.get("labels", {})
         if labels.get(LABEL + "version") != VERSION:
@@ -433,7 +436,14 @@ class Storage:
                         )
                     ownership = self.owned(entry)
                     if ownership is None:
-                        if LABEL + "version" in config.get("labels", {}):
+                        if re.fullmatch(
+                            r"magik2-v1-[0-9a-f]{12}-[0-9a-f]{12}", entry["id"]
+                        ):
+                            row.update(
+                                ownership="legacy-retained",
+                                reason="retired MagiK 2 container; explicit cleanup required",
+                            )
+                        elif LABEL + "version" in config.get("labels", {}):
                             row.update(
                                 ownership="other-manager",
                                 reason="different management version or state root",
@@ -585,7 +595,8 @@ class Storage:
                 if (
                     record["version"] != VERSION
                     or not re.fullmatch(r"[0-9a-f]{12}", path.stem)
-                    or ref != f"magik-build:{path.stem}"
+                    or ref
+                    not in {f"magik-build:{path.stem}", f"magik2-build:{path.stem}"}
                 ):
                     raise ValueError("invalid managed image record")
                 last_used = self.timestamp(record["last_used"])
@@ -593,6 +604,12 @@ class Storage:
                     continue
                 if images[ref] != record["digest"]:
                     raise ValueError("image digest changed; skipped")
+                if ref == f"magik2-build:{path.stem}":
+                    image_rows[ref].update(
+                        ownership="legacy-retained",
+                        reason="retired MagiK 2 image; explicit cleanup required",
+                    )
+                    continue
                 eligible = (
                     path.stem not in protected_recipes
                     and images[ref] not in protected

--- a/magik/host/magik/update_deploy.py
+++ b/magik/host/magik/update_deploy.py
@@ -171,10 +171,12 @@ def device_lock(identity):
 
 
 def ensure_service_boot(agent):
+    print("Verifying native service boot registration...", flush=True)
     reply, _ = agent._request("service-boot-state", {}, attempts=2, timeout=10)
     if reply.operation != "service-boot-state":
         raise AgentError.from_fields(reply.fields)
     if reply.fields.get("ready") is not True:
+        print("Registering native service startup (no reboot)...", flush=True)
         # Idempotent fixed boot registration; reconcile a lost mutation reply.
         try:
             reply, _ = agent._request(
@@ -190,8 +192,33 @@ def ensure_service_boot(agent):
             or reply.fields.get("ready") is not True
         ):
             raise AgentError(
-                "native service boot registration is not verified; platform not installed"
+                "native service boot registration is not verified; deployment incomplete"
             )
+    return dict(reply.fields)
+
+
+def report_verification(current):
+    platform = current["platform"]
+    runtime = platform.get("runtime_verification", {})
+    main = runtime.get("main", {}).get("matches_installed")
+    main_result = (
+        "verified" if main is True else "mismatch" if main is False else "unavailable"
+    )
+    loaded = current.get("running", {}).get("scanout_slots_module_loaded")
+    loaded_result = (
+        "yes" if loaded is True else "no" if loaded is False else "unavailable"
+    )
+    print(
+        f"Platform v0.{platform.get('version')}: installed files "
+        f"{'verified' if platform.get('verified') else 'NOT verified'}; "
+        f"running Main identity: {main_result}.",
+        flush=True,
+    )
+    print(
+        f"Scanout module loaded: {loaded_result}. "
+        "FPGA and scanout module: exact loaded identities unverified. Linux kernel: not managed by this update.",
+        flush=True,
+    )
 
 
 def apply_updates(agent, identity, pair, run, attended, *, already_locked=False):
@@ -202,6 +229,9 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
         payloads = {
             kind: verify(kind, pair[kind]) for kind in ("platform", "databases")
         }
+        print(
+            "Inspecting installed releases and unfinished publications...", flush=True
+        )
         current = state(agent)
         if not previous and current["stages"]:
             # Older hosts incorrectly keyed journals by service version. Adopt only
@@ -265,6 +295,10 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
                     kind == "databases" or pending.get("boot_id") != current["boot_id"]
                 )
             ):
+                print(
+                    f"Reconciling {kind} stage {stage['stage']} (no reboot)...",
+                    flush=True,
+                )
                 reply, _ = agent._request(
                     "publication-control",
                     {"stage": stage["stage"], "action": "finish", "attended": True},
@@ -273,6 +307,17 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
                 )
                 if reply.operation != "publication-complete":
                     raise AgentError.from_fields(reply.fields)
+                from .results import append_event
+
+                append_event(
+                    run,
+                    {
+                        "phase": "publication-reconciled",
+                        "kind": kind,
+                        "stage": stage["stage"],
+                        "outcome": "verified",
+                    },
+                )
             else:
                 raise AgentError(
                     f"unfinished publication {stage['stage']}; inspect/restore the saved stage before retrying; no reboot repeated"
@@ -304,6 +349,10 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
         with tempfile.TemporaryDirectory(prefix="magik-update-") as temporary:
             directory = Path(temporary)
             if platform_needed or databases_needed:
+                print(
+                    "Preparing required release artifacts and local application...",
+                    flush=True,
+                )
                 from .preflight import require_space
 
                 require_space(directory, 2 * 1024**3, "release preparation")
@@ -313,11 +362,12 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
                 else None
             )
             platform_files = prepare(pair, directory) if platform_needed else None
-            if platform_needed:
-                ensure_service_boot(agent)
             if databases_needed and not platform_needed:
                 package = repository() / "apps/mister"
                 ensure_arm_application(package)
+            # Recovery/current-platform paths also need durable service startup.
+            # This fixed, idempotent registration never changes boot mode/reboots.
+            boot_registration = ensure_service_boot(agent)
             if platform_files or db_files:
                 atomic_json(pending_path, {"desired": pair, "run": str(run.resolve())})
             for kind, files in (("platform", platform_files), ("databases", db_files)):
@@ -332,20 +382,23 @@ def apply_updates(agent, identity, pair, run, attended, *, already_locked=False)
                 fields = {"kind": kind, "layout": "dev"}
                 if kind == "platform":
                     fields.update(attended=True, activate_fpga=True)
-                print(f"Installing {pair[kind]['tag']}")
+                print(f"Installing {pair[kind]['tag']}", flush=True)
                 publish(agent, evidence, files, **fields)
                 current = state(agent)
                 if needed(current[kind], pair[kind], kind, payloads[kind]):
                     raise AgentError(
                         f"{kind} installation did not verify; evidence: {evidence}"
                     )
+                print(f"{pair[kind]['tag']}: installed files verified.", flush=True)
         atomic_json(
             root() / "devices" / f"{device_key}.json",
             {
                 "identity": identity,
                 "desired": pair,
                 "verified": current,
+                "service_boot": boot_registration,
                 "run": str(run.resolve()),
             },
         )
         pending_path.unlink(missing_ok=True)
+        report_verification(current)

--- a/magik/host/magik/updates.py
+++ b/magik/host/magik/updates.py
@@ -119,6 +119,7 @@ def desired():
 
 
 def update(*, return_pair=False):
+    print("Discovering latest published platform and databases...", flush=True)
     with lock(root() / "download.lock"):
         result = subprocess.run(
             [
@@ -173,6 +174,7 @@ def update(*, return_pair=False):
                 with tempfile.TemporaryDirectory(
                     dir=directory.parent, prefix="download-"
                 ) as temporary:
+                    print(f"Downloading {tag}...", flush=True)
                     args = [
                         "gh",
                         "release",
@@ -190,7 +192,7 @@ def update(*, return_pair=False):
                     os.rename(temporary, directory)
                 outcome = "downloaded"
             pair[kind] = entry
-            print(f"{tag}: {outcome}, verified: {directory.resolve()}")
+            print(f"{tag}: {outcome}, verified: {directory.resolve()}", flush=True)
         atomic_json(root() / "desired.json", pair)
         print("Queued for all devices.")
         if not return_pair:

--- a/magik/host/tests/test_storage.py
+++ b/magik/host/tests/test_storage.py
@@ -133,6 +133,38 @@ def setup(tmp_path, monkeypatch):
     return manager, host, repository, now
 
 
+def test_retired_namespace_is_reported_without_adoption_or_cleanup(setup):
+    manager, host, repo, now = setup
+    recipe = recipe_key(repo)
+    item = entry(repo, recipe)
+    item["id"] = item["id"].replace("magik-v1-", "magik2-v1-")
+    item["configuration"]["labels"][LABEL + "state"] = str(manager.root.resolve())
+    ref = f"magik2-build:{recipe}"
+    item["configuration"]["image"]["reference"] = ref
+    host.entries.append(item)
+    host.images[ref] = "sha256:" + recipe
+    record = manager.root / "images" / f"{recipe}.json"
+    atomic_json(
+        record,
+        {
+            "version": "1",
+            "reference": ref,
+            "digest": host.images[ref],
+            "last_used": now[0] - IDLE_SECONDS - 1,
+        },
+    )
+    result = manager.inspect(repo, apply=True, all_idle=True, measure=False)
+    assert not result["errors"]
+    assert result["containers"][0]["ownership"] == "legacy-retained"
+    row = next(row for row in result["images"] if row["reference"] == ref)
+    assert row["ownership"] == "legacy-retained"
+    assert not row["eligible"] and not row["removed"]
+    assert host.entries == [item] and ref in host.images and record.exists()
+    assert not any(
+        call[1] in {"start", "stop", "delete", "exec"} for call in host.calls
+    )
+
+
 def add(setup, name="other", *, age=0, managed=True, recipe=None):
     manager, host, repository, now = setup
     owner = repository.parent / name

--- a/magik/host/tests/test_updates.py
+++ b/magik/host/tests/test_updates.py
@@ -8,6 +8,16 @@ import zipfile
 import pytest
 
 from magik import updates, update_deploy
+from magik.update_deploy import ensure_service_boot
+
+
+def test_verification_progress_is_flushed(deploy_case, monkeypatch):
+    _, current, _ = deploy_case
+    writer = Mock()
+    monkeypatch.setattr("builtins.print", writer)
+    update_deploy.report_verification(current)
+    assert writer.call_count == 2
+    assert all(call.kwargs.get("flush") is True for call in writer.call_args_list)
 
 
 def test_boot_registration_reconciles_lost_reply_without_replay():
@@ -117,6 +127,9 @@ def deploy_case(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(update_deploy, "state", lambda *_: current)
     monkeypatch.setattr(update_deploy, "ensure_arm_application", Mock())
+    monkeypatch.setattr(
+        update_deploy, "ensure_service_boot", Mock(return_value={"ready": True})
+    )
     publish = Mock()
     monkeypatch.setattr(update_deploy, "publish", publish)
     return pair, current, publish
@@ -128,6 +141,102 @@ def test_current_pair_is_noop_on_multiple_devices(deploy_case, tmp_path):
         update_deploy.apply_updates(Mock(), identity, pair, tmp_path, False)
     publish.assert_not_called()
     assert len(list((updates.root() / "devices").glob("*.json"))) == 2
+
+
+@pytest.mark.parametrize("recover", [False, True])
+@pytest.mark.parametrize("database_change", [False, True])
+@pytest.mark.parametrize("boot_ready", [False, True])
+def test_boot_check_includes_recovery_and_current_platform(
+    deploy_case, tmp_path, monkeypatch, recover, database_change, boot_ready
+):
+    pair, current, publish = deploy_case
+    monkeypatch.setattr(update_deploy, "ensure_service_boot", ensure_service_boot)
+    monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
+    if database_change:
+        current["databases"]["version"] = 1
+    if recover:
+        current["stages"] = [
+            {
+                "stage": "a" * 32,
+                "pending": {"kind": "platform", "layout": "dev", "boot_id": "previous"},
+            }
+        ]
+        previous = tmp_path / "previous"
+        updates.atomic_json(previous / "platform/publication.json", {"stage": "a" * 32})
+        updates.atomic_json(
+            updates.root()
+            / "devices"
+            / f"{hashlib.sha256(b'one').hexdigest()}-pending.json",
+            {"run": str(previous)},
+        )
+    agent = Mock()
+    installed_boot = boot_ready
+
+    def request(operation, fields, **kwargs):
+        nonlocal installed_boot
+        if operation == "publication-control":
+            assert fields["action"] == "finish"
+            current["stages"] = []
+            return SimpleNamespace(operation="publication-complete", fields={}), b""
+        if operation == "service-boot-install":
+            assert kwargs["attempts"] == 1
+            installed_boot = True
+        else:
+            assert operation == "service-boot-state"
+        return SimpleNamespace(
+            operation="service-boot-state", fields={"ready": installed_boot}
+        ), b""
+
+    agent._request.side_effect = request
+
+    def published(*args, **kwargs):
+        assert installed_boot
+        assert kwargs["kind"] == "databases"
+        current["databases"]["version"] = 2
+
+    publish.side_effect = published
+    update_deploy.apply_updates(agent, "one", pair, tmp_path, recover)
+    operations = [call.args[0] for call in agent._request.call_args_list]
+    assert operations.count("service-boot-install") == int(not boot_ready)
+    assert publish.call_count == int(database_change)
+    receipt = json.loads(
+        (
+            updates.root() / "devices" / f"{hashlib.sha256(b'one').hexdigest()}.json"
+        ).read_text()
+    )
+    assert receipt["service_boot"]["ready"] is True
+
+
+def test_boot_failure_blocks_completion_and_database_install(
+    deploy_case, tmp_path, monkeypatch
+):
+    pair, current, publish = deploy_case
+    current["databases"]["version"] = 1
+    monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
+    monkeypatch.setattr(
+        update_deploy,
+        "ensure_service_boot",
+        Mock(side_effect=RuntimeError("boot unverified")),
+    )
+    with pytest.raises(RuntimeError, match="boot unverified"):
+        update_deploy.apply_updates(Mock(), "one", pair, tmp_path, False)
+    publish.assert_not_called()
+    assert not (
+        updates.root() / "devices" / f"{hashlib.sha256(b'one').hexdigest()}.json"
+    ).exists()
+
+
+def test_runtime_report_does_not_equate_active_with_verified_identity(
+    deploy_case, capsys
+):
+    _, current, _ = deploy_case
+    update_deploy.report_verification(current)
+    output = capsys.readouterr().out
+    assert "running Main identity: unavailable" in output
+    assert "exact loaded identities unverified" in output
+    current["platform"]["runtime_verification"] = {"main": {"matches_installed": True}}
+    update_deploy.report_verification(current)
+    assert "running Main identity: verified" in capsys.readouterr().out
 
 
 def test_unrelated_corrupt_journal_does_not_block_current_device(deploy_case, tmp_path):
@@ -300,7 +409,6 @@ def test_platform_success_database_failure_retries_only_database(
     current["platform"]["version"] = 1
     current["databases"]["version"] = 1
     prepare = Mock(return_value={"platform": tmp_path})
-    monkeypatch.setattr(update_deploy, "ensure_service_boot", Mock())
     monkeypatch.setattr(update_deploy, "prepare", prepare)
     monkeypatch.setattr(update_deploy, "database_files", lambda *_: {"db": tmp_path})
 

--- a/scripts/magik
+++ b/scripts/magik
@@ -11,4 +11,4 @@ case "${1:-}" in
     check) UV_ARGS+=(--extra testing) ;;
     mcp) UV_ARGS+=(--extra mcp) ;;
 esac
-exec uv run "${UV_ARGS[@]}" --project "$ROOT/magik/host" python -m magik.cli "$@"
+exec uv run "${UV_ARGS[@]}" --project "$ROOT/magik/host" python -u -m magik.cli "$@"


### PR DESCRIPTION
## Summary

Follow up on the first successful platform/database delivery and the gaps it exposed.

- Verify and, if necessary, register native service boot startup on every queued real-MagiK deploy, including recovered platform transactions and already-current devices. Save boot-registration evidence in the per-board completion receipt. Registration is idempotent and does not reboot or change boot mode.
- Add capability-gated runtime evidence to publication state: the running Main executable hash and its match against the installed binary, separate module-loaded state, explicitly unknown FPGA/module runtime build identities, and an explicit indication that the Linux kernel image is not managed by this update. Print these verification limits rather than implying that healthy runtime status proves every loaded identity.
- Recognize retired MagiK 2 container/image namespaces as `legacy-retained`. Keep them visible in storage reports without repeatedly treating valid legacy metadata as errors. Never adopt, stop or delete these resources automatically, even with all-idle cleanup.
- Run the CLI unbuffered, flush release/recovery progress, and record successfully reconciled stages in the deployment event log.

## Validation

- `PYTHONPATH=magik/host uv run --frozen --project magik/host --extra mcp python -m pytest magik/host/tests -q`: **223 passed**.
- `scripts/cargo test --manifest-path magik/agent/Cargo.toml --lib`: **46 passed**, with local socket fixtures enabled.
- `scripts/cargo clippy --manifest-path magik/agent/Cargo.toml --all-targets -- -D warnings`: passed.
- Ruff formatting/lint, shell syntax, diff checks and pre-commit checks passed.

Coverage includes recovered/current platforms, database-only changes, missing/already-present boot registration, boot failure preventing database publication and completion, retained legacy resources under all-idle cleanup, unknown/mismatched/matching Main evidence, and flushed output.

## Boundaries

No device changes or reboot were performed while implementing or testing this PR. Exact loaded FPGA/module build attestation is still unavailable and is now reported honestly; no new unsupported verification claim is made. A witnessed service return after a future attended reboot remains a separate hardware acceptance step.
